### PR TITLE
Increment cache_first_available_item by one in uwsgi_cache_set when an index is reused from cache_unused_stack and cache_first_available_item is equal to the index reused.

### DIFF
--- a/core/cache.c
+++ b/core/cache.c
@@ -269,6 +269,9 @@ int uwsgi_cache_set(char *key, uint16_t keylen, char *val, uint64_t vallen, uint
 			//uwsgi_log("!!! REUSING CACHE SLOT !!! (faci: %llu)\n", (unsigned long long) uwsgi.shared->cache_first_available_item);
 			index = uwsgi.cache_unused_stack[uwsgi.shared->cache_unused_stack_ptr];
 			uwsgi.shared->cache_unused_stack_ptr--;
+			if (index == uwsgi.shared->cache_first_available_item) {
+				uwsgi.shared->cache_first_available_item++;
+			}
 		}
 		else {
 			index = uwsgi.shared->cache_first_available_item;


### PR DESCRIPTION
Cache is empty to start with:
cache_unused_stack_ptr = 0
cache_first_available_item = 1

Add key "A":
key "A" -> cache_items[1]
cache_first_available_item = 2
cache_hashtable[hash("A")] = 1

Add key "B":
key "B" -> cache_items[2]
cache_first_available_item = 3
cache_hashtable[hash("B")] = 2

Delete key "B"
cache_unused_stack[1] = 2
cache_unused_stack_ptr = 1
cache_hashtable[hash("B")] = 0
cache_first_available_item = 2

Add key "C":
key C -> cache_items[2] - reused from cache_unused_stack[1]
cache_unused_stack_ptr = 0
cache_hashtable[hash("C")] = 2

At this point, cache_first_available_item is still equal to 2 and there is nothing to reuse anymore.
Add key "D":
key D -> cache_items[2] - Issue here is that key "C" is already here so it gets overwritten.
cache_hashtable[hash("D")] = 2

Get key "C":
cache_get_index returns 0 because the hash at cache_items[2] is not the same as hash("C"). cache_hashtable[hash("C")] does contains index 2 though.

Now if you try to add key "C". The key "C" will be added over and over and create more and more collisions. Getting key "C" will still return None.

I think cache_first_available_item should be incremented by one in uwsgi_cache_set when an index is reused from cache_unused_stack and cache_first_available_item is equal to the index reused.
