### PR TITLE
disable static files offloading for methods other than GET and HEAD

### DIFF
--- a/core/protocol.c
+++ b/core/protocol.c
@@ -1030,6 +1030,12 @@ next:
 
 	// check for static files
 
+	// skip methods other than GET and HEAD
+	if (uwsgi_strncmp(wsgi_req->method, wsgi_req->method_len, "GET", 3) &&
+	    uwsgi_strncmp(wsgi_req->method, wsgi_req->method_len, "HEAD", 4)) {
+		return 0;
+	}
+
 	// skip extensions
 	struct uwsgi_string_list *sse = uwsgi.static_skip_ext;
 	while(sse) {


### PR DESCRIPTION
It doesn't make sense to offload files on every method, when creating REST API I need to be able to do DELETE /path and right now I can't if the file exists.
