### PR TITLE
Hard fail if --listen > somaxconn

### DIFF
--- a/core/socket.c
+++ b/core/socket.c
@@ -611,8 +611,9 @@ int bind_to_tcp(char *socket_name, int listen_queue, char *tcp_port) {
 	}
 
 #ifdef __linux__
-        if (uwsgi.listen_queue > uwsgi_linux_somaxconn()) {
-		uwsgi_log("Listen queue size is greater than the system max net.core.somaxconn (%i).\n", uwsgi_linux_somaxconn());
+        long somaxconn = uwsgi_num_from_file("/proc/sys/net/core/somaxconn");
+        if (somaxconn > 0 && uwsgi.listen_queue > somaxconn) {
+		uwsgi_log("Listen queue size is greater than the system max net.core.somaxconn (%i).\n", somaxconn);
 		uwsgi_nuclear_blast();
 	}
 #endif

--- a/core/utils.c
+++ b/core/utils.c
@@ -841,22 +841,22 @@ void uwsgi_linux_ksm_map(void) {
 #endif
 
 #ifdef __linux__
-int uwsgi_linux_somaxconn(void) {
+long uwsgi_num_from_file(char *filename) {
         char buf[16];
-        char *filename = "/proc/sys/net/core/somaxconn";
-	int fd = open(filename, O_RDONLY);
         ssize_t len;
-	if (fd < 0) {
-		uwsgi_error_open(filename);
-		return -1;
-	}
+        int fd = open(filename, O_RDONLY);
+        if (fd < 0) {
+                uwsgi_error_open(filename);
+                return -1L;
+        }       
         len = read(fd, buf, sizeof(buf));
         if (len == 0) {
-		uwsgi_log("read error %s\n", filename);
-	        return -1;
-        }
-        return (int)strtol(buf, (char **)NULL, 10);
-}
+                uwsgi_log("read error %s\n", filename);
+                return -1L;
+        }       
+	close(fd);
+        return strtol(buf, (char **)NULL, 10);
+}     
 #endif
 
 // setup for a new request

--- a/uwsgi.h
+++ b/uwsgi.h
@@ -2754,7 +2754,7 @@ int uwsgi_get_shared_socket_num(struct uwsgi_socket *);
 
 #ifdef __linux__
 void uwsgi_set_cgroup(void);
-int uwsgi_linux_somaxconn(void);
+long uwsgi_num_from_file(char *);
 #endif
 
 void uwsgi_add_sockets_to_queue(int, int);


### PR DESCRIPTION
Hello,

This patch causes uwsgi to hard fail if the listen parameter is greater than the system limit on linux. For whatever reason listen() will silently truncate the backlog limit if its greater the number set by /proc/sys/net/core/somaxconn. This caused one of our servers to fail since its system limit was not increased. I thought it would be good for uwsgi to hard fail on startup if those numbers disagreed.
