### PR TITLE
fix curl crashing master on slow dns responses

### DIFF
--- a/plugins/airbrake/airbrake_plugin.c
+++ b/plugins/airbrake/airbrake_plugin.c
@@ -229,6 +229,7 @@ static void uwsgi_airbrake_loop(struct uwsgi_thread *ut) {
 	curl_easy_setopt(curl, CURLOPT_POST, 1L);
 	struct curl_slist *expect = NULL; expect = curl_slist_append(expect, "Expect:");
 	curl_easy_setopt(curl, CURLOPT_HTTPHEADER, expect);
+	curl_easy_setopt(curl, CURLOPT_NOSIGNAL, 1);
 
 	struct uwsgi_airbrake_config *uacc = (struct uwsgi_airbrake_config *) ut->data;
 	char *opts = uwsgi_str(uacc->arg);

--- a/plugins/alarm_curl/alarm_curl_plugin.c
+++ b/plugins/alarm_curl/alarm_curl_plugin.c
@@ -154,6 +154,7 @@ static void uwsgi_alarm_curl_loop(struct uwsgi_thread *ut) {
 	curl_easy_setopt(curl, CURLOPT_POST, 1L);
 	struct curl_slist *expect = NULL; expect = curl_slist_append(expect, "Expect:");
 	curl_easy_setopt(curl, CURLOPT_HTTPHEADER, expect);
+	curl_easy_setopt(curl, CURLOPT_NOSIGNAL, 1);
 
 	struct uwsgi_alarm_curl_config *uacc = (struct uwsgi_alarm_curl_config *) ut->data;
 	char *opts = uwsgi_str(uacc->arg);


### PR DESCRIPTION
I had a crash in libcurl when airbrake plugin tried to send crash report:

```
Jun 14 08:56:39 localhost app: *** longjmp causes uninitialized stack frame ***: [app@5693] uWSGI master terminated
Jun 14 08:56:39 localhost app: ======= Backtrace: =========
Jun 14 08:56:39 localhost app: /lib/libc.so.6(__fortify_fail+0x37)[0x7f97ab351d27]
Jun 14 08:56:39 localhost app: /lib/libc.so.6(+0x101cb9)[0x7f97ab351cb9]
Jun 14 08:56:39 localhost app: /lib/libc.so.6(__longjmp_chk+0x33)[0x7f97ab351c23]
Jun 14 08:56:39 localhost app: /usr/lib/libcurl.so.4(+0x91e5)[0x7f97aa5d81e5]
Jun 14 08:56:39 localhost app: /lib/libpthread.so.0(+0xf8f0)[0x7f97ad45d8f0]
Jun 14 08:56:39 localhost app: /lib/libc.so.6(epoll_wait+0x33)[0x7f97ab339813]
Jun 14 08:56:39 localhost app: [app@5693] uWSGI master(event_queue_wait+0x22)[0x44a5e2]
Jun 14 08:56:39 localhost app: [app@5693] uWSGI master(master_loop+0x9d5)[0x429b75]
Jun 14 08:56:39 localhost app: [app@5693] uWSGI master(uwsgi_start+0x12a8)[0x452d58]
Jun 14 08:56:39 localhost app: /lib/libc.so.6(clone+0x6d)[0x7f97ab33921d]
```

I've found [this solution](http://stackoverflow.com/questions/9191668/error-longjmp-causes-uninitialized-stack-frame#comment11574609_9191668) which is more covered [here](http://curl.haxx.se/mail/lib-2002-12/0103.html)

This patch sets this option for both alarm_curl and airbrake plugins.
