### PR TITLE
Fix imports for the JVM plugin

### DIFF
--- a/plugins/jvm/uwsgiplugin.py
+++ b/plugins/jvm/uwsgiplugin.py
@@ -1,4 +1,5 @@
-import os,sys
+import os
+import shutil
 
 NAME='jvm'
 


### PR DESCRIPTION
The JVM plugin failed to import `shutil` so I've added that.

Furthermore, `sys` wasn't needed so I removed it.
