### PR TITLE
Fix uwsgi_route_var_mime

### DIFF
--- a/core/routing.c
+++ b/core/routing.c
@@ -1704,7 +1704,7 @@ static char *uwsgi_route_var_mime(struct wsgi_request *wsgi_req, char *key, uint
         char *var_value = uwsgi_get_var(wsgi_req, key, keylen, &var_vallen);
         if (var_value) {
 		size_t mime_type_len = 0;
-		char *ret = uwsgi_get_mime_type(key, keylen, &mime_type_len);
+		ret = uwsgi_get_mime_type(var_value, var_vallen, &mime_type_len);
 		if (ret) *vallen = mime_type_len;
         }
         return ret;


### PR DESCRIPTION
Fix some bugs introduced in c57baae4775f4e665b7e158582234ac558a2bf7b preventing the 'mime' routing function from working with request variables, and actually return the found mimetype

The uwsgi_route_var_mime function had two errors preventing it from (afaics ever) working:
1. Redefine the 'ret' variable inside an if block. This meant that if the uwsgi_get_mime_type function ever actually found a matching mimetype, the length of the matching value would be corectly set, but the function returns NULL (the value of the function-level ret variable)
2. The function was looking up the request variable correctly, BUT then passing in the raw config string to uwsgi_get_mime_type NOT the resolved varible value, making the lookup just a waste of cycles.
