### PR TITLE
Emperor - extending the imperial monitor (dir and glob) .. 

### DIFF
--- a/core/uwsgi.c
+++ b/core/uwsgi.c
@@ -171,7 +171,6 @@ static struct uwsgi_option uwsgi_base_options[] = {
 	{"master", no_argument, 'M', "enable master process", uwsgi_opt_true, &uwsgi.master_process, 0},
 	{"honour-stdin", no_argument, 0, "do not remap stdin to /dev/null", uwsgi_opt_true, &uwsgi.honour_stdin, 0},
 	{"emperor", required_argument, 0, "run the Emperor", uwsgi_opt_add_string_list, &uwsgi.emperor, 0},
-	{"emperor-nofollow", no_argument, 0, "do not follow symlinks when checking for mtime", uwsgi_opt_true, &uwsgi.emperor_nofollow, 0},
 	{"emperor-procname", required_argument, 0, "set the Emperor process name", uwsgi_opt_set_str, &uwsgi.emperor_procname, 0},
 	{"emperor-freq", required_argument, 0, "set the Emperor scan frequency (default 3 seconds)", uwsgi_opt_set_int, &uwsgi.emperor_freq, 0},
 	{"emperor-required-heartbeat", required_argument, 0, "set the Emperor tolerance about heartbeats", uwsgi_opt_set_int, &uwsgi.emperor_heartbeat, 0},

--- a/uwsgi.h
+++ b/uwsgi.h
@@ -1672,7 +1672,6 @@ struct uwsgi_server {
 	char *emperor_procname;
 	int emperor_fd;
 	int emperor_queue;
-	int emperor_nofollow;
 	int emperor_tyrant;
 	int emperor_tyrant_nofollow;
 	int emperor_fd_config;


### PR DESCRIPTION
.. to recognize a 'touch --no-dereference $INI_FILE' (changing the mtime of the symlink) which is supposed to reload only one vassal instead of reloading all of the vassals defined by a symlink pointing to the same physical file.

Two main points:

1) checking for instances that need to be reloaded
I just extended the test that checks whether mtime has changed, making it check also the mtime of the symbolic link (having saved it previously).
Wisely placed the new test as the _right_ OR operand as it should not be used often (until known and appreciated, perhaps :) )

``` C
if (st.st_mtime > ui_current->last_mod || lst.st_mtime > ui_current->last_mod) {
    time_t new_mtime = lst.st_mtime >= st.st_mtime ? lst.st_mtime : st.st_mtime;
    emperor_respawn(ui_current, new_mtime);
}
```

2) checking for instances to be removed
Restored the code before the introduction of the option 'emperor-nofollow'.
The idea is that it's not relevant in the case of  whether the file is a symlink or not:
- if it is a symlink and it has been removed, then both stat and lstat will return an error => stat is OK
- if it is a symlink and it has NOT been removed, then the decision for removing the instance depends on the physical file => stat wins
- if it is not a symlink, stat and lstat will give the same result => stat is OK

``` C
if (stat(filename, &st)) {
    emperor_stop(c_ui);
}
```
