### PR TITLE
--cron2 option

### DIFF
--- a/core/uwsgi.c
+++ b/core/uwsgi.c
@@ -656,6 +656,7 @@ static struct uwsgi_option uwsgi_base_options[] = {
 	{"zerg-server", required_argument, 0, "enable the zerg server on the specified UNIX socket", uwsgi_opt_set_str, &uwsgi.zerg_server, UWSGI_OPT_MASTER},
 
 	{"cron", required_argument, 0, "add a cron task", uwsgi_opt_add_cron, NULL, UWSGI_OPT_MASTER},
+	{"cron2", required_argument, 0, "add a cron task (key=val syntax)", uwsgi_opt_add_cron2, NULL, UWSGI_OPT_MASTER},
 	{"unique-cron", required_argument, 0, "add a unique cron task", uwsgi_opt_add_unique_cron, NULL, UWSGI_OPT_MASTER},
 	{"cron-harakiri", required_argument, 0, "set the maximum time (in seconds) we wait for cron command to complete", uwsgi_opt_set_int, &uwsgi.cron_harakiri, 0},
 #ifdef UWSGI_SSL

--- a/uwsgi.h
+++ b/uwsgi.h
@@ -3263,6 +3263,7 @@ void uwsgi_opt_add_shared_socket(char *, char *, void *);
 void uwsgi_opt_add_socket(char *, char *, void *);
 void uwsgi_opt_add_lazy_socket(char *, char *, void *);
 void uwsgi_opt_add_cron(char *, char *, void *);
+void uwsgi_opt_add_cron2(char *, char *, void *);
 void uwsgi_opt_add_unique_cron(char *, char *, void *);
 void uwsgi_opt_load_plugin(char *, char *, void *);
 void uwsgi_opt_load_dl(char *, char *, void *);


### PR DESCRIPTION
This should support all possible syntaxes:

```
--cron2 key=val command
--cron2 key=val command with spaces
--cron2 command
--cron2 command with spaces
```

The only restriction is that you can't use spaces in key=val part. I'll add docs if this patch is ok.

Example:

```
$ uwsgi -s :0 -M --cron2 "unique=1 sleep 70"
[...]
Thu May 23 13:46:25 2013 - [uwsgi-cron] running "sleep 70" (pid 20732)
```
