### PR TITLE
Set ECDHE curve independently from DHE parameters

### DIFF
--- a/core/ssl.c
+++ b/core/ssl.c
@@ -245,17 +245,19 @@ SSL_CTX *uwsgi_ssl_new_server_context(char *name, char *crt, char *key, char *ci
                 if (dh) {
                         SSL_CTX_set_tmp_dh(ctx, dh);
                         DH_free(dh);
+                }
+        }
 #if OPENSSL_VERSION_NUMBER >= 0x0090800fL
 #ifndef OPENSSL_NO_ECDH
 #ifdef NID_X9_62_prime256v1
-                        EC_KEY *ecdh = EC_KEY_new_by_curve_name(NID_X9_62_prime256v1);
-                        SSL_CTX_set_tmp_ecdh(ctx, ecdh);
-                        EC_KEY_free(ecdh);
-#endif
-#endif
-#endif
-                }
+        EC_KEY *ecdh = EC_KEY_new_by_curve_name(NID_X9_62_prime256v1);
+        if (ecdh) {
+                SSL_CTX_set_tmp_ecdh(ctx, ecdh);
+                EC_KEY_free(ecdh);
         }
+#endif
+#endif
+#endif
 
 	if (crt_need_free) free(crt);
 


### PR DESCRIPTION
Hi,

ECDHE doesn’t require DHE parameters so the logic in core/ssl.c isn’t correct.

You can test it easily: run a uwsgi server with a certificate without DH params using current master and with this patch applied (use `'AESGCM'` for ciphers).  Connect using `openssl s_client -connect host:port` to each.   In the current behavior you’ll get `AES256-GCM-SHA384`, with the patch `ECDHE-RSA-AES256-GCM-SHA384`.

I wasn’t able to locate any tests for this code, so I haven’t added any but I took the liberty to check the return value. :)

BTW, if the DHE-behavior is documented somewhere, I was too dumb to find it.
