### PR TITLE
try to escape json

### DIFF
--- a/core/master_utils.c
+++ b/core/master_utils.c
@@ -696,8 +696,17 @@ struct uwsgi_stats *uwsgi_master_generate_stats() {
 		while (ud) {
 			if (uwsgi_stats_object_open(us))
 				goto end;
-			if (uwsgi_stats_keyval_comma(us, "cmd", ud->command))
+
+			// allocate 2x the size of original command
+			// in case we need to escape all chars
+			char *cmd = uwsgi_malloc(strlen(ud->command)*2);
+			escape_json(ud->command, strlen(ud->command), cmd);
+			if (uwsgi_stats_keyval_comma(us, "cmd", cmd)) {
+				free(cmd);
 				goto end;
+			}
+			free(cmd);
+
 			if (uwsgi_stats_keylong_comma(us, "pid", (unsigned long long) (ud->pid < 0) ? 0 : ud->pid))
 				goto end;
 			if (uwsgi_stats_keylong(us, "respawns", (unsigned long long) ud->respawns ? 0 : ud->respawns))
@@ -1106,8 +1115,13 @@ struct uwsgi_stats *uwsgi_master_generate_stats() {
 			if (uwsgi_stats_keyslong_comma(us, "week", (long long) ucron->week))
 				goto end;
 
-			if (uwsgi_stats_keyval_comma(us, "command", ucron->command))
+			char *cmd = uwsgi_malloc(strlen(ucron->command)*2);
+			escape_json(ucron->command, strlen(ucron->command), cmd);
+			if (uwsgi_stats_keyval_comma(us, "command", cmd)) {
+				free(cmd);
 				goto end;
+			}
+			free(cmd);
 
 			if (uwsgi_stats_keylong_comma(us, "unique", (unsigned long long) ucron->unique))
 				goto end;

--- a/core/utils.c
+++ b/core/utils.c
@@ -3065,6 +3065,36 @@ void escape_shell_arg(char *src, size_t len, char *dst) {
 	*ptr++ = 0;
 }
 
+void escape_json(char *src, size_t len, char *dst) {
+
+	size_t i;
+	char *ptr = dst;
+
+	for (i = 0; i < len; i++) {
+		if (src[i] == '\t') {
+			*ptr++ = '\\';
+			*ptr++ = 't';
+		}
+		else if (src[i] == '\n') {
+			*ptr++ = '\\';
+			*ptr++ = 'n';
+		}
+		else if (src[i] == '\r') {
+			*ptr++ = '\\';
+			*ptr++ = 'r';
+		}
+		else if (src[i] == '"') {
+			*ptr++ = '\\';
+			*ptr++ = '"';
+		}
+		else {
+			*ptr++ = src[i];
+		}
+	}
+
+	*ptr++ = 0;
+}
+
 void http_url_decode(char *buf, uint16_t * len, char *dst) {
 
 	uint16_t i;

--- a/uwsgi.h
+++ b/uwsgi.h
@@ -3227,6 +3227,7 @@ struct uwsgi_gateway_socket *uwsgi_new_gateway_socket(char *, char *);
 struct uwsgi_gateway_socket *uwsgi_new_gateway_socket_from_fd(int, char *);
 
 void escape_shell_arg(char *, size_t, char *);
+void escape_json(char *, size_t, char *);
 
 void *uwsgi_malloc_shared(size_t);
 void *uwsgi_calloc_shared(size_t);


### PR DESCRIPTION
cron stats commands shows each task command, but there mighe be a command that contains characters that json requires us to be escaped. It looks that we only need to escape `\` and `"`, jsonlint tells me output is valid after this, but python2.6 still complains.
Can you please take a look at this?
