### PR TITLE
Fix segfault in psgi plugin

### DIFF
--- a/plugins/psgi/psgi_plugin.c
+++ b/plugins/psgi/psgi_plugin.c
@@ -513,6 +513,10 @@ void uwsgi_perl_after_request(struct wsgi_request *wsgi_req) {
 
 	log_request(wsgi_req);
 
+	// We may be called after an early exit in XS_coroae_accept_request, 
+	// before the environ is set up.
+	if (!wsgi_req->async_environ) return;
+
 	// dereference %env
 	SV *env = SvRV((SV *) wsgi_req->async_environ);
 


### PR DESCRIPTION
Under test load we've seen segfaults in psgi plugin. gdb and logging shows we're in uwsgi_perl_after_request called from XS_coroae_accept_request from an early error path (the wsgi_req->socket->proto returning status < 0).

Given that it seems legitimate that we might have an incomplete wsgi_req (with no async_environ), a NULL check during cleanup seems appropriate. Hope that's a reasonable response to the problem.
