### PR TITLE
fixed dump daemon process termination

### DIFF
--- a/core/daemons.c
+++ b/core/daemons.c
@@ -235,9 +235,11 @@ void uwsgi_detach_daemons() {
 			// try to gracefully stop daemon, kill it if it won't die
 			// if mercy is not set than wait up to 3 seconds
 			time_t timeout = uwsgi_now() + (uwsgi.reload_mercy ? uwsgi.reload_mercy : 3);
+			int waitpid_status;
 			while (!kill(ud->pid, 0)) {
 				kill(-ud->pid, SIGTERM);
 				sleep(1);
+				waitpid(-ud->pid, &waitpid_status, WNOHANG);
 				if (uwsgi_now() >= timeout) {
 					uwsgi_log("[uwsgi-daemons] daemon did not died in time, killing (pid: %d): %s\n", (int) ud->pid, ud->command);
 					kill(-ud->pid, SIGKILL);


### PR DESCRIPTION
I've noticed that graceful process termination in daemons I've added for legion daemons patch doesn't work properly for my dump daemons, example:

```
uwsgi --http :8080 --wsgi-file tests/staticfile.py -M --logdate --attach-daemon="memcached -p 11311 -vv"
```

Issue is that memcached is spawned using subshell, uWSGI only knows subshell pid and it sends SIGTERM to subshells process group. Memcached terminates properly, but subshell is left running as defunct process (I'm not sure why), checks in uWSGI continue to find ud->pid (subshell) alive and we need to wait until --reload-mercy timeout is reached.

This patch will fix it rather brutally, for dumb processes we send SIGTERM, sleep for 3 seconds and retry with SIGKILL if needed. With smart daemons it is not needed.
I'm not sure if this is the best we could do, maybe some simple fix would prevent those defunct shells (but would it work in all cases?).
