### PR TITLE
.gitignore: add /core/config_py.c to ignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 
 /uwsgi
 /uwsgibuild.*
+/core/config_py.c
 
 /t/ring/target
 


### PR DESCRIPTION
This file added in e4903ee is generated by the build system and should
be in the ignore file.
