### PR TITLE
[legion] periodic warnings when no quorum is reached

### DIFF
--- a/core/legion.c
+++ b/core/legion.c
@@ -294,6 +294,10 @@ static void legions_check_nodes_step2() {
 				}
 			}
 		}
+		else if (votes > 0 && votes < ul->quorum && (uwsgi_now() - ul->last_warning >= 60)) {
+			uwsgi_log("[uwsgi-legion] no quorum: only %d vote(s) for Legion %s, %d needed to elect a Lord\n", votes, ul->legion, ul->quorum);
+			ul->last_warning = uwsgi_now();
+		}
 
 		ul = ul->next;
 	}

--- a/uwsgi.h
+++ b/uwsgi.h
@@ -554,6 +554,8 @@ struct uwsgi_legion {
 
 	time_t unix_check;
 
+	time_t last_warning;
+
 	EVP_CIPHER_CTX *encrypt_ctx;
 	EVP_CIPHER_CTX *decrypt_ctx;
 


### PR DESCRIPTION
If quorum can't be reached than uWSGI should issue periodic warning in logs so that user will know that something bad is going on. Since legion can announce at high rates such warning should keep track of time on it's own.
