### PR TITLE
handle core/dot_h.c as other build objects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@
 /uwsgibuild.*
 
 /t/ring/target
+
+core/dot_h.c

--- a/uwsgiconfig.py
+++ b/uwsgiconfig.py
@@ -1355,6 +1355,7 @@ if __name__ == "__main__":
         os.system("rm -f lib/*.o")
         os.system("rm -f plugins/*/*.o")
         os.system("rm -f build/*.o")
+        os.system("rm -f core/dot_h.c")
     elif cmd == '--check':
         os.system("cppcheck --max-configs=1000 --enable=all -q core/ plugins/ proto/ lib/ apache2/")
 


### PR DESCRIPTION
add autogenerated core/dot_h.c to .gitignore, so it won't be added by mistake to git, also remove it during make clean (just in case)
