### PR TITLE
free values on old sync node list

### DIFF
--- a/plugins/legion_cache_fetch/legion_cache_fetch.c
+++ b/plugins/legion_cache_fetch/legion_cache_fetch.c
@@ -38,6 +38,7 @@ static int legion_action_cache_fetch_from_legion(struct uwsgi_legion *ul, char *
 	struct uwsgi_string_list *next;
 	while (usl) {
 		next = usl->next;
+		free(usl->value);
 		free(usl);
 		usl = next;
 	}


### PR DESCRIPTION
I don't see anything else that should be free() before swapping uc->sync_list with new list generated from legion scrolls, if you see anything just let me know
