### PR TITLE
too much copy&paste in legion stats

### DIFF
--- a/core/master_utils.c
+++ b/core/master_utils.c
@@ -1162,9 +1162,6 @@ struct uwsgi_stats *uwsgi_master_generate_stats() {
 		if (uwsgi_stats_key(us, "legions"))
 			goto end;
 
-		if (uwsgi_stats_list_open(us))
-			goto end;
-
 		struct uwsgi_legion *legion = uwsgi.legions;
 		while (legion) {
 			if (uwsgi_stats_object_open(us))
@@ -1243,9 +1240,6 @@ struct uwsgi_stats *uwsgi_master_generate_stats() {
 					goto end;
 			}
 		}
-
-		if (uwsgi_stats_list_close(us))
-			goto end;
 
 	}
 


### PR DESCRIPTION
I had extra uwsgi_stats_list_{open,close}, now it passes json lint tests
