### PR TITLE
weighted least reference count (wlrc) load balancing algorithm

### DIFF
--- a/core/subscription.c
+++ b/core/subscription.c
@@ -82,13 +82,47 @@ static struct uwsgi_subscribe_node *uwsgi_subscription_algo_lrc(struct uwsgi_sub
 
 	struct uwsgi_subscribe_node *choosen_node = NULL;
 	node = current_slot->nodes;
-        uint64_t min_rc = 0;
+	uint64_t min_rc = 0;
 	while(node) {
 		if (!node->death_mark) {
 			if (min_rc == 0 || node->reference < min_rc) {
 				min_rc = node->reference;
 				choosen_node = node;
-				if (min_rc == 0 && !(node->next && node->next->reference <= node->reference && node->next->requests <= node->requests)) break;
+				if (min_rc == 0 && !(node->next && node->next->reference <= node->reference && node->next->requests <= node->requests))
+					break;
+			}
+		}
+		node = node->next;
+	}
+
+	if (choosen_node) {
+		choosen_node->reference++;
+	}
+
+	return choosen_node;
+}
+
+// weighted least reference count
+static struct uwsgi_subscribe_node *uwsgi_subscription_algo_wlrc(struct uwsgi_subscribe_slot *current_slot, struct uwsgi_subscribe_node *node) {
+	// if node is NULL we are in the second step (in wlrc mode we do not use the first step)
+	if (node) return NULL;
+
+	struct uwsgi_subscribe_node *choosen_node = NULL;
+	node = current_slot->nodes;
+	double min_rc = 0;
+	while(node) {
+		if (!node->death_mark) {
+			// node->weight is always >= 1, we can safely use it as divider
+			double ref = (double) node->reference / (double) node->weight;
+			double next_node_ref = 0;
+			if (node->next)
+				next_node_ref = (double) node->next->reference / (double) node->next->weight;
+
+			if (min_rc == 0 || ref < min_rc) {
+				min_rc = ref;
+				choosen_node = node;
+				if (min_rc == 0 && !(node->next && next_node_ref <= ref && node->next->requests <= node->requests))
+					break;
 			}
 		}
 		node = node->next;
@@ -151,6 +185,11 @@ void uwsgi_subscription_set_algo(char *algo) {
 
 	if (!strcmp(algo,"lrc")) {
 		uwsgi.subscription_algo = uwsgi_subscription_algo_lrc;
+		return;
+	}
+
+	if (!strcmp(algo,"wlrc")) {
+		uwsgi.subscription_algo = uwsgi_subscription_algo_wlrc;
 		return;
 	}
 


### PR DESCRIPTION
Same as [lrc weight handling support pull request](https://github.com/unbit/uwsgi/pull/14) but implemented as separate algorithm. Reasons:
- I disliked idea of patching current lrc algo, it should be left alone as is
- I've come to conclusion that wlrc algo might be usefull and I would opt for including it

In practice wlrc gives us weighted algorithm that can handle misbehaving nodes (while wrr can't), so if someone is using nodes with different hardware specs than one node might have few times more memory and cpu cores, and so it can spawn much more workers. In such case lrc will probably forward more requests to it only when lower spec nodes are heavily loaded and they start to have longer response times (in theory, I didn't tested it).

Tested with _ab -r -c 13 -n 13000 url_, each node had number of workers equal to it's weight value. Results:
- wlrc
  
  ```
  172.16.200.56:3001: weight=1 failcnt=0 requests=1235
  172.16.200.70:3001: weight=4 failcnt=0 requests=4301
  172.16.200.55:3001: weight=8 failcnt=0 requests=7464
  ```
- lrc
  
  ```
  172.16.200.70:3001: weight=4 failcnt=0 requests=5847
  172.16.200.55:3001: weight=8 failcnt=0 requests=5353
  172.16.200.56:3001: weight=1 failcnt=0 requests=1800
  ```
