### PR TITLE
set http status on head static request

### DIFF
--- a/core/protocol.c
+++ b/core/protocol.c
@@ -1919,6 +1919,7 @@ int uwsgi_real_file_serve(struct wsgi_request *wsgi_req, char *real_filename, si
 
 				// if it is a HEAD request just skip transfer
 				if (!uwsgi_strncmp(wsgi_req->method, wsgi_req->method_len, "HEAD", 4)) {
+					wsgi_req->status = 200;
 					return 0;
 				}
 


### PR DESCRIPTION
Without this uWSGI logs all head requests with 500:

```
$ curl -I localhost:8080/config2.ru
HTTP/1.1 200 OK
Content-Length: 77
Last-Modified: Fri, 05 Oct 2012 18:06:36 GMT
```

uWSGI log:

```
[pid: 17249|app: -1|req: -1/1] 127.0.0.1 () {26 vars in 372 bytes} [Fri Nov  2 11:24:41 2012] HEAD /config2.ru => generated 0 bytes in 1 msecs (HTTP/1.1 500) 2 headers in 85 bytes (0 switches on core 0)
```
