### PR TITLE
don't recalculate avg_rt for static files

### DIFF
--- a/core/static.c
+++ b/core/static.c
@@ -459,6 +459,8 @@ int uwsgi_real_file_serve(struct wsgi_request *wsgi_req, char *real_filename, si
 	uwsgi_log("[uwsgi-fileserve] file %s found\n", real_filename);
 #endif
 
+	// static file - don't update avg_rt after request
+	wsgi_req->do_not_account_avg_rt = 1;
 
 	size_t fsize = st->st_size;
         if (wsgi_req->range_to) {

--- a/core/utils.c
+++ b/core/utils.c
@@ -1051,10 +1051,11 @@ void uwsgi_close_request(struct wsgi_request *wsgi_req) {
 	uint64_t end_of_request = uwsgi_micros();
 	wsgi_req->end_of_request = end_of_request;
 
-	tmp_rt = wsgi_req->end_of_request - wsgi_req->start_of_request;
-
-	uwsgi.workers[uwsgi.mywid].running_time += tmp_rt;
-	uwsgi.workers[uwsgi.mywid].avg_response_time = (uwsgi.workers[uwsgi.mywid].avg_response_time + tmp_rt) / 2;
+	if (!wsgi_req->do_not_account_avg_rt) {
+		tmp_rt = wsgi_req->end_of_request - wsgi_req->start_of_request;
+		uwsgi.workers[uwsgi.mywid].running_time += tmp_rt;
+		uwsgi.workers[uwsgi.mywid].avg_response_time = (uwsgi.workers[uwsgi.mywid].avg_response_time + tmp_rt) / 2;
+	}
 
 	// get memory usage
 	if (uwsgi.logging_options.memory_report == 1 || uwsgi.force_get_memusage) {

--- a/plugins/router_static/router_static.c
+++ b/plugins/router_static/router_static.c
@@ -64,6 +64,9 @@ int uwsgi_routing_func_file(struct wsgi_request *wsgi_req, struct uwsgi_route *u
 	struct uwsgi_buffer *ub_s = uwsgi_routing_translate(wsgi_req, ur, *subject, *subject_len, urfc->status, urfc->status_len);
         if (!ub_s) goto end2;
 
+	// static file - don't update avg_rt after request
+	wsgi_req->do_not_account_avg_rt = 1;
+
 	if (urfc->no_headers) goto send;
 
 	if (uwsgi_response_prepare_headers(wsgi_req, ub_s->buf, ub_s->pos)) {
@@ -132,6 +135,9 @@ int uwsgi_routing_func_sendfile(struct wsgi_request *wsgi_req, struct uwsgi_rout
         struct uwsgi_buffer *ub_s = uwsgi_routing_translate(wsgi_req, ur, *subject, *subject_len, urfc->status, urfc->status_len);
         if (!ub_s) goto end2;
 
+        // static file - don't update avg_rt after request
+        wsgi_req->do_not_account_avg_rt = 1;
+
 	if (urfc->no_headers) goto send;
 
         if (uwsgi_response_prepare_headers(wsgi_req, ub_s->buf, ub_s->pos)) {
@@ -198,6 +204,9 @@ int uwsgi_routing_func_fastfile(struct wsgi_request *wsgi_req, struct uwsgi_rout
 
         struct uwsgi_buffer *ub_s = uwsgi_routing_translate(wsgi_req, ur, *subject, *subject_len, urfc->status, urfc->status_len);
         if (!ub_s) goto end2;
+
+        // static file - don't update avg_rt after request
+        wsgi_req->do_not_account_avg_rt = 1;
 
 	if (urfc->no_headers) goto send;
 

--- a/uwsgi.h
+++ b/uwsgi.h
@@ -1566,6 +1566,9 @@ struct wsgi_request {
 #ifdef UWSGI_SSL
 	SSL *ssl;
 #endif
+
+	// do not update avg_rt after request
+	int do_not_account_avg_rt;
 };
 
 


### PR DESCRIPTION
Related to #80, consider this scenario:
- I'm running application with `--offload-threads=2 --route-run=offload:`
- my app is single php/python/ruby view and a lot of static files (html/css/js)

Clients will make a lot more requests to static files then to application view, each static file request will be offloaded and it will update avg_rt metric with very low value (~0.2 millisecond).
avg_rt is averaged on every write (`avg_rt = (avg_rt + last_request_time)/2`) so we will end up with avg_rt reported in stats as value very close to 0

I think it makes sense to simply skip avg_rt recalculation for static files as it is meaningless.
