### PR TITLE
reset worker memory usage when --idle option kills it

### DIFF
--- a/core/master_checks.c
+++ b/core/master_checks.c
@@ -122,6 +122,8 @@ void uwsgi_master_check_idle() {
 			}
 			else {
 				uwsgi.workers[i].pid = 0;
+				uwsgi.workers[i].rss_size = 0;
+				uwsgi.workers[i].vsz_size = 0;
 			}
 		}
 		uwsgi_add_sockets_to_queue(uwsgi.master_queue, -1);


### PR DESCRIPTION
needed for #479
