### PR TITLE
zero pids after worker killed due to --idle usage

### DIFF
--- a/core/master_checks.c
+++ b/core/master_checks.c
@@ -112,6 +112,9 @@ void uwsgi_master_check_idle() {
 				if (errno != ECHILD)
 					uwsgi_error("uwsgi_master_check_idle()/waitpid()");
 			}
+			else {
+				uwsgi.workers[i].pid = 0;
+			}
 		}
 		uwsgi_add_sockets_to_queue(uwsgi.master_queue, -1);
 		uwsgi_log("cheap mode enabled: waiting for socket connection...\n");


### PR DESCRIPTION
It looks that worker pids are simply not zeroed after `--idle` kicks in, but maybe they should be zeroed somewhere else?

Also this SIGKILL seems brutal, isn't it possible that we be lucky enough to send SIGKILL just after new request was received? Wouldn't it be better to mark worker as ready for graceful shutdown (and each request would reset such marker) ?

```
uwsgi --wsgi-file tests/staticfile.py -L -M --idle 2 -p 20 --http :8080 --cheaper 1 --cheaper-initial 10 --auto-procname  --stats :4444
```

is enough to test it, after idle check pids in stat socket
