### PR TITLE
Make travis fail is test request had errors

### DIFF
--- a/tests/travis.sh
+++ b/tests/travis.sh
@@ -38,7 +38,7 @@ http_test() {
     if [ "$UPID" != "" ]; then
         echo -e "${bldgre}>>> Spawned PID $UPID, running tests${txtrst}"
         sleep 5
-        curl -I $URL
+        curl -fI $URL
         RET=$?
         if [ $RET != 0 ]; then
             die "${bldred}>>> Error during curl run${txtrst}"


### PR DESCRIPTION
This will add missing -f switch to curl options so that it will exit with non-zero return code if request fails. Right now it's always zero no matter if request was succeeded or not.
