### PR TITLE
uwsgi_setup_log_master must always be called after logto()

### DIFF
--- a/core/uwsgi.c
+++ b/core/uwsgi.c
@@ -2198,7 +2198,7 @@ void uwsgi_setup(int argc, char *argv[], char *envp[]) {
 		uwsgi_opt_flock(NULL, uwsgi.flock_wait2, NULL);
 
 	// setup master logging
-	if (uwsgi.log_master && !uwsgi.daemonize2)
+	if (uwsgi.log_master && !uwsgi.daemonize2 && !uwsgi.logto2)
 		uwsgi_setup_log_master();
 
 	// setup offload engines
@@ -2481,6 +2481,7 @@ int uwsgi_start(void *v_argv) {
 	if (uwsgi.logto2) {
 		if (!uwsgi.is_a_reload || uwsgi.log_reopen) {
 			logto(uwsgi.logto2);
+			uwsgi_setup_log_master();
 		}
 	}
 


### PR DESCRIPTION
fixes --logto2 (and --logto rotation still works)
