### PR TITLE
missing cast to long long in metrics

### DIFF
--- a/core/metrics.c
+++ b/core/metrics.c
@@ -390,7 +390,7 @@ static void *uwsgi_metrics_loop(void *arg) {
 
 			if (uwsgi.metrics_dir && metric->map) {
 				if (value != new_value) {
-					int ret = snprintf(metric->map, uwsgi.page_size, "%lld\n", new_value);
+					int ret = snprintf(metric->map, uwsgi.page_size, "%lld\n", (long long) new_value);
 					if (ret > 0) {
 						memset(metric->map+ret, 0, 4096-ret);
 					}


### PR DESCRIPTION
fixes:

```
core/metrics.c: In function ‘uwsgi_metrics_loop’:
core/metrics.c:393:6: error: format ‘%lld’ expects argument of type ‘long long int’, but argument 4 has type ‘int64_t’ [-Werror=format]
core/metrics.c:393:6: error: format ‘%lld’ expects argument of type ‘long long int’, but argument 4 has type ‘int64_t’ [-Werror=format]
cc1: all warnings being treated as errors
```
