### PR TITLE
Add "include" config entry

### DIFF
--- a/core/uwsgi.c
+++ b/core/uwsgi.c
@@ -95,6 +95,7 @@ static struct uwsgi_option uwsgi_base_options[] = {
 	{"disable-write-exception", no_argument, 0, "disable exception generation on write()/writev()", uwsgi_opt_true, &uwsgi.disable_write_exception, 0},
 
 	{"inherit", required_argument, 0, "use the specified file as config template", uwsgi_opt_load, NULL, 0},
+	{"include", required_argument, 0, "include the specified file as immediate configuration", uwsgi_opt_load, NULL, UWSGI_OPT_IMMEDIATE},
 	{"daemonize", required_argument, 'd', "daemonize uWSGI", uwsgi_opt_set_str, &uwsgi.daemonize, 0},
 	{"daemonize2", required_argument, 0, "daemonize uWSGI after app loading", uwsgi_opt_set_str, &uwsgi.daemonize2, 0},
 	{"stop", required_argument, 0, "stop an instance", uwsgi_opt_pidfile_signal, (void *) SIGINT, UWSGI_OPT_IMMEDIATE},


### PR DESCRIPTION
This was required for the following scenario:

```
uwsgi app.ini
```

app.ini:

```
[uwsgi]
appname=foo
include=_base.ini
```

_base.ini:

```
[uwsgi]
chdir=/blah/foo/projs/%(appname)
# ...
```

Inherit wouldn't cut it because `uwsgi_run_config_pass` was run before that.
