### PR TITLE
Pre-Drop Privileges Hook

### DIFF
--- a/core/uwsgi.c
+++ b/core/uwsgi.c
@@ -2816,6 +2816,13 @@ next2:
 		exit(1);
 	}
 
+	// must be run before dropping privileges
+	for (i = 0; i < 256; i++) {
+		if (uwsgi.p[i]->pre_drop_privs) {
+			uwsgi.p[i]->pre_drop_privs();
+		}
+	}
+
 	if (uwsgi.master_as_root) {
 		uwsgi_as_root();
 	}

--- a/core/uwsgi.c
+++ b/core/uwsgi.c
@@ -2816,14 +2816,14 @@ next2:
 		exit(1);
 	}
 
-	// must be run before dropping privileges
-	for (i = 0; i < 256; i++) {
-		if (uwsgi.p[i]->pre_drop_privs) {
-			uwsgi.p[i]->pre_drop_privs();
-		}
-	}
-
 	if (uwsgi.master_as_root) {
+		// must be run before dropping privileges
+		for (i = 0; i < 256; i++) {
+			if (uwsgi.p[i]->as_root) {
+				uwsgi.p[i]->as_root();
+			}
+		}
+
 		uwsgi_as_root();
 	}
 

--- a/plugins/python/python_plugin.c
+++ b/plugins/python/python_plugin.c
@@ -370,16 +370,16 @@ UWSGI_RELEASE_GIL
 
 }
 
-void uwsgi_python_pre_drop_privs() {
+void uwsgi_python_as_root() {
 
 	if (uwsgi.i_am_a_spooler) {
 		UWSGI_GET_GIL
 	}
 
-	// call the pre_drop_privs hook
+	// call the as_root hook
 	PyObject *uwsgi_dict = get_uwsgi_pydict("uwsgi");
 	if (uwsgi_dict) {
-		PyObject *pfh = PyDict_GetItemString(uwsgi_dict, "pre_drop_privs_hook");
+		PyObject *pfh = PyDict_GetItemString(uwsgi_dict, "as_root_hook");
 		if (pfh) {
 			python_call(pfh, PyTuple_New(0), 0, NULL);
 		}
@@ -1831,7 +1831,7 @@ struct uwsgi_plugin python_plugin = {
 	.modifier1 = 0,
 	.init = uwsgi_python_init,
 	.post_fork = uwsgi_python_post_fork,
-	.pre_drop_privs = uwsgi_python_pre_drop_privs,
+	.as_root = uwsgi_python_as_root,
 	.options = uwsgi_python_options,
 	.request = uwsgi_request_wsgi,
 	.after_request = uwsgi_after_request_wsgi,

--- a/uwsgi.h
+++ b/uwsgi.h
@@ -931,6 +931,7 @@ struct uwsgi_plugin {
 	int (*init) (void);
 	void (*post_init) (void);
 	void (*post_fork) (void);
+        void (*pre_drop_privs) (void);
 	struct uwsgi_option *options;
 	void (*enable_threads) (void);
 	void (*init_thread) (int);

--- a/uwsgi.h
+++ b/uwsgi.h
@@ -931,7 +931,7 @@ struct uwsgi_plugin {
 	int (*init) (void);
 	void (*post_init) (void);
 	void (*post_fork) (void);
-        void (*pre_drop_privs) (void);
+	void (*as_root) (void);
 	struct uwsgi_option *options;
 	void (*enable_threads) (void);
 	void (*init_thread) (int);

--- a/uwsgidecorators.py
+++ b/uwsgidecorators.py
@@ -15,7 +15,7 @@ if uwsgi.masterpid() == 0:
 spooler_functions = {}
 mule_functions = {}
 postfork_chain = []
-
+predrop_chain = []
 
 def get_free_signal():
     for signum in xrange(0, 256):
@@ -36,13 +36,21 @@ def postfork_chain_hook():
     for f in postfork_chain:
         f()
 
+def predrop_chain_hook():
+    for f in predrop_chain:
+        f()
+
 uwsgi.spooler = manage_spool_request
 uwsgi.post_fork_hook = postfork_chain_hook
-
+uwsgi.pre_drop_privs_hook = predrop_chain_hook
 
 class postfork(object):
     def __init__(self, f):
         postfork_chain.append(f)
+
+class predrop(object):
+    def __init__(self, f):
+        predrop_chain.append(f)
 
 
 class spool(object):

--- a/uwsgidecorators.py
+++ b/uwsgidecorators.py
@@ -15,7 +15,7 @@ if uwsgi.masterpid() == 0:
 spooler_functions = {}
 mule_functions = {}
 postfork_chain = []
-predrop_chain = []
+as_root_chain = []
 
 def get_free_signal():
     for signum in xrange(0, 256):
@@ -36,21 +36,21 @@ def postfork_chain_hook():
     for f in postfork_chain:
         f()
 
-def predrop_chain_hook():
-    for f in predrop_chain:
+def as_root_chain_hook():
+    for f in as_root_chain:
         f()
 
 uwsgi.spooler = manage_spool_request
 uwsgi.post_fork_hook = postfork_chain_hook
-uwsgi.pre_drop_privs_hook = predrop_chain_hook
+uwsgi.as_root_hook = as_root_chain_hook
 
 class postfork(object):
     def __init__(self, f):
         postfork_chain.append(f)
 
-class predrop(object):
+class as_root(object):
     def __init__(self, f):
-        predrop_chain.append(f)
+        as_root_chain.append(f)
 
 
 class spool(object):


### PR DESCRIPTION
This hook allows code to execute before the child process drops privileges. If the master happens to be running as root (master-as-root option), then the children have the opportunity to read privileged resources, open files, sockets, shared memory etc. that are otherwise restricted by file ownership before they lose their root privileges.
