### PR TITLE
use client address if X-Forwarded-For is missing

### DIFF
--- a/core/protocol.c
+++ b/core/protocol.c
@@ -784,7 +784,8 @@ int uwsgi_parse_vars(struct wsgi_request *wsgi_req) {
 							wsgi_req->method = ptrbuf;
 							wsgi_req->method_len = strsize;
 						}
-						else if (!uwsgi.log_x_forwarded_for && !uwsgi_strncmp("REMOTE_ADDR", 11, wsgi_req->hvec[wsgi_req->var_cnt].iov_base, wsgi_req->hvec[wsgi_req->var_cnt].iov_len)) {
+						else if ((!uwsgi.log_x_forwarded_for || uwsgi_strncmp("HTTP_X_FORWARDED_FOR", 20, wsgi_req->hvec[wsgi_req->var_cnt].iov_base, wsgi_req->hvec[wsgi_req->var_cnt].iov_len))
+							&& !uwsgi_strncmp("REMOTE_ADDR", 11, wsgi_req->hvec[wsgi_req->var_cnt].iov_base, wsgi_req->hvec[wsgi_req->var_cnt].iov_len)) {
 							wsgi_req->remote_addr = ptrbuf;
 							wsgi_req->remote_addr_len = strsize;
 						}


### PR DESCRIPTION
With this patch uWSGI will fallback to REMOTE_ADDR if HTTP_X_FORWARDED_FOR is missing but --log-x-forwarded-for was used.
For example if one uses SSL terminator of some sort, than plain HTTP requests won't have X-Forwarded-For, while HTTPS requests might have, we should use X-Forwarded-For only if it is present in headers, if not client address should be used.
