### PR TITLE
Fixing argument for length of the string 'destroy'

### DIFF
--- a/plugins/emperor_zeromq/emperor_zeromq.c
+++ b/plugins/emperor_zeromq/emperor_zeromq.c
@@ -166,7 +166,7 @@ static void uwsgi_imperial_monitor_zeromq_cmd(struct uwsgi_emperor_scanner *ues)
 		}
 	}
 	// destroy an instance
-	else if (!uwsgi_strncmp(ez_cmd, ez_cmd_len, "destroy", 6)) {
+	else if (!uwsgi_strncmp(ez_cmd, ez_cmd_len, "destroy", 7)) {
 		struct uwsgi_instance *ui = emperor_get(name);
 		if (!ui) {
 			uwsgi_log("[emperor-zeromq] unknown instance \"%s\"\n", name);


### PR DESCRIPTION
As reported in issue #431 when using emperor_zeromq, you can't destroy an instance as it doesn't recognize the destroy command. This is due to the uwsgi_strncmp call's final argument being off by one. To validate this bug agsinIf you pass 'destro' as the command it works. This change fixes the length argument.
