### PR TITLE
Fix mule farm initialization

### DIFF
--- a/core/mule.c
+++ b/core/mule.c
@@ -441,7 +441,7 @@ void uwsgi_setup_mules_and_farms() {
 			mules_list++;
 
 			strncpy(uwsgi.farms[i].name, farm_value, 0xff);
-			free(farm_value);
+			
 
 			// create the socket pipe
 			create_signal_pipe(uwsgi.farms[i].signal_pipe);
@@ -462,7 +462,7 @@ void uwsgi_setup_mules_and_farms() {
 			uwsgi_log("created farm %d name: %s mules:%s\n", i + 1, uwsgi.farms[i].name, strchr(farm_name->value, ':') + 1);
 
 			farm_name = farm_name->next;
-
+			free(farm_value);
 		}
 
 	}


### PR DESCRIPTION
The mules_list pointer points to the same buffer as farm_value, so when farm_value is freed the subsequent strtok operations on mules_list will have undefined behavior. On my flavor of linux the farm_value buffer is cleared, so strtok never finds any of the mule ids and the mules never get added to the farm.
