### PR TITLE
add alarm-segfault and allow to push segfaults to airbrake compatible er...

### DIFF
--- a/core/utils.c
+++ b/core/utils.c
@@ -1736,7 +1736,7 @@ void *uwsgi_malloc(size_t size) {
 	if (ptr == NULL) {
 		uwsgi_error("malloc()");
 		uwsgi_log("!!! tried memory allocation of %llu bytes !!!\n", (unsigned long long) size);
-		uwsgi_backtrace(uwsgi.backtrace_depth);
+		uwsgi_backtrace(uwsgi.backtrace_depth, 1);
 		exit(1);
 	}
 

--- a/plugins/alarm_curl/alarm_curl_plugin.c
+++ b/plugins/alarm_curl/alarm_curl_plugin.c
@@ -1,5 +1,8 @@
-#include "../../uwsgi.h"
+#include <uwsgi.h>
+
+#include <libxml/parser.h>
 #include <curl/curl.h>
+
 
 extern struct uwsgi_server uwsgi;
 
@@ -8,6 +11,7 @@ struct uwsgi_alarm_curl_config {
 	char *arg;
 	char *subject;
 	char *to;
+	char *airbrake_key;
 };
 
 struct uwsgi_alarm_curl_opt {
@@ -41,7 +45,11 @@ static void uwsgi_alarm_curl_int(CURL *curl, CURLoption option, char *arg, struc
 }
 
 static void uwsgi_alarm_curl_set_subject(CURL *curl, CURLoption option, char *arg, struct uwsgi_alarm_curl_config *uacc) {
-	uacc->subject = arg;	
+	uacc->subject = arg;
+}
+
+static void uwsgi_alarm_curl_set_airbrake(CURL *curl, CURLoption option, char *arg, struct uwsgi_alarm_curl_config *uacc) {
+	uacc->airbrake_key = arg;
 }
 
 static struct uwsgi_alarm_curl_opt uaco[] = {
@@ -59,6 +67,7 @@ static struct uwsgi_alarm_curl_opt uaco[] = {
 	{"method", CURLOPT_CUSTOMREQUEST, NULL},
 	{"timeout", CURLOPT_TIMEOUT, uwsgi_alarm_curl_int},
 	{"conn_timeout", CURLOPT_CONNECTTIMEOUT, uwsgi_alarm_curl_int},
+	{"airbrake", 0, uwsgi_alarm_curl_set_airbrake},
 	{NULL, 0, NULL},
 };
 
@@ -90,6 +99,70 @@ end:
 	*equal = '=';
 }
 
+static void uwsgi_alarm_curl_format_airbrake(struct uwsgi_thread *ut) {
+	xmlChar *xmlbuff;
+	int buffersize;
+	xmlDocPtr doc = NULL;
+	xmlNodePtr notice_node = NULL, node = NULL, line_node = NULL;
+	struct uwsgi_alarm_curl_config *uacc = ut->data;
+
+	doc = xmlNewDoc(BAD_CAST "1.0");
+	notice_node = xmlNewNode(NULL, BAD_CAST "notice");
+	xmlNewProp(notice_node, BAD_CAST "version", BAD_CAST "2.3");
+	xmlDocSetRootElement(doc, notice_node);
+
+	xmlNewChild(notice_node, NULL, BAD_CAST "api-key", BAD_CAST uacc->airbrake_key);
+
+	node = xmlNewChild(notice_node, NULL, BAD_CAST "notifier", NULL);
+	xmlNewChild(node, NULL, BAD_CAST "name", BAD_CAST "alarm_airbrake");
+	xmlNewChild(node, NULL, BAD_CAST "version", BAD_CAST UWSGI_VERSION);
+	xmlNewChild(node, NULL, BAD_CAST "url", BAD_CAST "https://github.com/unbit/uwsgi");
+
+	node = xmlNewChild(notice_node, NULL, BAD_CAST "error", NULL);
+	xmlNewChild(node, NULL, BAD_CAST "class", BAD_CAST "RuntimeError");
+	xmlNewChild(node, NULL, BAD_CAST "message", BAD_CAST uacc->subject);
+	node = xmlNewChild(node, NULL, BAD_CAST "backtrace", NULL);
+
+	char *p = strtok(ut->buf, "\n");
+	while (p) {
+		char *n = strchr(p, '(');
+		if (n) {
+			line_node = xmlNewChild(node, NULL, BAD_CAST "line", NULL);
+			*n = 0;
+			char *pls = strchr(n+1, '+');
+			if (pls) {
+				*pls = 0;
+			}
+
+			if ((n+1)[0] == ')') {
+				xmlNewProp(line_node, BAD_CAST "method", BAD_CAST "()");
+			}
+			else {
+				xmlNewProp(line_node, BAD_CAST "method", BAD_CAST n+1);
+			}
+
+			xmlNewProp(line_node, BAD_CAST "file", BAD_CAST p);
+
+			xmlNewProp(line_node, BAD_CAST "number", BAD_CAST "0");
+		}
+		p = strtok(NULL, "\n");
+	}
+
+	node = xmlNewChild(notice_node, NULL, BAD_CAST "server-environment", NULL);
+	xmlNewChild(node, NULL, BAD_CAST "environment-name", BAD_CAST "production");
+	xmlNewChild(node, NULL, BAD_CAST "app-version", BAD_CAST UWSGI_VERSION);
+
+	xmlDocDumpFormatMemory(doc, &xmlbuff, &buffersize, 1);
+
+	xmlFreeDoc(doc);
+	xmlCleanupParser();
+	xmlMemoryDump();
+
+	free(ut->buf);
+	ut->buf = (char *) xmlbuff;
+	ut->len = (size_t) buffersize;
+}
+
 static size_t uwsgi_alarm_curl_read_callback(void *ptr, size_t size, size_t nmemb, void *userp) {
 	struct uwsgi_thread *ut = (struct uwsgi_thread *) userp;
 	size_t full_size = size * nmemb;
@@ -106,7 +179,6 @@ static size_t uwsgi_alarm_curl_read_callback(void *ptr, size_t size, size_t nmem
 		if (uacc->subject) required += 9 + strlen(uacc->subject) + 1;
 		if (required > full_size) goto skip;
 
-
 		if (uacc->to) {
 			memcpy(addr, "To: ", 4); addr+=4;
 			memcpy(addr, uacc->to, strlen(uacc->to)); addr += strlen(uacc->to);
@@ -120,6 +192,7 @@ static size_t uwsgi_alarm_curl_read_callback(void *ptr, size_t size, size_t nmem
 			*addr ++= '\n';
 			newline = 1;
 		}
+
 skip:
 		if (newline > 0) {
 			*addr = '\n';
@@ -135,7 +208,7 @@ skip:
 	memcpy(ptr, ut->buf + ut->pos, remains);
 	ut->pos += remains;
 
-	return remains;	
+	return remains;
 }
 
 static void uwsgi_alarm_curl_loop(struct uwsgi_thread *ut) {
@@ -150,7 +223,6 @@ static void uwsgi_alarm_curl_loop(struct uwsgi_thread *ut) {
 	curl_easy_setopt(curl, CURLOPT_TIMEOUT, uwsgi.shared->options[UWSGI_OPTION_SOCKET_TIMEOUT]);
 	curl_easy_setopt(curl, CURLOPT_READFUNCTION, uwsgi_alarm_curl_read_callback);
 	curl_easy_setopt(curl, CURLOPT_READDATA, ut);
-	curl_easy_setopt(curl, CURLOPT_UPLOAD, 1L);
 	curl_easy_setopt(curl, CURLOPT_POST, 1L);
 	struct curl_slist *expect = NULL; expect = curl_slist_append(expect, "Expect:");
 	curl_easy_setopt(curl, CURLOPT_HTTPHEADER, expect);
@@ -167,7 +239,7 @@ static void uwsgi_alarm_curl_loop(struct uwsgi_thread *ut) {
 	}
 
 	for(;;) {
-		int ret = event_queue_wait(ut->queue, -1, &interesting_fd);	
+		int ret = event_queue_wait(ut->queue, -1, &interesting_fd);
 		if (ret <= 0) continue;
 		if (interesting_fd != ut->pipe[1]) continue;
 		ssize_t rlen = read(ut->pipe[1], ut->buf, uwsgi.log_master_bufsize);
@@ -175,12 +247,26 @@ static void uwsgi_alarm_curl_loop(struct uwsgi_thread *ut) {
 		ut->pos = 0;
 		ut->len = (size_t) rlen;
 		ut->custom0 = 0;
+		if (uacc->airbrake_key) {
+			uwsgi_alarm_curl_format_airbrake(ut);
+			if (!uacc->subject) uacc->subject = "uWSGI alarm";
+			curl_slist_append(expect, "Accept: */*");
+			curl_slist_append(expect, "Content-Type: text/xml; charset=utf-8");
+			curl_easy_setopt(curl, CURLOPT_HTTPHEADER, expect);
+			curl_easy_setopt(curl, CURLOPT_POSTFIELDS, ut->buf);
+			curl_easy_setopt(curl, CURLOPT_POSTFIELDSIZE, ut->len);
+		}
+		else {
+			curl_easy_setopt(curl, CURLOPT_UPLOAD, 1L);
+		}
 		curl_easy_setopt(curl, CURLOPT_INFILESIZE_LARGE, (curl_off_t) ut->len);
 		CURLcode res = curl_easy_perform(curl);
 		if (res != CURLE_OK) {
 			uwsgi_log_alarm("-curl] curl_easy_perform() failed: %s\n", curl_easy_strerror(res));
 		}
-		
+		else {
+			uwsgi_log_alarm("-curl] request sent successfully\n", NULL);
+		}
 	}
 }
 

--- a/plugins/alarm_curl/uwsgiplugin.py
+++ b/plugins/alarm_curl/uwsgiplugin.py
@@ -1,6 +1,9 @@
+from uwsgiconfig import spcall
+
+
 NAME='alarm_curl'
 
-CFLAGS = []
+CFLAGS = [spcall('xml2-config --cflags')]
 LDFLAGS = []
-LIBS = ['-lcurl']
+LIBS = ['-lcurl', spcall('xml2-config --libs')]
 GCC_LIST = ['alarm_curl_plugin']

--- a/uwsgi.h
+++ b/uwsgi.h
@@ -1158,12 +1158,12 @@ struct uwsgi_alarm_fd {
 
 struct uwsgi_alarm_fd *uwsgi_add_alarm_fd(int, char *, size_t, char *, size_t);
 
-#ifdef UWSGI_PCRE
 struct uwsgi_alarm_ll {
 	struct uwsgi_alarm_instance *alarm;
 	struct uwsgi_alarm_ll *next;
 };
 
+#ifdef UWSGI_PCRE
 struct uwsgi_alarm_log {
 	pcre *pattern;
 	pcre_extra *pattern_extra;
@@ -1846,11 +1846,13 @@ struct uwsgi_server {
 	uint64_t alarm_msg_size;
 	struct uwsgi_string_list *alarm_list;
 	struct uwsgi_string_list *alarm_logs_list;
+	struct uwsgi_string_list *alarm_segfaults_list;
 	struct uwsgi_alarm_fd *alarm_fds;
 	struct uwsgi_string_list *alarm_fd_list;
 	struct uwsgi_alarm *alarms;
 	struct uwsgi_alarm_instance *alarm_instances;
 	struct uwsgi_alarm_log *alarm_logs;
+	struct uwsgi_alarm_ll *alarm_segfaults;
 	struct uwsgi_thread *alarm_thread;
 
 	int threaded_logger;
@@ -3319,7 +3321,7 @@ void uwsgi_reload(char **);
 
 char *uwsgi_chomp(char *);
 int uwsgi_file_to_string_list(char *, struct uwsgi_string_list **);
-void uwsgi_backtrace(int);
+void uwsgi_backtrace(int, int);
 void uwsgi_check_logrotate(void);
 char *uwsgi_check_touches(struct uwsgi_string_list *);
 


### PR DESCRIPTION
...ror trackers (tested with errbit)

This is updated patch that adds:
- `--alarm-segfault` option for raising alarm on segfault in uWSGI
- format airbrake notification xml and post it to airbrake compatible servers using alarm_curl plugin, usage:

```
plugins = alarm_curl
alarm = errbit curl:http://airbrake.server/notifier_api/v2/notices;airbrake=<AIRBRAKE API KEY>;subject=uWSGI Segfault
alarm-segfault = errbit
```

and cause uWSGI to segfault, traceback will be recorded in airbrake server.

We could even setup public errbit server and start collection segfaults from uWSGI users, but I fear that soon they would contain:

```

/uwsgi:0→ buy_cheap_viagra()
/uwsgi:0→ enlarge_anythig()
/uwsgi:0→ ()
```

This fixes #145 

Airbrake API docs are [here](http://help.airbrake.io/kb/api-2/notifier-api-version-23)
