### PR TITLE
Drop obvious invalid requests.

### DIFF
--- a/plugins/http/http.c
+++ b/plugins/http/http.c
@@ -194,6 +194,11 @@ int http_headers_parse(struct corerouter_peer *peer) {
 		ptr++;
 	}
 
+        // ensure we have a method
+        if (base == ptr) {
+          return -1;
+        }
+
 	// REQUEST_URI / PATH_INFO / QUERY_STRING
 	base = ptr;
 	while (ptr < watermark) {
@@ -226,6 +231,11 @@ int http_headers_parse(struct corerouter_peer *peer) {
 		ptr++;
 	}
 
+        // ensure we have a URI
+        if (base == ptr) {
+          return -1;
+        }
+
 	// SERVER_PROTOCOL
 	base = ptr;
 	while (ptr < watermark) {
@@ -243,6 +253,11 @@ int http_headers_parse(struct corerouter_peer *peer) {
 		}
 		ptr++;
 	}
+
+        // ensure we have a protocol
+        if (base == ptr) {
+          return -1;
+        }
 
 	// SCRIPT_NAME
 	if (uwsgi_buffer_append_keyval(out, "SCRIPT_NAME", 11, "", 0)) return -1;


### PR DESCRIPTION
These requests should not be forwarded to the backend, I think WSGI apps expect at least these parameters to be set.
