### PR TITLE
don't free lock name of a named cache

### DIFF
--- a/core/cache.c
+++ b/core/cache.c
@@ -129,9 +129,9 @@ void uwsgi_cache_init(struct uwsgi_cache *uc) {
 	uc->data = ((char *)uc->items) + ((sizeof(struct uwsgi_cache_item)+uc->keysize) * uc->max_items);
 
 	if (uc->name) {
+		// can't free that until shutdown
 		char *lock_name = uwsgi_concat2("cache_", uc->name);
 		uc->lock = uwsgi_rwlock_init(lock_name);
-		free(lock_name);
 	}
 	else {
 		uc->lock = uwsgi_rwlock_init("cache");


### PR DESCRIPTION
When one uses named cache uWSGI creates a lock for it, but the reference to lock name is lost right after that since `free()` is called on it.

Before:

```
$ uwsgi --cache2 name=test_cache,maxitems=1024,blocksize=1024 -s :0 --stats :4444

$ nc localhost 4444
{
        "version":"1.5-dev-37927c6",
[...]
        "locks":[
[...]
                {
                        "����":0
                }
        ],
[...]
```

After

```
$ nc localhost 4444
{
        "version":"1.5-dev-5bbc7ee",
[...]
        "locks":[
[...]
                {
                        "cache_test_cache":1339
                }
        ],
[...]
```

I think it's safe to just don't free that name since it's just allocated once at the start, but You might want to solve this otherwise.
