### PR TITLE
Support for graceful reload of mule processes.

### DIFF
--- a/core/init.c
+++ b/core/init.c
@@ -113,6 +113,7 @@ void uwsgi_init_default() {
 	uwsgi.log_master_bufsize = 8192;
 
 	uwsgi.worker_reload_mercy = 60;
+	uwsgi.mule_reload_mercy = 60;
 
 	uwsgi.max_vars = MAX_VARS;
 	uwsgi.vec_size = 4 + 1 + (4 * MAX_VARS);

--- a/core/master.c
+++ b/core/master.c
@@ -135,6 +135,15 @@ void uwsgi_master_check_mercy() {
 			}
 		}
 	}
+
+	for (i = 0; i < uwsgi.mules_cnt; i++) {
+		if (uwsgi.mules[i].pid > 0 && uwsgi.mules[i].cursed_at) {
+			if (uwsgi_now() > uwsgi.mules[i].no_mercy_at) {
+				uwsgi_log_verbose("mule %d (pid: %d) is taking too much time to die...NO MERCY !!!\n", i + 1, uwsgi.mules[i].pid);
+				uwsgi_curse_mule(i, SIGKILL);
+			}
+		}
+	}
 }
 
 
@@ -907,6 +916,7 @@ int master_loop(char **argv, char **environ) {
 			for (i = 0; i < uwsgi.mules_cnt; i++) {
 				if (uwsgi.mules[i].pid == diedpid) {
 					uwsgi_log("mule %d (pid: %d) annihilated\n", i + 1, (int) diedpid);
+					uwsgi.mules[i].pid = 0;
 					goto next;
 				}
 			}

--- a/core/master_checks.c
+++ b/core/master_checks.c
@@ -25,6 +25,11 @@ int uwsgi_master_check_reload(char **argv) {
                                 return 0;
                         }
                 }
+		for(i=0;i<uwsgi.mules_cnt;i++) {
+			if (uwsgi.mules[i].pid > 0) {
+				return 0;
+			}
+		}
 		uwsgi_reload(argv);
 		// never here (unless in shared library mode)
 		return -1;

--- a/core/master_utils.c
+++ b/core/master_utils.c
@@ -24,6 +24,15 @@ void uwsgi_curse(int wid, int sig) {
 	}
 }
 
+void uwsgi_curse_mule(int mid, int sig) {
+	uwsgi.mules[mid].cursed_at = uwsgi_now();
+	uwsgi.mules[mid].no_mercy_at = uwsgi.mules[mid].cursed_at + uwsgi.mule_reload_mercy;
+
+	if (sig) {
+		(void) kill(uwsgi.mules[mid].pid, sig);
+	}
+}
+
 static void uwsgi_signal_spoolers(int signum) {
 
         struct uwsgi_spooler *uspool = uwsgi.spoolers;
@@ -50,15 +59,6 @@ void uwsgi_destroy_processes() {
                         kill(ushared->gateways[i].pid, SIGKILL);
 			waitpid(ushared->gateways[i].pid, &waitpid_status, 0);
 			uwsgi_log("gateway \"%s %d\" has been buried (pid: %d)\n", ushared->gateways[i].name, ushared->gateways[i].num, (int) ushared->gateways[i].pid);
-		}
-        }
-
-	// TODO mules can be programmed to be gracefully reloaded
-        for (i = 0; i < uwsgi.mules_cnt; i++) {
-                if (uwsgi.mules[i].pid > 0) {
-                        kill(uwsgi.mules[i].pid, SIGKILL);
-			waitpid(uwsgi.mules[i].pid, &waitpid_status, 0);
-			uwsgi_log("mule %d has been buried (pid: %d)\n", i, (int) uwsgi.mules[i].pid);
 		}
         }
 

--- a/core/mule.c
+++ b/core/mule.c
@@ -43,7 +43,7 @@ void uwsgi_mule(int id) {
 #endif
 
 		signal(SIGALRM, SIG_IGN);
-                signal(SIGHUP, SIG_IGN);
+                signal(SIGHUP, end_me);
                 signal(SIGINT, end_me);
                 signal(SIGTERM, end_me);
                 signal(SIGUSR1, SIG_IGN);

--- a/plugins/python/python_plugin.c
+++ b/plugins/python/python_plugin.c
@@ -168,6 +168,8 @@ struct uwsgi_option uwsgi_python_options[] = {
 	{"py-sharedarea", required_argument, 0, "create a sharedarea from a python bytearray object of the specified size", uwsgi_opt_add_string_list, &up.sharedarea, 0},
 #endif
 
+	{"py-call-osafterfork", no_argument, 0, "enable child processes running cpython to trap OS signals", uwsgi_opt_true, &up.call_osafterfork, 0},
+
 	{0, 0, 0, 0, 0, 0, 0},
 };
 
@@ -376,6 +378,11 @@ void uwsgi_python_post_fork() {
 	if (uwsgi.i_am_a_spooler) {
 		UWSGI_GET_GIL
 	}	
+
+	// reset python signal flags so child processes can trap signals
+	if (up.call_osafterfork) {
+		PyOS_AfterFork();
+	}
 
 	uwsgi_python_reset_random_seed();
 

--- a/plugins/python/uwsgi_python.h
+++ b/plugins/python/uwsgi_python.h
@@ -197,6 +197,8 @@ struct uwsgi_python {
 	PyObject *raw_callable;
 
 	struct uwsgi_string_list *sharedarea;
+
+	int call_osafterfork;
 };
 
 

--- a/uwsgi.h
+++ b/uwsgi.h
@@ -2706,6 +2706,8 @@ struct uwsgi_server {
 	char *notify_socket;
 	int notify_socket_fd;
 	char *subscription_notify_socket;
+
+	int mule_reload_mercy;
 };
 
 struct uwsgi_rpc {
@@ -2939,6 +2941,9 @@ struct uwsgi_mule {
 	time_t user_harakiri;
 
 	char name[0xff];
+
+	time_t cursed_at;
+	time_t no_mercy_at;
 };
 
 struct uwsgi_mule_farm {
@@ -3006,6 +3011,7 @@ void spooler(struct uwsgi_spooler *);
 pid_t spooler_start(struct uwsgi_spooler *);
 
 void uwsgi_curse(int, int);
+void uwsgi_curse_mule(int, int);
 void uwsgi_destroy_processes(void);
 
 void set_harakiri(int);


### PR DESCRIPTION
- On reload master now signals mule with HUP instead of KILL.
- Mule can override default handler (added PyOS_AfterFork to enable
  this for python plugin).
- Copied cursed_at/no_mercy_at pattern used with worker processes.
- Added mule_reload_mercy option.
