### PR TITLE
plugins/jvm: let override jvm arch

### DIFF
--- a/plugins/jvm/uwsgiplugin.py
+++ b/plugins/jvm/uwsgiplugin.py
@@ -7,7 +7,11 @@ JVM_INCPATH = None
 JVM_LIBPATH = None
 
 operating_system = os.uname()[0].lower()
-arch = os.uname()[4].lower()
+
+try:
+    arch = os.environ['JVM_ARCH']
+except:
+    arch = os.uname()[4].lower()
 
 if arch in ('i686', 'x86', 'x86_32'):
     arch = 'i386'


### PR DESCRIPTION
On mixed 64 bit kernel / 32 bit userspace linux systems the jvm
does not get recognized automatically if installed.

Permit to force an arch by exporting JVM_ARCH which is way more
easier than exporting the full path for includes and libraries.
