### PR TITLE
don't alert user on worker restarts caused by hitting max requests

### DIFF
--- a/core/master.c
+++ b/core/master.c
@@ -1592,6 +1592,9 @@ next:
 				uwsgi_log("DAMN ! worker %d (pid: %d) died :( trying respawn ...\n", uwsgi.mywid, (int) diedpid);
 			}
 		}
+		else if (uwsgi.workers[uwsgi.mywid].delta_requests >= uwsgi.shared->options[UWSGI_OPTION_MAX_REQUESTS]) {
+			// worker restarted after hitting max requests
+		}
 		else {
                 	uwsgi_log("DAMN ! worker %d (pid: %d) MISTERIOUSLY died :( trying respawn ...\n", uwsgi.mywid, (int) diedpid);
 		}


### PR DESCRIPTION
When worker restarts due to hitting request limit uWSGI generates warning that might be confusing to users since it looks like something bad has happened while everything is under control:

```
Nov  7 22:01:42 localhost app: ...The work of process 99 is done. Seeya!
Nov  7 22:01:43 localhost app: DAMN ! worker 1 (pid: 99) MISTERIOUSLY died :( trying respawn ...
Nov  7 22:01:43 localhost app: Respawned uWSGI worker 1 (new pid: 111)
```

With this patch uWSGI handles such condition and doesn't show any warning:

```
Nov  7 22:03:26 localhost app: ...The work of process 99 is done. Seeya!
Nov  7 22:03:27 localhost app: Respawned uWSGI worker 1 (new pid: 111)
```
