### PR TITLE
.gitignore build products and cache files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+*.o
+*.py[co]
+
+/uwsgi
+/uwsgibuild.*


### PR DESCRIPTION
simply adds a `gitignore` so `git status` is useful again.
