### PR TITLE
Nagios pedantic-ness

### DIFF
--- a/plugins/nagios/nagios.c
+++ b/plugins/nagios/nagios.c
@@ -28,8 +28,11 @@ int nagios() {
 
 	int fd = uwsgi_connect(uwsgi.sockets->name, uwsgi.shared->options[UWSGI_OPTION_SOCKET_TIMEOUT], 0);
 	if (fd < 0) {
-		fprintf(stdout, "UWSGI CRITICAL: could not connect() to workers\n");
-		exit(2);
+	    fprintf(stdout, "UWSGI CRITICAL: could not connect() to workers: %s\n", strerror(errno));
+        if (errno == EPERM || errno == EACCES) {
+            exit(3);
+        }
+	    exit(2);
 	}
 
 	uh.modifier1 = UWSGI_MODIFIER_PING;


### PR DESCRIPTION
- Added print of strerror
- Exited with a value of 3 if EPERM or EACCES as per http://nagiosplug.sourceforge.net/developer-guidelines.html#AEN76
- Needs more testing. I just edited the source in github
