### PR TITLE
perl: fix a regression with caller() not indicating the starting *.psgi ...

### DIFF
--- a/plugins/psgi/psgi_loader.c
+++ b/plugins/psgi/psgi_loader.c
@@ -370,12 +370,16 @@ int init_psgi_app(struct wsgi_request *wsgi_req, char *app, uint16_t app_len, Pe
 		// uperl.embedding as an argument so we won't execute
 		// BEGIN blocks in app_name twice.
 		{
-			char *perl_init_arg[] = { "", "-e", "0" };
+			char *perl_e_arg = uwsgi_concat2("#line 0 ", app_name);
+			char *perl_init_arg[] = { "", "-e", perl_e_arg };
 			if (perl_parse(interpreters[i], xs_init, 3, perl_init_arg, NULL)) {
 				// what to do here ? i hope no-one will use threads with dynamic apps... but clear the whole stuff...
 				free(callables);
+                                free(perl_e_arg);
 				uwsgi_perl_free_stashes();
 				goto clear;
+			} else {
+				free(perl_e_arg);
 			}
 		}
 

--- a/t/perl/test.psgi
+++ b/t/perl/test.psgi
@@ -59,6 +59,10 @@ my $app = sub {
 	uwsgi::signal(17);
 	uwsgi::signal(30);
 
+	my ($package, $filename, $line) = caller;
+	die "Expecting reasonable caller() return values, not [$package, $filename, $line]"
+	    unless $package eq 'main' and $filename =~ /\btest\.psgi$/s and $line == 0;
+
 	if ($env->{'psgix.cleanup'}) {
 		print "cleanup supported\n";
 		push @{$env->{'psgix.cleanup.handlers'}}, $one;


### PR DESCRIPTION
...program

In 2.0.1-41-g3480c30 I introduced a regression with how the top-level
stackframe would appear within Perl programs. Before we'd show the
filename of the *.psgi file, but after we just showed "-e".

We can retain the bugfix I added in 2.0.1-41-g3480c30 while having a
sensible stacktrace by overriding the file via the #line directive.
