### PR TITLE
[carbon] allow setting empty carbon root node

### DIFF
--- a/plugins/carbon/carbon.c
+++ b/plugins/carbon/carbon.c
@@ -62,7 +62,11 @@ void carbon_post_init() {
 		usl = usl->next;
 	}
 
-	if (!u_carbon.root_node) u_carbon.root_node = "uwsgi";
+	if (!u_carbon.root_node) u_carbon.root_node = "uwsgi.";
+	if (strlen(u_carbon.root_node) && !uwsgi_endswith(u_carbon.root_node, ".")) {
+		u_carbon.root_node = uwsgi_concat2(u_carbon.root_node, ".");
+	}
+
 	if (u_carbon.freq < 1) u_carbon.freq = 60;
 	if (u_carbon.timeout < 1) u_carbon.timeout = 3;
 	if (u_carbon.max_retries <= 0) u_carbon.max_retries = 1;
@@ -170,7 +174,7 @@ void carbon_push_stats(int retry_cycle) {
 		unsigned long long worker_busyness = 0;
 		unsigned long long total_harakiri = 0;
 
-		wok = carbon_write(&fd, "uwsgi.%s.%s.requests %llu %llu\n", uwsgi.hostname, u_carbon.id, (unsigned long long) uwsgi.workers[0].requests, (unsigned long long) uwsgi.current_time);
+		wok = carbon_write(&fd, "%s.%s.requests %llu %llu\n", u_carbon.root_node, uwsgi.hostname, u_carbon.id, (unsigned long long) uwsgi.workers[0].requests, (unsigned long long) uwsgi.current_time);
 		if (!wok) goto clear;
 
 		for(i=1;i<=uwsgi.numproc;i++) {
@@ -209,43 +213,43 @@ void carbon_push_stats(int retry_cycle) {
 			//skip per worker metrics when disabled
 			if (u_carbon.no_workers) continue;
 
-			wok = carbon_write(&fd, "%s.%s.%s.worker%d.requests %llu %llu\n", u_carbon.root_node, uwsgi.hostname, u_carbon.id, i, (unsigned long long) uwsgi.workers[i].requests, (unsigned long long) uwsgi.current_time);
+			wok = carbon_write(&fd, "%s%s.%s.worker%d.requests %llu %llu\n", u_carbon.root_node, uwsgi.hostname, u_carbon.id, i, (unsigned long long) uwsgi.workers[i].requests, (unsigned long long) uwsgi.current_time);
 			if (!wok) goto clear;
 
 			if (uwsgi.shared->options[UWSGI_OPTION_MEMORY_DEBUG] == 1 || uwsgi.force_get_memusage) {
-				wok = carbon_write(&fd, "%s.%s.%s.worker%d.rss_size %llu %llu\n", u_carbon.root_node, uwsgi.hostname, u_carbon.id, i, (unsigned long long) uwsgi.workers[i].rss_size, (unsigned long long) uwsgi.current_time);
+				wok = carbon_write(&fd, "%s%s.%s.worker%d.rss_size %llu %llu\n", u_carbon.root_node, uwsgi.hostname, u_carbon.id, i, (unsigned long long) uwsgi.workers[i].rss_size, (unsigned long long) uwsgi.current_time);
 				if (!wok) goto clear;
 
-				wok = carbon_write(&fd, "%s.%s.%s.worker%d.vsz_size %llu %llu\n", u_carbon.root_node, uwsgi.hostname, u_carbon.id, i, (unsigned long long) uwsgi.workers[i].vsz_size, (unsigned long long) uwsgi.current_time);
+				wok = carbon_write(&fd, "%s%s.%s.worker%d.vsz_size %llu %llu\n", u_carbon.root_node, uwsgi.hostname, u_carbon.id, i, (unsigned long long) uwsgi.workers[i].vsz_size, (unsigned long long) uwsgi.current_time);
 				if (!wok) goto clear;
 			}
 
-			wok = carbon_write(&fd, "%s.%s.%s.worker%d.avg_rt %llu %llu\n", u_carbon.root_node, uwsgi.hostname, u_carbon.id, i, (unsigned long long) avg_rt, (unsigned long long) uwsgi.current_time);
+			wok = carbon_write(&fd, "%s%s.%s.worker%d.avg_rt %llu %llu\n", u_carbon.root_node, uwsgi.hostname, u_carbon.id, i, (unsigned long long) avg_rt, (unsigned long long) uwsgi.current_time);
 			if (!wok) goto clear;
 
-			wok = carbon_write(&fd, "%s.%s.%s.worker%d.tx %llu %llu\n", u_carbon.root_node, uwsgi.hostname, u_carbon.id, i, (unsigned long long) uwsgi.workers[i].tx, (unsigned long long) uwsgi.current_time);
+			wok = carbon_write(&fd, "%s%s.%s.worker%d.tx %llu %llu\n", u_carbon.root_node, uwsgi.hostname, u_carbon.id, i, (unsigned long long) uwsgi.workers[i].tx, (unsigned long long) uwsgi.current_time);
 			if (!wok) goto clear;
 
-			wok = carbon_write(&fd, "%s.%s.%s.worker%d.busyness %llu %llu\n", u_carbon.root_node, uwsgi.hostname, u_carbon.id, i, (unsigned long long) worker_busyness, (unsigned long long) uwsgi.current_time);
+			wok = carbon_write(&fd, "%s%s.%s.worker%d.busyness %llu %llu\n", u_carbon.root_node, uwsgi.hostname, u_carbon.id, i, (unsigned long long) worker_busyness, (unsigned long long) uwsgi.current_time);
 			if (!wok) goto clear;
 
-			wok = carbon_write(&fd, "%s.%s.%s.worker%d.harakiri %llu %llu\n", u_carbon.root_node, uwsgi.hostname, u_carbon.id, i, (unsigned long long) uwsgi.workers[i].harakiri_count, (unsigned long long) uwsgi.current_time);
+			wok = carbon_write(&fd, "%s%s.%s.worker%d.harakiri %llu %llu\n", u_carbon.root_node, uwsgi.hostname, u_carbon.id, i, (unsigned long long) uwsgi.workers[i].harakiri_count, (unsigned long long) uwsgi.current_time);
 			if (!wok) goto clear;
 
 		}
 
 		if (uwsgi.shared->options[UWSGI_OPTION_MEMORY_DEBUG] == 1 || uwsgi.force_get_memusage) {
-			wok = carbon_write(&fd, "%s.%s.%s.rss_size %llu %llu\n", u_carbon.root_node, uwsgi.hostname, u_carbon.id, (unsigned long long) total_rss, (unsigned long long) uwsgi.current_time);
+			wok = carbon_write(&fd, "%s%s.%s.rss_size %llu %llu\n", u_carbon.root_node, uwsgi.hostname, u_carbon.id, (unsigned long long) total_rss, (unsigned long long) uwsgi.current_time);
 			if (!wok) goto clear;
 
-			wok = carbon_write(&fd, "%s.%s.%s.vsz_size %llu %llu\n", u_carbon.root_node, uwsgi.hostname, u_carbon.id, (unsigned long long) total_vsz, (unsigned long long) uwsgi.current_time);
+			wok = carbon_write(&fd, "%s%s.%s.vsz_size %llu %llu\n", u_carbon.root_node, uwsgi.hostname, u_carbon.id, (unsigned long long) total_vsz, (unsigned long long) uwsgi.current_time);
 			if (!wok) goto clear;
 		}
 
-		wok = carbon_write(&fd, "%s.%s.%s.avg_rt %llu %llu\n", u_carbon.root_node, uwsgi.hostname, u_carbon.id, (unsigned long long) (active_workers ? total_avg_rt / active_workers : 0), (unsigned long long) uwsgi.current_time);
+		wok = carbon_write(&fd, "%s%s.%s.avg_rt %llu %llu\n", u_carbon.root_node, uwsgi.hostname, u_carbon.id, (unsigned long long) (active_workers ? total_avg_rt / active_workers : 0), (unsigned long long) uwsgi.current_time);
 		if (!wok) goto clear;
 
-		wok = carbon_write(&fd, "%s.%s.%s.tx %llu %llu\n", u_carbon.root_node, uwsgi.hostname, u_carbon.id, (unsigned long long) total_tx, (unsigned long long) uwsgi.current_time);
+		wok = carbon_write(&fd, "%s%s.%s.tx %llu %llu\n", u_carbon.root_node, uwsgi.hostname, u_carbon.id, (unsigned long long) total_tx, (unsigned long long) uwsgi.current_time);
 		if (!wok) goto clear;
 
 		if (active_workers > 0) {
@@ -254,18 +258,18 @@ void carbon_push_stats(int retry_cycle) {
 		} else {
 			total_avg_busyness = 0;
 		}
-		wok = carbon_write(&fd, "%s.%s.%s.busyness %llu %llu\n", u_carbon.root_node, uwsgi.hostname, u_carbon.id, (unsigned long long) total_avg_busyness, (unsigned long long) uwsgi.current_time);
+		wok = carbon_write(&fd, "%s%s.%s.busyness %llu %llu\n", u_carbon.root_node, uwsgi.hostname, u_carbon.id, (unsigned long long) total_avg_busyness, (unsigned long long) uwsgi.current_time);
 		if (!wok) goto clear;
 
-		wok = carbon_write(&fd, "%s.%s.%s.active_workers %llu %llu\n", u_carbon.root_node, uwsgi.hostname, u_carbon.id, (unsigned long long) active_workers, (unsigned long long) uwsgi.current_time);
+		wok = carbon_write(&fd, "%s%s.%s.active_workers %llu %llu\n", u_carbon.root_node, uwsgi.hostname, u_carbon.id, (unsigned long long) active_workers, (unsigned long long) uwsgi.current_time);
 		if (!wok) goto clear;
 
 		if (uwsgi.cheaper) {
-			wok = carbon_write(&fd, "%s.%s.%s.cheaped_workers %llu %llu\n", u_carbon.root_node, uwsgi.hostname, u_carbon.id, (unsigned long long) uwsgi.numproc - active_workers, (unsigned long long) uwsgi.current_time);
+			wok = carbon_write(&fd, "%s%s.%s.cheaped_workers %llu %llu\n", u_carbon.root_node, uwsgi.hostname, u_carbon.id, (unsigned long long) uwsgi.numproc - active_workers, (unsigned long long) uwsgi.current_time);
 			if (!wok) goto clear;
 		}
 
-		wok = carbon_write(&fd, "%s.%s.%s.harakiri %llu %llu\n", u_carbon.root_node, uwsgi.hostname, u_carbon.id, (unsigned long long) total_harakiri, (unsigned long long) uwsgi.current_time);
+		wok = carbon_write(&fd, "%s%s.%s.harakiri %llu %llu\n", u_carbon.root_node, uwsgi.hostname, u_carbon.id, (unsigned long long) total_harakiri, (unsigned long long) uwsgi.current_time);
 		if (!wok) goto clear;
 
 		usl->healthy = 1;


### PR DESCRIPTION
This adds ability to use empty carbon root node, so that carbon-id will be out root.
It also adds dot at the end of user specified root node if it's missing.

I kept `required_argument` flag, so from command line user needs to explicitly set empty string `""` (IMHO should be more typo resistant than allowing argument-less --carbon-root).

Also `requests` metric was still using hardcoded root.
