### PR TITLE
add flag SA_RESTART to sigaction in func uwsgi_unix_signal

### DIFF
--- a/core/utils.c
+++ b/core/utils.c
@@ -1915,6 +1915,7 @@ void uwsgi_unix_signal(int signum, void (*func) (int)) {
 	memset(&sa, 0, sizeof(struct sigaction));
 
 	sa.sa_handler = func;
+	sa.sa_flags = SA_RESTART;
 
 	sigemptyset(&sa.sa_mask);
 


### PR DESCRIPTION
In order to avoid the EINTR error
