### PR TITLE
core/strings: don't dereference NULL pointers in uwsgi_strncmp

### DIFF
--- a/core/strings.c
+++ b/core/strings.c
@@ -59,6 +59,9 @@ int uwsgi_strncmp(char *src, int slen, char *dst, int dlen) {
         if (slen != dlen)
                 return 1;
 
+        if (!dlen || !slen || !src || !dst)
+                return 1;
+
         return memcmp(src, dst, dlen);
 
 }


### PR DESCRIPTION
Don't pass NULL pointers down to memcmp.

Reported by Coverity as CID #1010085.
