### PR TITLE
feature/extract: dump the specified address to stdout and exit

### DIFF
--- a/core/uwsgi.c
+++ b/core/uwsgi.c
@@ -105,7 +105,8 @@ static struct uwsgi_option uwsgi_base_options[] = {
 	{"suspend", required_argument, 0, "suspend an instance", uwsgi_opt_pidfile_signal, (void *) SIGTSTP, UWSGI_OPT_IMMEDIATE},
 	{"resume", required_argument, 0, "resume an instance", uwsgi_opt_pidfile_signal, (void *) SIGTSTP, UWSGI_OPT_IMMEDIATE},
 
-	{"connect-and-read", required_argument, 0, "connect to a scoekt and wait for data from it", uwsgi_opt_connect_and_read, NULL, UWSGI_OPT_IMMEDIATE},
+	{"connect-and-read", required_argument, 0, "connect to a socket and wait for data from it", uwsgi_opt_connect_and_read, NULL, UWSGI_OPT_IMMEDIATE},
+	{"extract", required_argument, 0, "fetch/dump any supported address to stdout", uwsgi_opt_extract, NULL, UWSGI_OPT_IMMEDIATE},
 
 	{"listen", required_argument, 'l', "set the socket listen queue size", uwsgi_opt_set_int, &uwsgi.listen_queue, 0},
 	{"max-vars", required_argument, 'v', "set the amount of internal iovec/vars structures", uwsgi_opt_max_vars, NULL, 0},
@@ -3879,4 +3880,19 @@ void uwsgi_opt_connect_and_read(char *opt, char *address, void *foobar) {
 		}
 		uwsgi_log("%.*s", (int) len, buf);
 	}
+}
+
+void uwsgi_opt_extract(char *opt, char *address, void *foobar) {
+
+	int len = 0;
+	char *buf;
+
+	buf = uwsgi_open_and_read(address, &len, 0, NULL);
+	if (len > 0) {
+		if (write(1, buf, len) != len) {
+			uwsgi_error("write()");
+			exit(1);
+		};
+	};
+	exit(0);
 }

--- a/uwsgi.h
+++ b/uwsgi.h
@@ -3216,6 +3216,7 @@ void manage_cluster_message(char *, int);
 void uwsgi_opt_add_custom_option(char *, char *, void *);
 void uwsgi_opt_cflags(char *, char *, void *);
 void uwsgi_opt_connect_and_read(char *, char *, void *);
+void uwsgi_opt_extract(char *, char *, void *);
 
 struct uwsgi_string_list *uwsgi_string_list_has_item(struct uwsgi_string_list *, char *, size_t);
 


### PR DESCRIPTION
similar to `--connect-and-read` except for file-like addresses; allows such
things as:

```
$ uwsgi --extract data://0
$ uwsgi --extract sym://embedded_json
$ uwsgi --extract http://me.local/config.xml
$ uwsgi --extract section://rootfs.tar.gz
$ uwsgi --ini exec://"uwsgi --extract section://rootfs.tar.gz | \
        tar xz && cat rootfs/config.ini"
```

...the latter of which embeds/extracts a complete rootfs for immediate use!
combined with embedded configs + declare-options, one can construct a self-
extracting -- single-file -- app that managed it's own plugins, configs,
databases, shared libs, [...]
