### PR TITLE
core/socket: close TCP server fd when spawning

### DIFF
--- a/core/master_utils.c
+++ b/core/master_utils.c
@@ -407,6 +407,7 @@ void uwsgi_reload(char **argv) {
 	/* check fd table (a module can obviosly open some fd on initialization...) */
 	uwsgi_log("closing all non-uwsgi socket fds > 2 (max_fd = %d)...\n", (int) uwsgi.max_fd);
 	for (i = 3; i < (int) uwsgi.max_fd; i++) {
+		fcntl(i, F_SETFD, 0);
 
 		if (uwsgi_fd_is_safe(i)) continue;
 

--- a/core/socket.c
+++ b/core/socket.c
@@ -84,6 +84,9 @@ static int create_server_socket(int domain, int type) {
 		return -1;
 	}
 
+	if (uwsgi.close_on_exec2 && fcntl(serverfd, F_SETFD, FD_CLOEXEC) < 0)
+		uwsgi_error("fcntl()");
+
 	if (domain != AF_UNIX) {
 		int reuse = 1;
 		if (setsockopt(serverfd, SOL_SOCKET, SO_REUSEADDR, (const void *) &reuse, sizeof(int)) < 0) {

--- a/core/uwsgi.c
+++ b/core/uwsgi.c
@@ -871,7 +871,8 @@ static struct uwsgi_option uwsgi_base_options[] = {
 	{"disable-sendfile", no_argument, 0, "disable sendfile() and rely on boring read()/write()", uwsgi_opt_true, &uwsgi.disable_sendfile, 0},
 
 	{"check-cache", optional_argument, 0, "check for response data in the specified cache (empty for default cache)", uwsgi_opt_set_str, &uwsgi.use_check_cache, 0},
-	{"close-on-exec", no_argument, 0, "set close-on-exec on sockets (could be required for spawning processes in requests)", uwsgi_opt_true, &uwsgi.close_on_exec, 0},
+	{"close-on-exec", no_argument, 0, "set close-on-exec on connection sockets (could be required for spawning processes in requests)", uwsgi_opt_true, &uwsgi.close_on_exec, 0},
+	{"close-on-exec2", no_argument, 0, "set close-on-exec on server sockets (could be required for spawning processes in requests)", uwsgi_opt_true, &uwsgi.close_on_exec2, 0},
 	{"mode", required_argument, 0, "set uWSGI custom mode", uwsgi_opt_set_str, &uwsgi.mode, 0},
 	{"env", required_argument, 0, "set environment variable", uwsgi_opt_set_env, NULL, 0},
 	{"envdir", required_argument, 0, "load a daemontools compatible envdir", uwsgi_opt_add_string_list, &uwsgi.envdirs, 0},

--- a/uwsgi.h
+++ b/uwsgi.h
@@ -2516,6 +2516,8 @@ struct uwsgi_server {
 	void (*gbcw_hook) (void);
 
 	int close_on_exec;
+	int close_on_exec2;
+
 	int tcp_nodelay;
 
 	char *loop;


### PR DESCRIPTION
If server fd is not closed, it is not possible to restart uwsgi if the spawned process is still running as it keeps the address/port bound.
