### PR TITLE
Convert tabs to spaces to fix indentation error

### DIFF
--- a/tests/websockets_echo.py
+++ b/tests/websockets_echo.py
@@ -3,11 +3,11 @@ import uwsgi
 import time
 
 def application(env, sr):
-
+    
     ws_scheme = 'ws'
     if 'HTTPS' in env or env['wsgi.url_scheme'] == 'https':
         ws_scheme = 'wss'
-
+    
     if env['PATH_INFO'] == '/':
         sr('200 OK', [('Content-Type','text/html')])
         return """
@@ -20,19 +20,19 @@ def application(env, sr):
               s.send("ciao");
             };
             s.onmessage = function(e) {
-		var bb = document.getElementById('blackboard')
-		var html = bb.innerHTML;
-		bb.innerHTML = html + '<br/>' + e.data;
+        var bb = document.getElementById('blackboard')
+        var html = bb.innerHTML;
+        bb.innerHTML = html + '<br/>' + e.data;
             };
-
-	    s.onerror = function(e) {
-			alert(e);
-		}
-
-	s.onclose = function(e) {
-		alert("connection closed");
-	}
-
+        
+        s.onerror = function(e) {
+            alert(e);
+        }
+    
+    s.onclose = function(e) {
+        alert("connection closed");
+    }
+            
             function invia() {
               var value = document.getElementById('testo').value;
               s.send(value);
@@ -43,13 +43,13 @@ def application(env, sr):
         <h1>WebSocket</h1>
         <input type="text" id="testo"/>
         <input type="button" value="invia" onClick="invia();"/>
-	<div id="blackboard" style="width:640px;height:480px;background-color:black;color:white;border: solid 2px red;overflow:auto">
-	</div>
+    <div id="blackboard" style="width:640px;height:480px;background-color:black;color:white;border: solid 2px red;overflow:auto">
+    </div>
     </body>
     </html>
         """ % (ws_scheme, env['HTTP_HOST'])
     elif env['PATH_INFO'] == '/foobar/':
-	uwsgi.websocket_handshake(env['HTTP_SEC_WEBSOCKET_KEY'], env.get('HTTP_ORIGIN', ''))
+        uwsgi.websocket_handshake(env['HTTP_SEC_WEBSOCKET_KEY'], env.get('HTTP_ORIGIN', ''))
         print "websockets..."
         while True:
             msg = uwsgi.websocket_recv()


### PR DESCRIPTION
The uwsgi.websocket_handshake call on line 52 was not indented properly, causing the Python interpreter to choke. Converting the few tabs sprinkled through the document to spaces fixes that error.
