### PR TITLE
Add optional logging to notfound plugin

### DIFF
--- a/plugins/notfound/notfound.c
+++ b/plugins/notfound/notfound.c
@@ -1,14 +1,29 @@
 #include <uwsgi.h>
 
-static int uwsgi_request_notfound(struct wsgi_request *wsgi_req) {
+static int uwsgi_notfound_log_enabled = 0;
 
+struct uwsgi_option uwsgi_notfound_options[] = {
+	{"notfound-log", no_argument, 0, "log requests to the notfound plugin", uwsgi_opt_true, &uwsgi_notfound_log_enabled, 0},
+	{NULL, 0, 0, NULL, NULL, NULL, 0},
+};
+
+static int uwsgi_request_notfound(struct wsgi_request *wsgi_req) {
+	if (uwsgi_parse_vars(wsgi_req)) {
+		return -1;
+	}
 	uwsgi_404(wsgi_req);
 	return UWSGI_OK;
 }
 
+static void uwsgi_notfound_log(struct wsgi_request *wsgi_req) {
+	if (uwsgi_notfound_log_enabled) {
+		log_request(wsgi_req);
+	}
+}
 
 struct uwsgi_plugin notfound_plugin = {
-
 	.name = "notfound",
+	.options = uwsgi_notfound_options,
 	.request = uwsgi_request_notfound,
+	.after_request = uwsgi_notfound_log,
 };


### PR DESCRIPTION
This adds an option to enable logging for requests to the notfound plugin which can be useful for static file/CGI serving.
