### PR TITLE
added mkdir to spooler, and general config

### DIFF
--- a/core/spooler.c
+++ b/core/spooler.c
@@ -21,9 +21,14 @@ void uwsgi_opt_add_spooler(char *opt, char *directory, void *mode) {
 	int i;
 	struct uwsgi_spooler *us;
 
+
 	if (access(directory, R_OK | W_OK | X_OK)) {
-		uwsgi_error("[spooler directory] access()");
-		exit(1);
+		mkdir(directory,0700);
+		
+		if (access(directory, R_OK | W_OK | X_OK)) {
+			uwsgi_error("[spooler directory] access()");
+			exit(1);
+			}
 	}
 
 	if (uwsgi.spooler_numproc > 0) {

--- a/core/uwsgi.c
+++ b/core/uwsgi.c
@@ -720,6 +720,7 @@ static struct uwsgi_option uwsgi_base_options[] = {
 
 	{"force-cwd", required_argument, 0, "force the initial working directory to the specified value", uwsgi_opt_set_str, &uwsgi.force_cwd, 0},
 	{"binsh", required_argument, 0, "override /bin/sh (used by exec hooks, it always fallback to /bin/sh)", uwsgi_opt_add_string_list, &uwsgi.binsh, 0},
+	{"mkdir", required_argument, 0, "chdir to specified directory before apps loading", uwsgi_opt_set_str, &uwsgi.mkdir, 0},
 	{"chdir", required_argument, 0, "chdir to specified directory before apps loading", uwsgi_opt_set_str, &uwsgi.chdir, 0},
 	{"chdir2", required_argument, 0, "chdir to specified directory after apps loading", uwsgi_opt_set_str, &uwsgi.chdir2, 0},
 	{"lazy", no_argument, 0, "set lazy mode (load apps in workers instead of master)", uwsgi_opt_true, &uwsgi.lazy, 0},
@@ -2482,6 +2483,13 @@ int uwsgi_start(void *v_argv) {
 		if (!uwsgi.is_a_reload || uwsgi.log_reopen) {
 			logto(uwsgi.logto2);
 			uwsgi_setup_log_master();
+		}
+	}
+
+	if (uwsgi.mkdir) {
+		if (mkdir(uwsgi.mkdir,0777)) {
+			uwsgi_error("mkdir()");
+			exit(1);
 		}
 	}
 

--- a/uwsgi.h
+++ b/uwsgi.h
@@ -2476,6 +2476,7 @@ struct uwsgi_server {
 	int skip_atexit;
 
 	char *force_cwd;
+	char *mkdir;
 	char *chdir;
 	char *chdir2;
 	struct uwsgi_string_list *binsh;


### PR DESCRIPTION
when dealing with spoolers on cloud based ephemeral disks, or temporal disks like /dev/shm it's useful to to be able to ask uwsgi to create the directory before it adds the spooler. 

note: I use /dev/shm because due to PCI rules I can't write some of the spooler data to disk because it contains CVV/CID credit card data. 
