### PR TITLE
improve php build script

### DIFF
--- a/plugins/php/uwsgiplugin.py
+++ b/plugins/php/uwsgiplugin.py
@@ -5,25 +5,24 @@ NAME='php'
 ld_run_path = None
 PHPPATH = 'php-config'
 
-try:
-    phpdir = os.environ['UWSGICONFIG_PHPDIR']
+phpdir = os.environ.get('UWSGICONFIG_PHPDIR')
+if phpdir:
     ld_run_path = "%s/lib" % phpdir
     PHPPATH = "%s/bin/php-config" % phpdir
-except:
-    pass
 
-try:
-    PHPPATH = os.environ['UWSGICONFIG_PHPPATH']
-except:
-    pass
+PHPPATH = os.environ.get('UWSGICONFIG_PHPPATH', PHPPATH)
 
 CFLAGS = [os.popen(PHPPATH + ' --includes').read().rstrip(), '-Wno-sign-compare']
-
 LDFLAGS = os.popen(PHPPATH + ' --ldflags').read().rstrip().split()
+
 if ld_run_path:
     LDFLAGS.append('-L%s' % ld_run_path)
     os.environ['LD_RUN_PATH'] = ld_run_path
 
 LIBS = [os.popen(PHPPATH + ' --libs').read().rstrip(), '-lphp5']
+
+phplibdir = os.environ.get('UWSGICONFIG_PHPLIBDIR')
+if phplibdir:
+    LIBS.append('-Wl,-rpath=%s' % phplibdir)
 
 GCC_LIST = ['php_plugin']


### PR DESCRIPTION
use UWSGICONFIG_PHPLIBDIR to specify the directory of the php library,
useful for Debian Wheezy which puts php5.so in /usr/lib/php5

small change: don't use exceptions for flow control
