### PR TITLE
Fixed a clear typo.

### DIFF
--- a/plugins/pypy/pypy_setup.py
+++ b/plugins/pypy/pypy_setup.py
@@ -87,7 +87,7 @@ def uwsgi_pypy_wsgi_handler(core):
     environ['uwsgi.core'] = core
 
     response = wsgi_application(environ, start_response) 
-    if type(response) == 'str':
+    if type(response) is str:
         writer(response)
     else:
         for chunk in response:


### PR DESCRIPTION
Only call writer once when the result of a WSGI application is a string.
