### PR TITLE
legion daemons

### DIFF
--- a/core/master_utils.c
+++ b/core/master_utils.c
@@ -692,9 +692,9 @@ struct uwsgi_stats *uwsgi_master_generate_stats() {
 				goto end;
 			if (uwsgi_stats_keyval_comma(us, "cmd", ud->command))
 				goto end;
-			if (uwsgi_stats_keylong_comma(us, "pid", (unsigned long long) ud->pid))
+			if (uwsgi_stats_keylong_comma(us, "pid", (unsigned long long) (ud->pid < 0) ? 0 : ud->pid))
 				goto end;
-			if (uwsgi_stats_keylong(us, "respawns", (unsigned long long) (ud->respawns - 1)))
+			if (uwsgi_stats_keylong(us, "respawns", (unsigned long long) ud->respawns ? 0 : ud->respawns))
 				goto end;
 			if (uwsgi_stats_object_close(us))
 				goto end;

--- a/core/uwsgi.c
+++ b/core/uwsgi.c
@@ -630,6 +630,11 @@ static struct uwsgi_option uwsgi_base_options[] = {
 	{"attach-daemon", required_argument, 0, "attach a command/daemon to the master process (the command has to not go in background)", uwsgi_opt_add_daemon, NULL, UWSGI_OPT_MASTER},
 	{"smart-attach-daemon", required_argument, 0, "attach a command/daemon to the master process managed by a pidfile (the command has to daemonize)", uwsgi_opt_add_daemon, NULL, UWSGI_OPT_MASTER},
 	{"smart-attach-daemon2", required_argument, 0, "attach a command/daemon to the master process managed by a pidfile (the command has to NOT daemonize)", uwsgi_opt_add_daemon, NULL, UWSGI_OPT_MASTER},
+#ifdef UWSGI_SSL
+	{"legion-attach-daemon", required_argument, 0, "same as --attach-daemon but daemon runs only on legion lord node", uwsgi_opt_add_daemon, NULL, UWSGI_OPT_MASTER},
+	{"legion-smart-attach-daemon", required_argument, 0, "same as --smart-attach-daemon but daemon runs only on legion lord node", uwsgi_opt_add_daemon, NULL, UWSGI_OPT_MASTER},
+	{"legion-smart-attach-daemon2", required_argument, 0, "same as --smart-attach-daemon2 but daemon runs only on legion lord node", uwsgi_opt_add_daemon, NULL, UWSGI_OPT_MASTER},
+#endif
 	{"daemons-honour-stdin", no_argument, 0, "do not change the stdin of external daemons to /dev/null", uwsgi_opt_true, &uwsgi.daemons_honour_stdin, UWSGI_OPT_MASTER},
 	{"plugins", required_argument, 0, "load uWSGI plugins", uwsgi_opt_load_plugin, NULL, UWSGI_OPT_IMMEDIATE},
 	{"plugin", required_argument, 0, "load uWSGI plugins", uwsgi_opt_load_plugin, NULL, UWSGI_OPT_IMMEDIATE},

--- a/uwsgi.h
+++ b/uwsgi.h
@@ -542,6 +542,10 @@ struct uwsgi_daemon {
 	// frequency of pidfile checks (default 10 secs)
 	int freq;
 
+#ifdef UWSGI_SSL
+	char *legion;
+#endif
+
 	struct uwsgi_daemon *next;
 };
 


### PR DESCRIPTION
This adds ability to run daemon only on legion lord, all legion daemons are stopped/killed when local node is stopping. Hopefully I covered all cases

Example:

```
[uwsgi]

master = true
http = :8081
stats = :2101
wsgi-file = tests/staticfile.py

logdate = true

legion = legion1 225.1.1.1:19678 100 bf-cbc:abc
legion-node = legion1 225.1.1.1:19678

legion-attach-daemon = legion1 memcached -p 10001

legion-smart-attach-daemon = legion1 /tmp/memcached.pid memcached -p 10002 -d -P /tmp/memcached.pid
```
