### PR TITLE
unique crons, fixes #227

### DIFF
--- a/core/master.c
+++ b/core/master.c
@@ -789,6 +789,7 @@ int master_loop(char **argv, char **environ) {
 			if (uwsgi_master_check_mules_death(diedpid)) continue;
 			if (uwsgi_master_check_gateways_death(diedpid)) continue;
 			if (uwsgi_master_check_daemons_death(diedpid)) continue;
+			if (uwsgi_master_check_cron_death(diedpid)) continue;
 		}
 
 

--- a/core/master_checks.c
+++ b/core/master_checks.c
@@ -277,3 +277,17 @@ int uwsgi_worker_is_busy(int wid) {
 	}
 	return 0;
 }
+
+int uwsgi_master_check_cron_death(int diedpid) {
+	struct uwsgi_cron *uc = uwsgi.crons;
+	while (uc) {
+		if (uc->pid == (pid_t) diedpid) {
+			uwsgi_log("[uwsgi-cron] command \"%s\" running with pid %d exited after %d second(s)\n", uc->command, uc->pid, uwsgi_now() - uc->started_at);
+			uc->pid = -1;
+			return -1;
+		}
+		uc = uc->next;
+	}
+	return 0;
+}
+

--- a/core/uwsgi.c
+++ b/core/uwsgi.c
@@ -653,9 +653,12 @@ static struct uwsgi_option uwsgi_base_options[] = {
 	{"zerg-server", required_argument, 0, "enable the zerg server on the specified UNIX socket", uwsgi_opt_set_str, &uwsgi.zerg_server, UWSGI_OPT_MASTER},
 
 	{"cron", required_argument, 0, "add a cron task", uwsgi_opt_add_cron, NULL, UWSGI_OPT_MASTER},
+	{"unique-cron", required_argument, 0, "add a unique cron task", uwsgi_opt_add_unique_cron, NULL, UWSGI_OPT_MASTER},
 #ifdef UWSGI_SSL
 	{"legion-cron", required_argument, 0, "add a cron task runnable only when the instance is a lord of the specified legion", uwsgi_opt_add_legion_cron, NULL, UWSGI_OPT_MASTER},
 	{"cron-legion", required_argument, 0, "add a cron task runnable only when the instance is a lord of the specified legion", uwsgi_opt_add_legion_cron, NULL, UWSGI_OPT_MASTER},
+	{"unique-legion-cron", required_argument, 0, "add a unique cron task runnable only when the instance is a lord of the specified legion", uwsgi_opt_add_unique_legion_cron, NULL, UWSGI_OPT_MASTER},
+	{"unique-cron-legion", required_argument, 0, "add a unique cron task runnable only when the instance is a lord of the specified legion", uwsgi_opt_add_unique_legion_cron, NULL, UWSGI_OPT_MASTER},
 #endif
 	{"loop", required_argument, 0, "select the uWSGI loop engine", uwsgi_opt_set_str, &uwsgi.loop, 0},
 	{"loop-list", no_argument, 0, "list enabled loop engines", uwsgi_opt_true, &uwsgi.loop_list, 0},

--- a/uwsgi.h
+++ b/uwsgi.h
@@ -2386,6 +2386,10 @@ struct uwsgi_cron {
 #endif
 	void (*func)(struct uwsgi_cron *, time_t);
 
+	time_t started_at;
+	uint8_t unique;
+	pid_t pid;
+
 	struct uwsgi_cron *next;
 };
 
@@ -3256,12 +3260,14 @@ void uwsgi_opt_add_shared_socket(char *, char *, void *);
 void uwsgi_opt_add_socket(char *, char *, void *);
 void uwsgi_opt_add_lazy_socket(char *, char *, void *);
 void uwsgi_opt_add_cron(char *, char *, void *);
+void uwsgi_opt_add_unique_cron(char *, char *, void *);
 void uwsgi_opt_load_plugin(char *, char *, void *);
 void uwsgi_opt_load_dl(char *, char *, void *);
 void uwsgi_opt_load(char *, char *, void *);
 void uwsgi_opt_safe_fd(char *, char *, void *);
 #ifdef UWSGI_SSL
 void uwsgi_opt_add_legion_cron(char *, char *, void *);
+void uwsgi_opt_add_unique_legion_cron(char *, char *, void *);
 void uwsgi_opt_sni(char *, char *, void *);
 struct uwsgi_string_list *uwsgi_ssl_add_sni_item(char *, char *, char *, char *, char *);
 #endif
@@ -4026,6 +4032,8 @@ void uwsgi_check_emperor(void);
 #ifdef UWSGI_AS_SHARED_LIBRARY
 int uwsgi_init(int, char **, char **);
 #endif
+
+int uwsgi_master_check_cron_death(int);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
```
$ uwsgi -s :0 -M --unique-cron "-1 -1 -1 -1 -1 sleep 70" --cron "-1 -1 -1 -1 -1 sleep 80" --logdate
[...]
Thu May 23 11:11:20 2013 - [uwsgi-cron] running "sleep 70" (pid 14369)
Thu May 23 11:11:20 2013 - [uwsgi-cron] running "sleep 80" (pid 14370)
Thu May 23 11:12:20 2013 - [uwsgi-cron] running "sleep 80" (pid 14376)
Thu May 23 11:12:30 2013 - [uwsgi-cron] command "sleep 70" running with pid 14369 exited after 70 second(s)
Thu May 23 11:12:31 2013 - [uwsgi-cron] running "sleep 70" (pid 14378)
Thu May 23 11:12:40 2013 - subprocess 14370 exited with code 0
Thu May 23 11:13:20 2013 - [uwsgi-cron] running "sleep 80" (pid 14380)
Thu May 23 11:13:40 2013 - subprocess 14376 exited with code 0
Thu May 23 11:13:41 2013 - [uwsgi-cron] command "sleep 70" running with pid 14378 exited after 70 second(s)
Thu May 23 11:13:42 2013 - [uwsgi-cron] running "sleep 70" (pid 14382)
Thu May 23 11:14:20 2013 - [uwsgi-cron] running "sleep 80" (pid 14384)
Thu May 23 11:14:40 2013 - subprocess 14380 exited with code 0
Thu May 23 11:14:52 2013 - [uwsgi-cron] command "sleep 70" running with pid 14382 exited after 70 second(s)
Thu May 23 11:14:53 2013 - [uwsgi-cron] running "sleep 70" (pid 14386)
Thu May 23 11:15:20 2013 - [uwsgi-cron] running "sleep 80" (pid 14391)
```

Note that overlapping --cron tasks (non unique) will eat up pids stored at uwsgi_cron->pid for already running instance, so for such late commands we will get `subprocess 14380 exited with code 0` instead of pretty `[uwsgi-cron] command "sleep 70" running with pid 14382 exited after 70 second(s)`.
But we would need to store all pids of executed commands and that just doesn't sound like a good idea.
