### PR TITLE
refactored legion opt functions to be more plugin friendly

### DIFF
--- a/uwsgi.h
+++ b/uwsgi.h
@@ -3760,9 +3760,12 @@ void uwsgi_user_unlock(int);
 
 #ifdef UWSGI_SSL
 void uwsgi_opt_legion(char *, char *, void *);
+struct uwsgi_legion *uwsgi_legion_register(char *, char *, char *, char *, char *);
 void uwsgi_opt_legion_node(char *, char *, void *);
+void uwsgi_legion_register_node(struct uwsgi_legion *, char *);
 void uwsgi_opt_legion_quorum(char *, char *, void *);
 void uwsgi_opt_legion_hook(char *, char *, void *);
+void uwsgi_legion_register_hook(struct uwsgi_legion *, char *, char *);
 void uwsgi_opt_legion_scroll(char *, char *, void *);
 void uwsgi_legion_add(struct uwsgi_legion *);
 char *uwsgi_ssl_rand(size_t);


### PR DESCRIPTION
It seems that I've managed not to break it (at least simple legion setups still works just fine), but please review and post any changes you want.

Also I've noticed that in original opt function `char *legion` is not always freed at the end, I saw only one comment in `uwsgi_opt_legion_scroll()` that it should not be freed. Please verify it we free it every time we should.

As always naming will probably need refactoring, just let me know.
