### PR TITLE
set python-bin from enviroment variable in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,10 @@
+python_bin=$(if $(PYTHON_BIN), $(PYTHON_BIN), python)
+
 all:
-	python uwsgiconfig.py --build
+	$(python_bin) uwsgiconfig.py --build
 
 clean:
-	python uwsgiconfig.py --clean
+	$(python_bin) uwsgiconfig.py --clean
 
 check:
-	python uwsgiconfig.py --check
+	$(python_bin) uwsgiconfig.py --check


### PR DESCRIPTION
currently the Makefile can only deal with the python-binary
wich is link to python. If you like to compile uwsgi with a
different pyhton-version you can just use

export PYTHON_BIN=/path/to/your/python
