### PR TITLE
enhanced file touch checker

### DIFF
--- a/core/utils.c
+++ b/core/utils.c
@@ -4071,17 +4071,35 @@ struct uwsgi_app *uwsgi_add_app(int id, uint8_t modifier1, char *mountpoint, int
 
 char *uwsgi_check_touches(struct uwsgi_string_list *touch_list) {
 
+	// touch->value   - file path
+	// touch->custom  - file timestamp
+	// touch->custom2 - 0 if file exists, 1 if it does not exists
+
 	struct uwsgi_string_list *touch = touch_list;
 	while (touch) {
 		struct stat tr_st;
 		if (stat(touch->value, &tr_st)) {
-			uwsgi_log("unable to stat() %s, events will be triggered as soon as the file is created\n", touch->value);
+			if (touch->custom) {
+#ifdef UWSGI_DEBUG
+				uwsgi_log("[uwsgi-check-touches] File %s was removed\n", touch->value);
+#endif
+				return touch->value;
+			}
+			else if (!touch->custom2) {
+				uwsgi_log("unable to stat() %s, events will be triggered as soon as the file is created\n", touch->value);
+				touch->custom2 = 1;
+			}
 			touch->custom = 0;
 		}
 		else {
-			if (!touch->custom)
+			if (!touch->custom && touch->custom2) {
+#ifdef UWSGI_DEBUG
+				uwsgi_log("[uwsgi-check-touches] File was created: %s\n", touch->value);
+#endif
 				touch->custom = (uint64_t) tr_st.st_mtime;
-			if ((uint64_t) tr_st.st_mtime > touch->custom) {
+				return touch->value;
+			}
+			else if (touch->custom && (uint64_t) tr_st.st_mtime > touch->custom) {
 #ifdef UWSGI_DEBUG
 				uwsgi_log("[uwsgi-check-touches] modification detected on %s: %llu -> %llu\n", touch->value, (unsigned long long) touch->custom, (unsigned long long) tr_st.st_mtime);
 #endif


### PR DESCRIPTION
I've noticed that if I use --touch-reload with path pointing to non-existing file, than uWSGI will spam my logs with `unable to stat() XXX, events will be triggered as soon as the file is created` so in effort to get rid of that I've modified uwsgi_check_touches() a little bit. Changes:
- `unable to stat() ...` will be printed only once
- uwsgi_check_touches() will react to watched files being created or deleted, not only modified

Merge this if reload should be handled on create/delete. IMHO it should at least on create, right now I need to create file and then modify its time stamp.
