### PR TITLE
daemon throttle code could pass values < 0 to sleep()

### DIFF
--- a/core/daemons.c
+++ b/core/daemons.c
@@ -263,6 +263,8 @@ void uwsgi_spawn_daemon(struct uwsgi_daemon *ud) {
 
 	if (uwsgi.current_time - ud->last_spawn <= 3) {
 		throttle = ud->respawns - (uwsgi.current_time - ud->last_spawn);
+		// if ud->respawns == 0 then we can end up with throttle < 0
+		if (throttle <= 0) throttle = 1;
 	}
 
 	pid_t pid = uwsgi_fork("uWSGI external daemon");
@@ -323,7 +325,7 @@ void uwsgi_spawn_daemon(struct uwsgi_daemon *ud) {
 
 		if (throttle) {
 			uwsgi_log("[uwsgi-daemons] throttling \"%s\" for %d seconds\n", ud->command, throttle);
-			sleep(throttle);
+			sleep((unsigned int) throttle);
 		}
 
 		uwsgi_log("[uwsgi-daemons] %sspawning \"%s\"\n", ud->respawns > 0 ? "re" : "", ud->command);


### PR DESCRIPTION
fixed sleep in daemons throttle code, sleep() only accepts unsigned int but in some cases uWSGI could pass value < 0

I've noticed that if daemon dies right after start I was getting:

```
Mon Oct 14 23:53:40 2013 - [uwsgi-daemons] throttling "my command" for -1 seconds
```

This way sleep() value would overflow and we would wait for very very long time for daemon to be respawned
