### PR TITLE
Still need to loop again when EAGAIN after a read triggered by an event, Fixes #363

### DIFF
--- a/core/reader.c
+++ b/core/reader.c
@@ -389,6 +389,8 @@ wait:
 				remains -= len;
                         	*rlen += len;
                         	continue;
+			}else if (errno == EAGAIN || errno == EWOULDBLOCK || errno == EINPROGRESS) {
+				goto wait;
 			}
 			*rlen = -1;
 			if (len == 0) {


### PR DESCRIPTION
Fixes #363
After a read event gets triggered and we try to read the body, sometimes the frontend might send it in chunks and there won't be the whole body in there, after a second read(proto_read_body might do several socket reads) EAGAINS the logical step is to wait again for a read event as the frontend will be sending the rest of the body soon.
