### PR TITLE
stop calling each plugins master_cycle() when uWSGI is stopping or reloading

### DIFF
--- a/core/master.c
+++ b/core/master.c
@@ -823,14 +823,16 @@ int master_loop(char **argv, char **environ) {
 		//uwsgi_log("uwsgi.ready_to_reload %d %d\n", uwsgi.ready_to_reload, uwsgi.numproc);
 
 		// run master_cycle hook for every plugin
-		for (i = 0; i < uwsgi.gp_cnt; i++) {
-			if (uwsgi.gp[i]->master_cycle) {
-				uwsgi.gp[i]->master_cycle();
+		if (!uwsgi.to_hell && !uwsgi.to_heaven) {
+			for (i = 0; i < uwsgi.gp_cnt; i++) {
+				if (uwsgi.gp[i]->master_cycle) {
+					uwsgi.gp[i]->master_cycle();
+				}
 			}
-		}
-		for (i = 0; i < 256; i++) {
-			if (uwsgi.p[i]->master_cycle) {
-				uwsgi.p[i]->master_cycle();
+			for (i = 0; i < 256; i++) {
+				if (uwsgi.p[i]->master_cycle) {
+					uwsgi.p[i]->master_cycle();
+				}
 			}
 		}
 


### PR DESCRIPTION
I'm not sure if this is needed but if calling master_cycle() in plugin is blocking master, than we should disable those calls once we know uWSGI is shutting down. This way we can have faster stop/reload - or at least we minimize the risk of hanging there (if there is any).
It looks like to_hell means shutting down and to_heaven means reloading so I used those.
For Your consideration.
