### PR TITLE
add system load avg info to stats

### DIFF
--- a/core/master_utils.c
+++ b/core/master_utils.c
@@ -828,6 +828,16 @@ struct uwsgi_stats *uwsgi_master_generate_stats() {
 
 	if (uwsgi_stats_keylong_comma(us, "load", (unsigned long long) uwsgi.shared->load))
 		goto end;
+
+	double load[3];
+	char loadavg[128] = "N/A";
+	if (getloadavg(load, 3) != -1) {
+		if (sprintf(loadavg, "%.2f, %.2f, %.2f", load[0], load[1], load[2]) < 0)
+			uwsgi_error("getloadavg()\n");
+	}
+	if (uwsgi_stats_keyval_comma(us, "system_loadavg", loadavg))
+		goto end;
+
 	if (uwsgi_stats_keylong_comma(us, "pid", (unsigned long long) getpid()))
 		goto end;
 	if (uwsgi_stats_keylong_comma(us, "uid", (unsigned long long) getuid()))


### PR DESCRIPTION
When looking at stats from multiple nodes it is useful to have also load avg stats from those nodes, so it would be nice to add it.

I'm not sure about availability, it seems that this is present on all UNIXes and Cygwin emulates it, but I've seen mixed reports so (provided that you are willing to merge it) we might:
a) push it as is and wait for people to complain that it does not compile on some platforms
b) ifdef it with `__linux__`, `__FreeBSD__`, `__sun__` and `__APPLE__` (for example)
