### PR TITLE
travis buildconf

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ compiler:
 
 script:
   - echo -e "\n\n>>> Building uWSGI binary"
-  - /usr/bin/python uwsgiconfig.py --build base
+  - /usr/bin/python uwsgiconfig.py --build travis
   - echo -e "\n\n>>> Building python26 plugin"
   - /usr/bin/python2.6 -V
   - /usr/bin/python2.6 uwsgiconfig.py --plugin plugins/python base python26

--- a/buildconf/travis.ini
+++ b/buildconf/travis.ini
@@ -1,0 +1,3 @@
+[uwsgi]
+main_plugin =
+inherit = base


### PR DESCRIPTION
Dedicated travis buildconf - using **base** doesn't compile all embedded plugins for some reason (?). Anyway it's handy to have a separate buildconf profile to tweak if needed.
