### PR TITLE
missing close() call in utils/uwsgi_num_from_file()

### DIFF
--- a/core/utils.c
+++ b/core/utils.c
@@ -852,6 +852,7 @@ long uwsgi_num_from_file(char *filename) {
         len = read(fd, buf, sizeof(buf));
         if (len == 0) {
                 uwsgi_log("read error %s\n", filename);
+                close(fd);
                 return -1L;
         }       
 	close(fd);


### PR DESCRIPTION
cppcheck complains about it so I've added close(fd) in case of read error, it could leak file descriptors otherwise
