### PR TITLE
better check for default value, this allows using false or empty string ...

### DIFF
--- a/uwsgiconfig.py
+++ b/uwsgiconfig.py
@@ -570,7 +570,7 @@ class uConf(object):
                 return None
             return value
         except:
-            if default:
+            if default is not None:
                 return default
             return None
 


### PR DESCRIPTION
...as defaults

I was getting this error today, it fixes it:

```
$ make
python uwsgiconfig.py --build
using profile: buildconf/default.ini
Traceback (most recent call last):
  File "uwsgiconfig.py", line 1220, in <module>
    build_uwsgi(uConf(bconf))
  File "uwsgiconfig.py", line 476, in __init__
    self.cflags = ['-O2', '-I.', '-Wall', '-Werror', '-D_LARGEFILE_SOURCE', '-D_FILE_OFFSET_BITS=64'] + os.environ.get("CFLAGS", "").split() + self.get('cflags','').split()
AttributeError: 'NoneType' object has no attribute 'split'
make: *** [all] Błąd 1
```
