### PR TITLE
cache refactoring for better plugin friendliness

### DIFF
--- a/uwsgi.h
+++ b/uwsgi.h
@@ -2753,6 +2753,8 @@ struct uwsgi_cache *uwsgi_cache_create(char *);
 struct uwsgi_cache *uwsgi_cache_by_name(char *);
 struct uwsgi_cache *uwsgi_cache_by_namelen(char *, uint16_t);
 void uwsgi_cache_create_all(void);
+void uwsgi_cache_sync_from_nodes(struct uwsgi_cache *);
+void uwsgi_cache_setup_nodes(struct uwsgi_cache *);
 
 void uwsgi_cache_sync_all(void);
 void uwsgi_cache_start_sweepers(void);
@@ -3773,6 +3775,7 @@ void uwsgi_legion_add(struct uwsgi_legion *);
 char *uwsgi_ssl_rand(size_t);
 void uwsgi_start_legions(void);
 int uwsgi_legion_announce(struct uwsgi_legion *);
+struct uwsgi_legion *uwsgi_legion_get_by_name(char *);
 struct uwsgi_legion_action *uwsgi_legion_action_get(char *);
 void uwsgi_legion_action_register(char *, int (*)(struct uwsgi_legion *, char *));
 int uwsgi_legion_action_call(char *, struct uwsgi_legion *, struct uwsgi_string_list *);


### PR DESCRIPTION
For legion cache syncing plugin I need API for dynamic cache udp syncing reconfiguration, so I moved few code pieces to dedicated functions and exported few already available functions in uwsgi.h.

But I'm not sure if this is enough to make new udp peers work (list of nodes that will receive updates). Please take a look and if calling `uwsgi_cache_setup_nodes` is enough.
