### PR TITLE
Accept also ':' as key/value delimiter

### DIFF
--- a/core/ini.c
+++ b/core/ini.c
@@ -45,7 +45,7 @@ char *ini_get_key(char *key) {
 
 	for (i = 0; i < (int) strlen(key); i++) {
 		ptr++;
-		if (key[i] == '=') {
+		if (key[i] == '=' || key[i] == ':') {
 			key[i] = 0;
 			return ptr;
 		}


### PR DESCRIPTION
The `:` is used frequently in Python .ini files parsed by ConfigParser.

> "The configuration file consists of sections, led by a [section] header and followed by name: value entries, with continuations in the style of RFC 822 (see section 3.1.1, “LONG HEADER FIELDS”); name=value is also accepted."

See [ConfigParser](http://docs.python.org/2/library/configparser.html) for more information.
