### PR TITLE
make lrc act like rr under low load

### DIFF
--- a/core/subscription.c
+++ b/core/subscription.c
@@ -88,7 +88,7 @@ static struct uwsgi_subscribe_node *uwsgi_subscription_algo_lrc(struct uwsgi_sub
 			if (min_rc == 0 || node->reference < min_rc) {
 				min_rc = node->reference;
 				choosen_node = node;
-				if (min_rc == 0) break;
+				if (min_rc == 0 && !(node->next && node->next->reference <= node->reference && node->next->requests <= node->requests)) break;
 			}
 		}
 		node = node->next;


### PR DESCRIPTION
with this patch lrc acts more like rr algorithm when request rate is very low. Side effect is that when one adds new node to long running cluster, then lrc will try to catch new node request count up to other nodes value, but since it will only happen during low request rate, than I don't consider it as an issue
