### PR TITLE
move libs from LIBS/SYSLIBS to the end of link, esp. after libpythonX.Y.a

### DIFF
--- a/plugins/python/uwsgiplugin.py
+++ b/plugins/python/uwsgiplugin.py
@@ -15,9 +15,9 @@ GCC_LIST = ['python_plugin', 'pyutils', 'pyloader', 'wsgi_handlers', 'wsgi_heade
 
 CFLAGS = ['-I' + sysconfig.get_python_inc(), '-I' + sysconfig.get_python_inc(plat_specific=True) ] 
 LDFLAGS = []
+LIBS = []
 
 if not 'UWSGI_PYTHON_NOLIB' in os.environ:
-    LIBS = sysconfig.get_config_var('LIBS').split() + sysconfig.get_config_var('SYSLIBS').split()
     # check if it is a non-shared build (but please, add --enable-shared to your python's ./configure script)
     if not sysconfig.get_config_var('Py_ENABLE_SHARED'):
         libdir = sysconfig.get_config_var('LIBPL')
@@ -50,5 +50,6 @@ if not 'UWSGI_PYTHON_NOLIB' in os.environ:
             os.environ['LD_RUN_PATH'] = "%s/lib" % sysconfig.PREFIX
 
         LIBS.append('-lpython%s' % get_python_version())
-else:
-    LIBS = []
+
+    LIBS.extend(sysconfig.get_config_var('LIBS').split())
+    LIBS.extend(sysconfig.get_config_var('SYSLIBS').split())


### PR DESCRIPTION
we are embedding all c-extensions into python core, many of which link to system libs like libz, libbz2, libxml2, libsqlite3, etc etc... and we make sure these libs are expressed in the `LIBS` var of sysconfig (which, as you probably know, is where python sticks manually added user libs during configure).

the problem is that uwsgi adds libpythonX.Y.a to the very end of the link, after all the `LIBS` and `SYSLIBS`, and is therefore unable to link correctly when using `--as-needed` linker flag.

i think this change is correct, and as reference, when python builds itself, it adds these flags _after_ libpythonX.Y.a
