### PR TITLE
cron harakiri and stats

### DIFF
--- a/core/cron.c
+++ b/core/cron.c
@@ -181,6 +181,8 @@ void uwsgi_manage_command_cron(time_t now) {
 							current_cron->pid = pid;
 							current_cron->started_at = now;
 							uwsgi_log_verbose("[uwsgi-cron] running \"%s\" (pid %d)\n", current_cron->command, current_cron->pid);
+							if (uwsgi.cron_harakiri)
+								current_cron->harakiri = now + uwsgi.cron_harakiri;
 						}
 					}
                                 }

--- a/core/master.c
+++ b/core/master.c
@@ -706,6 +706,7 @@ int master_loop(char **argv, char **environ) {
 			uwsgi_master_check_gateways_deadline();
 			uwsgi_master_check_mules_deadline();
 			uwsgi_master_check_spoolers_deadline();
+			uwsgi_master_check_crons_deadline();
 
 #ifdef __linux__
 #ifdef MADV_MERGEABLE

--- a/core/master_utils.c
+++ b/core/master_utils.c
@@ -1079,6 +1079,63 @@ struct uwsgi_stats *uwsgi_master_generate_stats() {
 			goto end;
 	}
 
+	struct uwsgi_cron *ucron = uwsgi.crons;
+	if (ucron) {
+		if (uwsgi_stats_comma(us))
+			goto end;
+		if (uwsgi_stats_key(us, "crons"))
+			goto end;
+		if (uwsgi_stats_list_open(us))
+			goto end;
+		while (ucron) {
+			if (uwsgi_stats_object_open(us))
+				goto end;
+
+			if (uwsgi_stats_keyslong_comma(us, "minute", (long long) ucron->minute))
+				goto end;
+
+			if (uwsgi_stats_keyslong_comma(us, "hour", (long long) ucron->hour))
+				goto end;
+
+			if (uwsgi_stats_keyslong_comma(us, "day", (long long) ucron->day))
+				goto end;
+
+			if (uwsgi_stats_keyslong_comma(us, "month", (long long) ucron->month))
+				goto end;
+
+			if (uwsgi_stats_keyslong_comma(us, "week", (long long) ucron->week))
+				goto end;
+
+			if (uwsgi_stats_keyval_comma(us, "command", ucron->command))
+				goto end;
+
+			if (uwsgi_stats_keylong_comma(us, "unique", (unsigned long long) ucron->unique))
+				goto end;
+
+#ifdef UWSGI_SSL
+			if (uwsgi_stats_keyval_comma(us, "legion", ucron->legion ? ucron->legion : ""))
+				goto end;
+#endif
+
+			if (uwsgi_stats_keyslong_comma(us, "pid", (long long) ucron->pid))
+				goto end;
+
+			if (uwsgi_stats_keylong(us, "started_at", (unsigned long long) ucron->started_at))
+				goto end;
+
+			if (uwsgi_stats_object_close(us))
+				goto end;
+
+			ucron = ucron->next;
+			if (ucron) {
+				if (uwsgi_stats_comma(us))
+					goto end;
+			}
+		}
+		if (uwsgi_stats_list_close(us))
+			goto end;
+	}
+
 #ifdef UWSGI_SSL
 	struct uwsgi_legion *legion = NULL;
 	if (uwsgi.legions) {

--- a/core/uwsgi.c
+++ b/core/uwsgi.c
@@ -657,6 +657,7 @@ static struct uwsgi_option uwsgi_base_options[] = {
 
 	{"cron", required_argument, 0, "add a cron task", uwsgi_opt_add_cron, NULL, UWSGI_OPT_MASTER},
 	{"unique-cron", required_argument, 0, "add a unique cron task", uwsgi_opt_add_unique_cron, NULL, UWSGI_OPT_MASTER},
+	{"cron-harakiri", required_argument, 0, "set the maximum time (in seconds) we wait for cron command to complete", uwsgi_opt_set_int, &uwsgi.cron_harakiri, 0},
 #ifdef UWSGI_SSL
 	{"legion-cron", required_argument, 0, "add a cron task runnable only when the instance is a lord of the specified legion", uwsgi_opt_add_legion_cron, NULL, UWSGI_OPT_MASTER},
 	{"cron-legion", required_argument, 0, "add a cron task runnable only when the instance is a lord of the specified legion", uwsgi_opt_add_legion_cron, NULL, UWSGI_OPT_MASTER},

--- a/uwsgi.h
+++ b/uwsgi.h
@@ -2185,6 +2185,7 @@ struct uwsgi_server {
 	struct uwsgi_string_list *map_socket;
 
 	struct uwsgi_cron *crons;
+	time_t cron_harakiri;
 
 	time_t respawn_delta;
 
@@ -2387,6 +2388,7 @@ struct uwsgi_cron {
 	void (*func)(struct uwsgi_cron *, time_t);
 
 	time_t started_at;
+	time_t harakiri;
 	uint8_t unique;
 	pid_t pid;
 
@@ -3899,6 +3901,7 @@ void uwsgi_master_check_workers_deadline(void);
 void uwsgi_master_check_gateways_deadline(void);
 void uwsgi_master_check_mules_deadline(void);
 void uwsgi_master_check_spoolers_deadline(void);
+void uwsgi_master_check_crons_deadline(void);
 int uwsgi_master_check_spoolers_death(int);
 int uwsgi_master_check_emperor_death(int);
 int uwsgi_master_check_mules_death(int);


### PR DESCRIPTION
I've ended up adding uwsgi_cron->harakiri since I think we will need per command harakiri timeout. Commands might be different and they might require different harakiri settings, with this patch we have global --cron-harakiri setting, but we should also add possibility to set this per cron task, this patch allows it, we just need to pick up syntax.

Would this be ok?

```
cron2 = minute=-2,week=1,harakiri=30,unique=1,legion=mylegion my fancy command
```

We could use "-1" as default value for crontab fields so user would only need to set few of them in most cases.
Everything after the key=val list would be interpreted as the command to run.
