### PR TITLE
fixed init log

### DIFF
--- a/core/init.c
+++ b/core/init.c
@@ -268,7 +268,7 @@ void uwsgi_setup_workers() {
 
 	total_memory *= (uwsgi.numproc + uwsgi.master_process);
 	if (uwsgi.numproc > 0)
-		uwsgi_log("mapped %lu bytes (%lu KB) for %d cores\n", total_memory, total_memory / 1024, uwsgi.cores * uwsgi.numproc);
+		uwsgi_log("mapped %llu bytes (%llu KB) for %d cores\n", (unsigned long long) total_memory, (unsigned long long) (total_memory / 1024), uwsgi.cores * uwsgi.numproc);
 
 }
 


### PR DESCRIPTION
With latest master I've noticed invalid messages during uWSGI startup:

`mapped 127728 bytes (0 KB) for 124 cores`

Just look at travis log: https://travis-ci.org/prymitive/uwsgi/jobs/4123644/#L605

Travis builds uWSGI with 32 bit Ubuntu, so it looks like it's just wrong log format, I've substituted `%lu` with `%llu` and it seems to be working fine under both 32 and 64 bit, but AFAIK casting it to `unsigned long long` is a proper solution, so this is what I did.

But the ugly part is that (u)int64_t requires different log format depending on the arch so there might be places where such casting is still needed.
