### PR TITLE
perl: Don't run BEGIN blocks twice in the provided *.psgi

### DIFF
--- a/t/perl/test.psgi
+++ b/t/perl/test.psgi
@@ -1,5 +1,9 @@
 use strict;
 use warnings;
+BEGIN {
+    die "PANIC: We should only load this once" if ++$main::count_BEGIN > 1;
+}
+die "PANIC: We should only run this once" if ++$main::count_runs > 1;
 
 uwsgi::register_rpc('hello', sub {
 	my ($one, $two, $three) = @_;


### PR DESCRIPTION
The psgi loaded was calling perl_parse() with the script ostensibly to
set up xsinit.

However it would also call perl_parse() with the path to our *.psgi
file, whith the result that any BEGIN block in the *.psgi file would be
run twice, but anything outside BEGIN blocks would only run once.

This means that any code within explicit BEGIN blocks will run twice,
and any "use" statement in the *.psgi file will run its import() routine
twice, but due to the module being in %INC already we won't actually
compile things twice.

The previous behavior dates all the way back to the initial introduction
of the PSGI plugin in 299fd9c.

Then when support for local::lib was added in 7cbe751 we initially did a
perl_eval_pv() of a "use" statement like I'm doing here again now, but
later on in 1561dd3 changed it to call perl_parse with the commit
message "another PSGI loading fix".

Since there's no info on what that fixed or what was broken before I
have no idea if I'm introducing a regression here, but I don't see why
this way of loding local::lib shouldn't work, and it correctly munges
@INC for me when I try it.

We may still have this bug in the remaining perl_parse() calls that
remain for supporting "preinit" and "mule".

I haven't tested those modes (I don't use them), but when we load the
Perl apps we should only perl_parse() once with -e1, and then
perl_eval_pv() to actually load the application. We should not call
perl_parse() on code that we're just about to perl_eval_pv(), or we'll
run into this bug.

To test this just run:

```
./uwsgi --http 127.0.0.1:8080 --psgi ./t/perl/test.psgi
```

It'll no longer PANIC on the BEGIN block being run twice now, at least
in that simplistic non-"preinit" non-"mule" mode.
