### PR TITLE
allow disabling cache warnings

### DIFF
--- a/uwsgi.h
+++ b/uwsgi.h
@@ -819,6 +819,8 @@ struct uwsgi_cache {
 	struct uwsgi_lock_item *lock;
 
 	struct uwsgi_cache *next;
+
+	int ignore_full;
 };
 
 struct uwsgi_option {


### PR DESCRIPTION
If cache is used for ssl sessions uWSGI can fill disk with logs about full cache
