### PR TITLE
Supporting JVM/Ring installing in Virtualenv

### DIFF
--- a/buildconf/pyring.ini
+++ b/buildconf/pyring.ini
@@ -1,0 +1,6 @@
+[uwsgi]
+main_plugin = python,gevent
+inherit = base
+plugins = jvm,ring
+plugin_dir = .
+

--- a/plugins/jvm/uwsgiplugin.py
+++ b/plugins/jvm/uwsgiplugin.py
@@ -36,15 +36,15 @@ else:
            JVM_LIBPATH = ["-L%s/jre/lib/%s/server" % (jvm, arch)]
            break
 
-try: 
+try:
     JVM_INCPATH = ['-I"' + os.environ['UWSGICONFIG_JVM_INCPATH'] + '"']
-except: 
-    pass 
+except:
+    pass
 
-try: 
+try:
     JVM_LIBPATH = ['-L"' + os.environ['UWSGICONFIG_JVM_LIBPATH'] + '"']
-except: 
-    pass 
+except:
+    pass
 
 if not JVM_INCPATH or not JVM_LIBPATH:
     print("unable to autodetect the JVM path, please specify UWSGICONFIG_JVM_INCPATH and UWSGICONFIG_JVM_LIBPATH environment vars")
@@ -69,3 +69,17 @@ def post_build(config):
     if os.system("cd %s/plugins/jvm ; jar cvf uwsgi.jar *.class" % os.getcwd()) != 0:
         os._exit(1)
     print("*** uwsgi.jar available in %s/plugins/jvm/uwsgi.jar ***" % os.getcwd())
+
+    env = os.environ.get('VIRTUAL_ENV')
+    if env:
+        src = "%s/plugins/jvm/uwsgi.jar" % os.getcwd()
+        tgt = "%s/lib/uwsgi.jar" % env
+        shutil.copyfile(src, tgt)
+        print("*** uwsgi.jar had been copied to %s" % tgt)
+
+        plugin = "%s/jvm_plugin.so" % os.getcwd()
+        if os.path.exists(plugin):
+            tgt = "%s/bin/jvm_plugin.so" % env
+            shutil.copyfile(plugin, tgt)
+            print("*** jvm_plugin.so had been copied to %s" % tgt)
+

--- a/plugins/ring/uwsgiplugin.py
+++ b/plugins/ring/uwsgiplugin.py
@@ -1,3 +1,6 @@
+import os
+import shutil
+
 jvm_path = 'plugins/jvm'
 
 up = {}
@@ -14,3 +17,13 @@ CFLAGS.append('-I%s' % jvm_path)
 LDFLAGS = []
 LIBS = []
 GCC_LIST = ['ring_plugin']
+
+def post_build(config):
+    env = os.environ.get('VIRTUAL_ENV')
+    if env:
+        plugin = "%s/ring_plugin.so" % os.getcwd()
+        if os.path.exists(plugin):
+            tgt = "%s/bin/ring_plugin.so" % env
+            shutil.copyfile(plugin, tgt)
+            print("*** ring_plugin.so had been copied to %s" % tgt)
+


### PR DESCRIPTION
Add code to support JVM/Ring installing in Virtualenv.

Test steps:
- virtualenv ENVHOME
- cd ENVHOME
- source bin/activate
- export UWSGI_PROFILE="pyring"
- pip install uwsgi
- check with path ENVHOME/bin , jvm_plugin.so and ring_plugin.so should be in this directory
- check with path ENVHOME/lib , uwsgi.jar should be in this directory
