### PR TITLE
Add build profile for coverity scan

### DIFF
--- a/buildconf/coverity.ini
+++ b/buildconf/coverity.ini
@@ -1,0 +1,4 @@
+[uwsgi]
+# pypy,jvm,ring,jwsgi
+main_plugin = erlang,psgi,rack,lua,python,gevent,php,cgi,mono,pyerl,go
+inherit = base


### PR DESCRIPTION
Add all the language plugins i can actually compile on my machine
so that we have a bit more plugin coverage instead of the plain make.
31 more bugs reported by Coverity scan.
