### PR TITLE
allow disabling retries in carbon

### DIFF
--- a/core/stats.c
+++ b/core/stats.c
@@ -475,7 +475,7 @@ void uwsgi_stats_pusher_loop(struct uwsgi_thread *ut) {
 					uspi->pusher->func(uspi, now, us->base, us->pos);
 				}
 				uspi->last_run = now;
-				if (uspi->needs_retry && uspi->retries < uspi->max_retries) {
+				if (uspi->needs_retry && uspi->max_retries > 0 && uspi->retries < uspi->max_retries) {
 					uwsgi_log("[uwsgi-stats-pusher] %s failed (%d), retry in %ds\n", uspi->pusher->name, uspi->retries, uspi->retry_delay);
 					uspi->next_retry = now + uspi->retry_delay;
 				} else if (uspi->needs_retry && uspi->retries >= uspi->max_retries) {

--- a/plugins/carbon/carbon.c
+++ b/plugins/carbon/carbon.c
@@ -107,7 +107,7 @@ static void carbon_post_init() {
 
 	if (u_carbon.freq < 1) u_carbon.freq = 60;
 	if (u_carbon.timeout < 1) u_carbon.timeout = 3;
-	if (u_carbon.max_retries <= 0) u_carbon.max_retries = 1;
+	if (u_carbon.max_retries < 0) u_carbon.max_retries = 0;
 	if (u_carbon.retry_delay <= 0) u_carbon.retry_delay = 7;
 	if (!u_carbon.id) {
 		u_carbon.id = uwsgi_str(uwsgi.sockets->name);


### PR DESCRIPTION
This patch allows disabling retries in carbon, by setting `--carbon-max-retry 0`
