### PR TITLE
Fix infinite loop in psgi/coroae

### DIFF
--- a/plugins/coroae/coroae.c
+++ b/plugins/coroae/coroae.c
@@ -161,7 +161,7 @@ request:
 #endif
 
         for(;;) {
-                if (uwsgi.p[wsgi_req->uh->modifier1]->request(wsgi_req)) {
+                if (uwsgi.p[wsgi_req->uh->modifier1]->request(wsgi_req) <= UWSGI_OK) {
                         goto end;
                 }
                 wsgi_req->switches++;


### PR DESCRIPTION
Perl PSGI app infinite loops since f20213ff10d1980a97c5c72c2e56044a05f21f8c

Looking at that change, other loop termination conditions are '<= UWSGI_OK'.
Using gdb to inspect the app while looping shows thats ->request is returning
UWSGI_OK in this case. However, the numeric value of this is zero, so we
never exit the for(;;) loop.

Cargo culting loop escape conditions from core/async.c (or gevent/gevent.c)
fixes the inf loop for psgi/coroae.
