### PR TITLE
always generate key if (EC)DH is used

### DIFF
--- a/core/ssl.c
+++ b/core/ssl.c
@@ -243,6 +243,7 @@ SSL_CTX *uwsgi_ssl_new_server_context(char *name, char *crt, char *key, char *ci
                 DH *dh = PEM_read_bio_DHparams(bio, NULL, NULL, NULL);
                 BIO_free(bio);
                 if (dh) {
+                        SSL_CTX_set_options(ctx, SSL_OP_SINGLE_DH_USE);
                         SSL_CTX_set_tmp_dh(ctx, dh);
                         DH_free(dh);
                 }
@@ -252,6 +253,7 @@ SSL_CTX *uwsgi_ssl_new_server_context(char *name, char *crt, char *key, char *ci
 #ifdef NID_X9_62_prime256v1
         EC_KEY *ecdh = EC_KEY_new_by_curve_name(NID_X9_62_prime256v1);
         if (ecdh) {
+                SSL_CTX_set_options(ctx, SSL_OP_SINGLE_ECDH_USE);
                 SSL_CTX_set_tmp_ecdh(ctx, ecdh);
                 EC_KEY_free(ecdh);
         }


### PR DESCRIPTION
I've found that this option is recommended if (EC)DH is used.

Docs:

```
Always create a new key when using temporary/ephemeral DH parameters (see SSL_CTX_set_tmp_dh_callback(3)). This option must be used to prevent small subgroup attacks, when the DH parameters were not generated using ``strong'' primes (e.g. when using DSA-parameters, see dhparam(1)). If ``strong'' primes were used, it is not strictly necessary to generate a new DH key during each handshake but it is also recommended. SSL_OP_SINGLE_DH_USE should therefore be enabled whenever temporary/ephemeral DH parameters are used.
```
