### PR TITLE
Broken pyerl build

### DIFF
--- a/plugins/pyerl/uwsgiplugin.py
+++ b/plugins/pyerl/uwsgiplugin.py
@@ -1,8 +1,16 @@
+import os
 from distutils import sysconfig
 
 NAME='pyerl'
-CFLAGS = ['-I' + sysconfig.get_python_inc(), '-I' + sysconfig.get_python_inc(plat_specific=True)]
-LDFLAGS = []
-LIBS = []
+
+ERLANGPATH = os.environ.get('UWSGICONFIG_ERLANGPATH', 'erl')
+
+includedir = os.popen(ERLANGPATH + " -noshell -noinput -eval \"io:format('~s~n', [code:lib_dir(erl_interface, include)])\" -s erlang halt").read().rstrip()
+libpath = os.popen(ERLANGPATH + " -noshell -noinput -eval \"io:format('~s~n', [code:lib_dir(erl_interface, lib)])\" -s erlang halt").read().rstrip()
+
+CFLAGS = [ '-I' + includedir, '-I' + sysconfig.get_python_inc(), '-I' + sysconfig.get_python_inc(plat_specific=True)]
+LDFLAGS = [ '-L' + libpath ]
+
+LIBS = ['-lei']
 
 GCC_LIST = ['pyerl']


### PR DESCRIPTION
Small patch to fix following error. erl_interface paths should be included to `plugins/pyerl/uwsgiconfig.py`

```
   [~/pg/uwsgi]$ python uwsgiconfig.py --build pyerl
   .........skipped........
   [thread 3][gcc -pthread] plugins/pyerl/pyerl.o
   In file included from plugins/pyerl/pyerl.c:1:0:
   plugins/pyerl/../erlang/erlang.h:1:16: fatal error: ei.h: No such file or directory
   compilation terminated.
```

Ubuntu 12.10, Python 2.7, esl-erlang 1:15.b.3-2
