### PR TITLE
cache-sync policy

### DIFF
--- a/core/init.c
+++ b/core/init.c
@@ -161,6 +161,8 @@ void uwsgi_init_default() {
 
 	uwsgi.empty = "";
 
+	uwsgi.cache_sync_policy = "always";
+
 	uwsgi.wait_read_hook = uwsgi_simple_wait_read_hook;
 	uwsgi.wait_write_hook = uwsgi_simple_wait_write_hook;
 
@@ -433,6 +435,11 @@ void sanitize_args() {
 	if (uwsgi.shared->options[UWSGI_OPTION_MAX_WORKER_LIFETIME] > 0 && uwsgi.shared->options[UWSGI_OPTION_MIN_WORKER_LIFETIME] >= uwsgi.shared->options[UWSGI_OPTION_MAX_WORKER_LIFETIME]) {
 		uwsgi_log("invalid min-worker-lifetime value (%d), must be lower than max-worker-lifetime (%d)\n",
 			uwsgi.shared->options[UWSGI_OPTION_MIN_WORKER_LIFETIME], uwsgi.shared->options[UWSGI_OPTION_MAX_WORKER_LIFETIME]);
+		exit(1);
+	}
+
+	if (strcmp(uwsgi.cache_sync_policy, "always") && strcmp(uwsgi.cache_sync_policy, "lastmod") && strcmp(uwsgi.cache_sync_policy, "items")) {
+		uwsgi_log("invalid cache sync policy: %s\n", uwsgi.cache_sync_policy);
 		exit(1);
 	}
 

--- a/core/uwsgi.c
+++ b/core/uwsgi.c
@@ -231,6 +231,7 @@ static struct uwsgi_option uwsgi_base_options[] = {
 	{"cache-udp-server", required_argument, 0, "bind the cache udp server (used only for set/update/delete) to the specified socket", uwsgi_opt_add_string_list, &uwsgi.cache_udp_server, UWSGI_OPT_MASTER},
 	{"cache-udp-node", required_argument, 0, "send cache update/deletion to the specified cache udp server", uwsgi_opt_add_string_list, &uwsgi.cache_udp_node, UWSGI_OPT_MASTER},
 	{"cache-sync", required_argument, 0, "copy the whole content of another uWSGI cache server on server startup", uwsgi_opt_set_str, &uwsgi.cache_sync, 0},
+	{"cache-sync-policy", no_argument, 0, "set policy for cache sync from remote server (default is \"always\")", uwsgi_opt_set_str, &uwsgi.cache_sync_policy, 0},
 	{"cache-use-last-modified", no_argument, 0, "update last_modified_at timestamp on every cache item modification (default is disabled)", uwsgi_opt_true, &uwsgi.cache_use_last_modified, 0},
 
 	{"load-file-in-cache", required_argument, 0, "load a static file in the cache", uwsgi_opt_add_string_list, &uwsgi.load_file_in_cache, 0},

--- a/plugins/cache/cache.c
+++ b/plugins/cache/cache.c
@@ -282,6 +282,14 @@ static int uwsgi_cache_request(struct wsgi_request *wsgi_req) {
 				uwsgi_buffer_destroy(cache_dump);
 				break;
 			}
+			if (uwsgi_buffer_append_keynum(cache_dump, "n_items", 7, uc->n_items)) {
+				uwsgi_buffer_destroy(cache_dump);
+				break;
+			}
+			if (uwsgi_buffer_append_keynum(cache_dump, "last_modified_at", 16, uc->last_modified_at)) {
+				uwsgi_buffer_destroy(cache_dump);
+				break;
+			}
 
 			if (uwsgi_buffer_set_uh(cache_dump, 111, 7)) {
 				uwsgi_buffer_destroy(cache_dump);

--- a/uwsgi.h
+++ b/uwsgi.h
@@ -729,6 +729,9 @@ struct uwsgi_cache {
 
 	int thread_server_fd;
 
+	uint8_t can_sync;
+	char *sync_policy;
+
 	struct uwsgi_string_list *nodes;
 	int udp_node_socket;
 	struct uwsgi_string_list *sync_nodes;
@@ -1891,6 +1894,7 @@ struct uwsgi_server {
 	int cache_setup;
 	int locking_setup;
 	int cache_use_last_modified;
+	char *cache_sync_policy;
 
 	struct uwsgi_dyn_dict *static_expires_type;
 	struct uwsgi_dyn_dict *static_expires_type_mtime;


### PR DESCRIPTION
This allows to specify when uWSGI should fetch cache dump from remote nodes, we can set it to only fetch it if remote cache has bigger last_modifed_at timestamp or contains more items, or to always fetch (default).

The only downside is that if cache-sync rejects remote dump then we have
`uwsgi_response_write_body_do(): Connection reset by peer [core/writer.c line 205]`
on remote node, I don't know how to close the connection so that other side won't consider it an error. I don't want  to read whole cache dump response since it might be very big.

please review
