### PR TITLE
new option to define minimum worker reload interval

### DIFF
--- a/core/init.c
+++ b/core/init.c
@@ -59,6 +59,8 @@ void uwsgi_init_default() {
 	uwsgi.shared->options[UWSGI_OPTION_SOCKET_TIMEOUT] = 4;
 	uwsgi.shared->options[UWSGI_OPTION_LOGGING] = 1;
 
+	uwsgi.minimum_worker_lifetime = 60;
+
 #ifdef UWSGI_SPOOLER
 	uwsgi.shared->spooler_frequency = 30;
 

--- a/core/uwsgi.c
+++ b/core/uwsgi.c
@@ -168,6 +168,7 @@ static struct uwsgi_option uwsgi_base_options[] = {
 
 	{"reaper", no_argument, 'r', "call waitpid(-1,...) after each request to get rid of zombies", uwsgi_opt_dyn_true, (void *) UWSGI_OPTION_REAPER, 0},
 	{"max-requests", required_argument, 'R', "reload workers after the specified amount of managed requests", uwsgi_opt_set_dyn, (void *) UWSGI_OPTION_MAX_REQUESTS, 0},
+	{"minimum-worker-lifetime", required_argument, 0, "number of seconds worker must run before being reloaded (default is 60)", uwsgi_opt_set_64bit, &uwsgi.minimum_worker_lifetime, 0},
 
 	{"socket-timeout", required_argument, 'z', "set internal sockets timeout", uwsgi_opt_set_dyn, (void *) UWSGI_OPTION_SOCKET_TIMEOUT, 0},
 	{"no-fd-passing", no_argument, 0, "disable file descriptor passing", uwsgi_opt_true, &uwsgi.no_fd_passing, 0},

--- a/uwsgi.h
+++ b/uwsgi.h
@@ -1291,6 +1291,8 @@ struct uwsgi_server {
 
 	int respawn_workers;
 	unsigned int reloads;
+	// minimum number of seconds between worker reloads
+	uint64_t minimum_worker_lifetime;
 
 	// leave master running as root
 	int master_as_root;


### PR DESCRIPTION
This patch adds new option that can be used to protect from workers being reloaded (due to max requests or memory usage) to fast. It allows to set a minimum interval between reloads.
Default is set 30 seconds but use whatever value You prefer as default if You dislike it.

Tested with:
`./uwsgi --master --http :8080 --wsgi-file tests/staticfile.py --disable-logging --logdate --max-requests 1`

Before:

```
Tue Dec 18 00:34:32 2012 - ...The work of process 12146 is done. Seeya!
Tue Dec 18 00:34:32 2012 - Respawned uWSGI worker 1 (new pid: 12149)
Tue Dec 18 00:34:32 2012 - ...The work of process 12149 is done. Seeya!
Tue Dec 18 00:34:33 2012 - Respawned uWSGI worker 1 (new pid: 12150)
Tue Dec 18 00:34:33 2012 - ...The work of process 12150 is done. Seeya!
Tue Dec 18 00:34:34 2012 - worker respawning too fast !!! i have to sleep a bit (2 seconds)...
Tue Dec 18 00:34:36 2012 - Respawned uWSGI worker 1 (new pid: 12151)
Tue Dec 18 00:34:36 2012 - ...The work of process 12151 is done. Seeya!
Tue Dec 18 00:34:37 2012 - Respawned uWSGI worker 1 (new pid: 12152)
Tue Dec 18 00:34:37 2012 - ...The work of process 12152 is done. Seeya!
Tue Dec 18 00:34:38 2012 - worker respawning too fast !!! i have to sleep a bit (2 seconds)...
Tue Dec 18 00:34:40 2012 - Respawned uWSGI worker 1 (new pid: 12153)
Tue Dec 18 00:34:40 2012 - SIGPIPE: writing to a closed pipe/socket/fd (probably the client disconnected) on request / (ip 127.0.0.1) !!!
Tue Dec 18 00:34:40 2012 - sendfile(): Broken pipe [core/sendfile.c line 105]
Tue Dec 18 00:34:40 2012 - ...The work of process 12153 is done. Seeya!
Tue Dec 18 00:34:41 2012 - Respawned uWSGI worker 1 (new pid: 12154)
```

After

```
Tue Dec 18 00:32:29 2012 - ...The work of process 11701 is done. Seeya!
Tue Dec 18 00:32:29 2012 - Respawned uWSGI worker 1 (new pid: 11704)
Tue Dec 18 00:32:59 2012 - ...The work of process 11704 is done. Seeya!
Tue Dec 18 00:32:59 2012 - Respawned uWSGI worker 1 (new pid: 11705)
Tue Dec 18 00:33:29 2012 - ...The work of process 11705 is done. Seeya!
Tue Dec 18 00:33:29 2012 - Respawned uWSGI worker 1 (new pid: 11706)
```
