### PR TITLE
Routing table appear to go nuts when used within a FOR loop

### DIFF
--- a/core/uwsgi.c
+++ b/core/uwsgi.c
@@ -80,6 +80,7 @@ static struct uwsgi_option uwsgi_base_options[] = {
 	{"for", required_argument, 0, "(opt logic) for cycle", uwsgi_opt_logic, (void *) uwsgi_logic_opt_for, UWSGI_OPT_IMMEDIATE},
 	{"for-glob", required_argument, 0, "(opt logic) for cycle (expand glob)", uwsgi_opt_logic, (void *) uwsgi_logic_opt_for_glob, UWSGI_OPT_IMMEDIATE},
 	{"endfor", optional_argument, 0, "(opt logic) end for cycle", uwsgi_opt_noop, NULL, UWSGI_OPT_IMMEDIATE},
+	{"end-for", optional_argument, 0, "(opt logic) end for cycle", uwsgi_opt_noop, NULL, UWSGI_OPT_IMMEDIATE},
 
 	{"if-opt", required_argument, 0, "(opt logic) check for option", uwsgi_opt_logic, (void *) uwsgi_logic_opt_if_opt, UWSGI_OPT_IMMEDIATE},
 	{"if-not-opt", required_argument, 0, "(opt logic) check for option", uwsgi_opt_logic, (void *) uwsgi_logic_opt_if_not_opt, UWSGI_OPT_IMMEDIATE},
@@ -108,6 +109,7 @@ static struct uwsgi_option uwsgi_base_options[] = {
 	{"if-directory", required_argument, 0, "(opt logic) check for directory existance", uwsgi_opt_logic, (void *) uwsgi_logic_opt_if_dir, UWSGI_OPT_IMMEDIATE},
 
 	{"endif", optional_argument, 0, "(opt logic) end if", uwsgi_opt_noop, NULL, UWSGI_OPT_IMMEDIATE},
+	{"end-if", optional_argument, 0, "(opt logic) end if", uwsgi_opt_noop, NULL, UWSGI_OPT_IMMEDIATE},
 
 	{"blacklist", required_argument, 0, "set options blacklist context", uwsgi_opt_set_str, &uwsgi.blacklist_context, UWSGI_OPT_IMMEDIATE},
 	{"end-blacklist", no_argument, 0, "clear options blacklist context", uwsgi_opt_set_null, &uwsgi.blacklist_context, UWSGI_OPT_IMMEDIATE},


### PR DESCRIPTION
easy to reproduce... while playing with 1.9 routing capabilities i tried to do this in the INI config:

```
mount = 360.json=threesixty:entry_json

for = HTTP_HOST REQUEST_URI QUERY_STRING REMOTE_ADDR HTTP_REFERER HTTP_USER_AGENT PATH_INFO
    route = ^ log:>>> %(_): ${%(_)}
end-for = 1

route = ^/360/json/ uwsgi:,,,360.json
route = ^/[^/]*$ break:403 Forbidden
```

...and while it did work as expected, i noticed uWSGI outputting this:

```
*** dumping internal routing table ***
[rule: 0] subject: path_info regexp: ^ action: log:>>> HTTP_HOST: ${HTTP_HOST}
[rule: 1] subject: path_info regexp: ^ action: log:>>> REQUEST_URI: ${REQUEST_URI}
[rule: 2] subject: path_info regexp: ^ action: log:>>> QUERY_STRING: ${QUERY_STRING}
[rule: 3] subject: path_info regexp: ^ action: log:>>> REMOTE_ADDR: ${REMOTE_ADDR}
[rule: 4] subject: path_info regexp: ^ action: log:>>> HTTP_REFERER: ${HTTP_REFERER}
[rule: 5] subject: path_info regexp: ^ action: log:>>> HTTP_USER_AGENT: ${HTTP_USER_AGENT}
[rule: 6] subject: path_info regexp: ^ action: log:>>> PATH_INFO: ${PATH_INFO}
[rule: 7] subject: path_info regexp: ^/360/json/ action: uwsgi:,,,360.json
[rule: 8] subject: path_info regexp: ^/360/json/ action: uwsgi:,,,360.json
[rule: 9] subject: path_info regexp: ^/360/json/ action: uwsgi:,,,360.json
[rule: 10] subject: path_info regexp: ^/360/json/ action: uwsgi:,,,360.json
[rule: 11] subject: path_info regexp: ^/360/json/ action: uwsgi:,,,360.json
[rule: 12] subject: path_info regexp: ^/360/json/ action: uwsgi:,,,360.json
[rule: 13] subject: path_info regexp: ^/360/json/ action: uwsgi:,,,360.json
[rule: 14] subject: path_info regexp: ^/[^/]*$ action: break:403 Forbidden
[rule: 15] subject: path_info regexp: ^/[^/]*$ action: break:403 Forbidden
[rule: 16] subject: path_info regexp: ^/[^/]*$ action: break:403 Forbidden
[rule: 17] subject: path_info regexp: ^/[^/]*$ action: break:403 Forbidden
[rule: 18] subject: path_info regexp: ^/[^/]*$ action: break:403 Forbidden
[rule: 19] subject: path_info regexp: ^/[^/]*$ action: break:403 Forbidden
[rule: 20] subject: path_info regexp: ^/[^/]*$ action: break:403 Forbidden
*** end of the internal routing table ***
```

...once i remove the loop, i get:

```
*** dumping internal routing table ***
[rule: 0] subject: path_info regexp: ^/360/json/ action: uwsgi:,,,360.json
[rule: 1] subject: path_info regexp: ^/[^/]*$ action: break:403 Forbidden
*** end of the internal routing table ***
```

...quite a difference :)
