### PR TITLE
Expose listen_queue metrics to carbon plugin

### DIFF
--- a/plugins/carbon/carbon.c
+++ b/plugins/carbon/carbon.c
@@ -385,6 +385,12 @@ metrics_loop:
 			}
 		}
 
+		wok = carbon_write(fd, "%s%s.%s.listen_queue %llu %llu\n", u_carbon.root_node, u_carbon.hostname, u_carbon.id, (unsigned long long) uwsgi.shared->backlog, (unsigned long long) now);
+		if (!wok) goto clear;
+
+		wok = carbon_write(fd, "%s%s.%s.listen_queue_errors %llu %llu\n", u_carbon.root_node, u_carbon.hostname, u_carbon.id, (unsigned long long) uwsgi.shared->backlog_errors, (unsigned long long) now);
+		if (!wok) goto clear;
+
 		usl->healthy = 1;
 		usl->errors = 0;
 


### PR DESCRIPTION
Very useful for spotting capacity or bottleneck problems on Carbon/Graphite. We've been using this patch in production for over a year without issue.
