### PR TITLE
nginx/uwsgi_params: pass SERVER_ADDR to uwsgi

### DIFF
--- a/nginx/uwsgi_params
+++ b/nginx/uwsgi_params
@@ -11,5 +11,6 @@ uwsgi_param  SERVER_PROTOCOL    $server_protocol;
 
 uwsgi_param  REMOTE_ADDR        $remote_addr;
 uwsgi_param  REMOTE_PORT        $remote_port;
+uwsgi_param  SERVER_ADDR        $server_addr;
 uwsgi_param  SERVER_PORT        $server_port;
 uwsgi_param  SERVER_NAME        $server_name;


### PR DESCRIPTION
nginx is capable of passing SERVER_ADDR to us like Apache would do via
mod_Ruwsgi, it just doesn't do so because that variable wasn't listed
in nginx/uwsgi_params.

This and other variables are passed from nginx from the nginx code in
src/http/ngx_http_variables.c. This was tested with nginx 1.0.15.
