### PR TITLE
add last_request attribute to subscription node, it will hold the number...

### DIFF
--- a/core/subscription.c
+++ b/core/subscription.c
@@ -91,7 +91,7 @@ static struct uwsgi_subscribe_node *uwsgi_subscription_algo_lrc(struct uwsgi_sub
 			if (min_rc == 0 || node->reference < min_rc) {
 				min_rc = node->reference;
 				choosen_node = node;
-				if (min_rc == 0 && !(node->next && node->next->reference <= node->reference && node->next->requests <= node->requests))
+				if (min_rc == 0 && !(node->next && node->next->reference <= node->reference && node->next->last_requests <= node->last_requests))
 					break;
 			}
 		}
@@ -125,7 +125,7 @@ static struct uwsgi_subscribe_node *uwsgi_subscription_algo_wlrc(struct uwsgi_su
 			if (min_rc == 0 || ref < min_rc) {
 				min_rc = ref;
 				choosen_node = node;
-				if (min_rc == 0 && !(node->next && next_node_ref <= ref && node->next->requests <= node->requests))
+				if (min_rc == 0 && !(node->next && next_node_ref <= ref && node->next->last_requests <= node->last_requests))
 					break;
 			}
 		}
@@ -376,6 +376,7 @@ struct uwsgi_subscribe_node *uwsgi_add_subscribe_node(struct uwsgi_subscribe_slo
 				node->weight = usr->weight;
 				if (!node->weight)
 					node->weight = 1;
+				node->last_requests = 0;
 				return node;
 			}
 			old_node = node;
@@ -394,6 +395,7 @@ struct uwsgi_subscribe_node *uwsgi_add_subscribe_node(struct uwsgi_subscribe_slo
 		node->modifier1 = usr->modifier1;
 		node->modifier2 = usr->modifier2;
 		node->requests = 0;
+		node->last_requests = 0;
 		node->transferred = 0;
 		node->reference = 0;
 		node->death_mark = 0;
@@ -470,6 +472,7 @@ struct uwsgi_subscribe_node *uwsgi_add_subscribe_node(struct uwsgi_subscribe_slo
 		current_slot->nodes->len = usr->address_len;
 		current_slot->nodes->reference = 0;
 		current_slot->nodes->requests = 0;
+		current_slot->nodes->last_requests = 0;
 		current_slot->nodes->transferred = 0;
 		current_slot->nodes->death_mark = 0;
 		current_slot->nodes->failcnt = 0;

--- a/plugins/corerouter/corerouter.c
+++ b/plugins/corerouter/corerouter.c
@@ -1009,6 +1009,7 @@ void corerouter_send_stats(struct uwsgi_corerouter *ucr) {
 					if (uwsgi_stats_keylong_comma(us, "modifier2", (unsigned long long) s_node->modifier2)) goto end0;
 					if (uwsgi_stats_keylong_comma(us, "last_check", (unsigned long long) s_node->last_check)) goto end0;
 					if (uwsgi_stats_keylong_comma(us, "requests", (unsigned long long) s_node->requests)) goto end0;
+					if (uwsgi_stats_keylong_comma(us, "last_requests", (unsigned long long) s_node->last_requests)) goto end0;
 					if (uwsgi_stats_keylong_comma(us, "tx", (unsigned long long) s_node->transferred)) goto end0;
 					if (uwsgi_stats_keylong_comma(us, "cores", (unsigned long long) s_node->cores)) goto end0;
 					if (uwsgi_stats_keylong_comma(us, "load", (unsigned long long) s_node->load)) goto end0;

--- a/plugins/corerouter/cr.h
+++ b/plugins/corerouter/cr.h
@@ -108,7 +108,10 @@
 	peer->connecting = 0;\
 	peer->can_retry = 0;\
         if (peer->static_node) peer->static_node->custom2++;\
-        if (peer->un) peer->un->requests++;\
+        if (peer->un) {\
+		peer->un->requests++;\
+		peer->un->last_requests++;\
+	}\
 
 
 struct corerouter_session;

--- a/uwsgi.h
+++ b/uwsgi.h
@@ -3086,7 +3086,11 @@ struct uwsgi_subscribe_node {
 
         time_t last_check;
 
+	// absolute number of requests
 	uint64_t requests;
+	// number of requests since last subscription ping
+	uint64_t last_requests;
+
 	uint64_t transferred;
 
 	int death_mark;


### PR DESCRIPTION
... of requests since last subscription ping

use node->last_requests instead of absolute request counter in (w)lrc

(instead of #17)
