### PR TITLE
count requests in (fast|http)router

### DIFF
--- a/plugins/fastrouter/fastrouter.c
+++ b/plugins/fastrouter/fastrouter.c
@@ -250,7 +250,7 @@ ssize_t fr_instance_connected(struct corerouter_session * cs) {
 	cs->buffer_pos = 0;
 
 	// ok instance is connected, wait for write again
-	cs->un->requests++;
+	if (cs->un) cs->un->requests++;
 	uwsgi_cr_hook_instance_write(cs, fr_instance_send_request_header);
 	// return a value > 0
 	return 1;

--- a/plugins/http/http.c
+++ b/plugins/http/http.c
@@ -882,7 +882,7 @@ ssize_t hr_instance_connected(struct corerouter_session * cs) {
 		return 1;
 	}
         // ok instance is connected, wait for write again
-        cs->un->requests++;
+        if (cs->un) cs->un->requests++;
         uwsgi_cr_hook_instance_write(cs, hr_instance_send_request_header);
         // return a value > 0
         return 1;


### PR DESCRIPTION
This patch restores requests counting in fastrouter and httprouter after porting to new api

```
Concurrency Level:      4
Time taken for tests:   1.968 seconds
Complete requests:      1000
Failed requests:        0
Write errors:           0
Total transferred:      97412000 bytes
HTML transferred:       97197000 bytes
Requests per second:    508.17 [#/sec] (mean)
Time per request:       7.871 [ms] (mean)
Time per request:       1.968 [ms] (mean, across all concurrent requests)
Transfer rate:          48341.72 [Kbytes/sec] received

"nodes": [
    {
        "name": "172.16.200.55:3001",
        "modifier1": 0,
        "modifier2": 0,
        "last_check": 1351504817,
        "requests": 1000,
        "tx": 0,
        "cores": 2,
        "load": 0,
        "weight": 1,
        "wrr": 0,
        "ref": 0,
        "failcnt": 0,
        "death_mark": 0
    }
]
```
