### PR TITLE
allow setting cheaper rss memory limits

### DIFF
--- a/core/init.c
+++ b/core/init.c
@@ -452,6 +452,19 @@ void sanitize_args() {
 		exit(1);
 	}
 
+	if (uwsgi.cheaper_rss_limit_soft && uwsgi.shared->options[UWSGI_OPTION_MEMORY_DEBUG] != 1 && uwsgi.force_get_memusage != 1) {
+		uwsgi_log("enabling cheaper-rss-limit-soft requires enabling also memory-report\n");
+		exit(1);
+	}
+	if (uwsgi.cheaper_rss_limit_hard && !uwsgi.cheaper_rss_limit_soft) {
+		uwsgi_log("enabling cheaper-rss-limit-hard requires setting also cheaper-rss-limit-soft\n");
+		exit(1);
+	}
+	if ( uwsgi.cheaper_rss_limit_soft && uwsgi.cheaper_rss_limit_hard <= uwsgi.cheaper_rss_limit_soft) {
+		uwsgi_log("cheaper-rss-limit-hard value must be higher than cheaper-rss-limit-soft value\n");
+		exit(1);
+	}
+
 	/* here we try to choose if thunder lock is a good thing */
 #ifdef UNBIT
 	if (uwsgi.numproc > 1 && !uwsgi.map_socket) {

--- a/core/uwsgi.c
+++ b/core/uwsgi.c
@@ -629,6 +629,8 @@ static struct uwsgi_option uwsgi_base_options[] = {
 	{"cheaper-algo-list", no_argument, 0, "list enabled cheapers algorithms", uwsgi_opt_true, &uwsgi.cheaper_algo_list, 0},
 	{"cheaper-algos-list", no_argument, 0, "list enabled cheapers algorithms", uwsgi_opt_true, &uwsgi.cheaper_algo_list, 0},
 	{"cheaper-list", no_argument, 0, "list enabled cheapers algorithms", uwsgi_opt_true, &uwsgi.cheaper_algo_list, 0},
+	{"cheaper-rss-limit-soft", required_argument, 0, "don't spawn new workers if total resident memory usage of all workers is higher than this limit", uwsgi_opt_set_64bit, &uwsgi.cheaper_rss_limit_soft, UWSGI_OPT_MASTER | UWSGI_OPT_CHEAPER},
+	{"cheaper-rss-limit-hard", required_argument, 0, "if total workers resident memory usage is higher try to stop workers", uwsgi_opt_set_64bit, &uwsgi.cheaper_rss_limit_hard, UWSGI_OPT_MASTER | UWSGI_OPT_CHEAPER},
 	{"idle", required_argument, 0, "set idle mode (put uWSGI in cheap mode after inactivity)", uwsgi_opt_set_int, &uwsgi.idle, UWSGI_OPT_MASTER},
 	{"die-on-idle", no_argument, 0, "shutdown uWSGI when idle", uwsgi_opt_true, &uwsgi.die_on_idle, 0},
 	{"mount", required_argument, 0, "load application under mountpoint", uwsgi_opt_add_string_list, &uwsgi.mounts, 0},

--- a/uwsgi.h
+++ b/uwsgi.h
@@ -1725,6 +1725,10 @@ struct uwsgi_server {
 	// enable idle mode
 	int idle;
 
+	// cheaper mode memory usage limits
+	uint64_t cheaper_rss_limit_soft;
+	uint64_t cheaper_rss_limit_hard;
+
 	// destroy the stack when idle
 	int die_on_idle;
 


### PR DESCRIPTION
This patch allows user to set rss memory limits for cheaper:
`cheaper-rss-limit-soft <bytes>` will prevent cheaper from spawning new workers if total rss memory of all workers is >= this value
`cheaper-rss-limit-hard <bytes>` requires soft limit to be enabled[1], if total rss memory of all workers is >= this value cheaper will cheap one worker and ignore needed_workers value returned by cheaper algo 

[1] - it makes no sense to only set hard limit, it would cheap a worker if hard limit is exceeded, but without soft value it could be respawned right away

Obviously to work properly one needs to provide:
`hard limit - soft limit > average worker memory usage`
Setting values to close to each other might result in way too aggressive  cheaping.

Please review
