### PR TITLE
core: setns_fds is an array on stack

### DIFF
--- a/core/master_utils.c
+++ b/core/master_utils.c
@@ -588,7 +588,7 @@ void uwsgi_fixup_fds(int wid, int muleid, struct uwsgi_gateway *ug) {
 		if (uwsgi.master_fifo_fd > -1) close(uwsgi.master_fifo_fd);
 
 #ifdef __linux__
-		if (uwsgi.setns_fds) {
+		if (uwsgi.setns_fds[0]) {
 			for(i=0;i<uwsgi.setns_fds_count;i++) {
 				close(uwsgi.setns_fds[i]);
 			}
@@ -1731,7 +1731,7 @@ void uwsgi_master_manage_setns(int fd) {
         struct cmsghdr *cmsg;
 	DIR *ns = NULL;
 
-	if (uwsgi.setns_fds && uwsgi.setns_fds_count) {
+	if (uwsgi.setns_fds[0] && uwsgi.setns_fds_count) {
 		fds = uwsgi.setns_fds;
 		num_fds = uwsgi.setns_fds_count;
 		goto send;


### PR DESCRIPTION
So it makes not sense to check if it's set to something. Instead
check if it's first member is not 0. We should'nt have fd 0 on
this array but maybe we should just check setns_fds_count.

Reported by Coverity as CID #1142188, #1142187.
