### PR TITLE
fix building with musl libc

### DIFF
--- a/core/lock.c
+++ b/core/lock.c
@@ -99,7 +99,7 @@ retry:
 			uwsgi_log("unable to set PTHREAD_PRIO_INHERIT\n");
 			exit(1);
 		}
-		if (pthread_mutexattr_setrobust_np(&attr, PTHREAD_MUTEX_ROBUST)) {
+		if (pthread_mutexattr_setrobust(&attr, PTHREAD_MUTEX_ROBUST)) {
 			uwsgi_log("unable to make the mutex 'robust'\n");
 			exit(1);
 		}
@@ -161,7 +161,7 @@ void uwsgi_lock_fast(struct uwsgi_lock_item *uli) {
 #ifdef EOWNERDEAD
 	if (pthread_mutex_lock((pthread_mutex_t *) uli->lock_ptr) == EOWNERDEAD) {
 		uwsgi_log("[deadlock-detector] a process holding a robust mutex died. recovering...\n");
-		pthread_mutex_consistent_np((pthread_mutex_t *) uli->lock_ptr);
+		pthread_mutex_consistent((pthread_mutex_t *) uli->lock_ptr);
 	}
 #else
 	pthread_mutex_lock((pthread_mutex_t *) uli->lock_ptr);

--- a/core/uwsgi.c
+++ b/core/uwsgi.c
@@ -1832,7 +1832,7 @@ void uwsgi_plugins_atexit(void) {
 
 void uwsgi_backtrace(int depth) {
 
-#if (defined(__linux__) && !defined(__UCLIBC__))|| (defined(__APPLE__) && !defined(NO_EXECINFO)) || defined(UWSGI_HAS_EXECINFO) 
+#if (defined(__GLIBC__) && !defined(__UCLIBC__))|| (defined(__APPLE__) && !defined(NO_EXECINFO)) || defined(UWSGI_HAS_EXECINFO)
 
 #include <execinfo.h>
 

--- a/uwsgi.h
+++ b/uwsgi.h
@@ -153,22 +153,7 @@ extern "C" {
 #endif
 #endif
 
-#ifndef _GNU_SOURCE
-#define _GNU_SOURCE
-#endif
-#include <stdio.h>
-#ifdef __UCLIBC__
-#include <sched.h>
-#endif
-#undef _GNU_SOURCE
-
-#include <stdlib.h>
-#include <stddef.h>
-#include <signal.h>
-#include <math.h>
-
-#include <sys/types.h>
-#ifdef __linux__
+#if defined(__linux__) || defined(__GNUC__)
 #ifndef _GNU_SOURCE
 #define _GNU_SOURCE
 #endif
@@ -176,6 +161,14 @@ extern "C" {
 #define __USE_GNU
 #endif
 #endif
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <stddef.h>
+#include <signal.h>
+#include <math.h>
+
+#include <sys/types.h>
 #include <sys/socket.h>
 #include <net/if.h>
 #ifdef __linux__
@@ -183,7 +176,6 @@ extern "C" {
 #define MSG_FASTOPEN   0x20000000
 #endif
 #endif
-#undef _GNU_SOURCE
 #include <netinet/in.h>
 
 #include <termios.h>
@@ -346,6 +338,9 @@ extern int pivot_root(const char *new_root, const char *put_old);
 #undef _XOPEN_SOURCE
 #ifdef __sun__
 #undef __EXTENSIONS__
+#endif
+#ifdef _GNU_SOURCE
+#undef _GNU_SOURCE
 #endif
 
 #define UWSGI_CACHE_FLAG_UNGETTABLE	0x01

--- a/uwsgi.h
+++ b/uwsgi.h
@@ -269,6 +269,9 @@ extern int pivot_root(const char *new_root, const char *put_old);
 #include <stdint.h>
 
 #include <sys/wait.h>
+#ifndef WAIT_ANY
+#define WAIT_ANY (-1)
+#endif
 
 #ifdef __APPLE__
 #ifndef MAC_OS_X_VERSION_MIN_REQUIRED


### PR DESCRIPTION
A set of patches needed to make uwsgi build on musl libc, which is fairly strict.

It is compile tested with musl libc and uClibc.