### PR TITLE
additional validation of the --cheaper value at startup

### DIFF
--- a/core/init.c
+++ b/core/init.c
@@ -398,6 +398,7 @@ void sanitize_args() {
                 uwsgi.ignore_write_errors = 1;
         }
 
+        if (uwsgi.cheaper_count == 0) uwsgi.cheaper = 0;
 
         if (uwsgi.cheaper_count > 0 && uwsgi.cheaper_count >= uwsgi.numproc) {
                 uwsgi_log("invalid cheaper value: must be lower than processes\n");


### PR DESCRIPTION
Fixes #152

The way current `--cheaper` (and probably some other dynamic options) work causes UWSGI_OPT_CHEAPER to be defined if user sets it to any value, so even `---cheaper 0` will enable it. `if (op->flags & UWSGI_OPT_CHEAPER)` check will pass in `core/utils.c` and `uwsgi.cheaper` will be set to 1.
The simplest fix for cheaper is to add another validation (and so I did), but there are probably other options that suffers from this, so maybe we need a better and more global change.
