### PR TITLE
Add ELB proxy protocol support to the HTTP module.

### DIFF
--- a/proto/http.c
+++ b/proto/http.c
@@ -79,7 +79,7 @@ static uint16_t http_add_uwsgi_header(struct wsgi_request *wsgi_req, char *hh, s
 	return 2 + keylen + 2 + hvlen;
 }
 
-static char *proxy1_parse(char *ptr, char *watermark, char **src, uint16_t *src_len, char **dst, uint16_t *dst_len,  char **src_port, uint16_t *src_port_len, char **dst_port, uint16_t *dst_port_len) {
+char *proxy1_parse(char *ptr, char *watermark, char **src, uint16_t *src_len, char **dst, uint16_t *dst_len,  char **src_port, uint16_t *src_port_len, char **dst_port, uint16_t *dst_port_len) {
 	// check for PROXY header
 	if (watermark - ptr > 6) {
 		if (memcmp(ptr, "PROXY ", 6)) return ptr;

--- a/uwsgi.h
+++ b/uwsgi.h
@@ -4441,6 +4441,7 @@ int uwsgi_exceptions_catch(struct wsgi_request *);
 uint64_t uwsgi_worker_exceptions(int);
 struct uwsgi_exception_handler *uwsgi_register_exception_handler(char *, int (*)(struct uwsgi_exception_handler_instance *, char *, size_t));
 
+char *proxy1_parse(char *ptr, char *watermark, char **src, uint16_t *src_len, char **dst, uint16_t *dst_len,  char **src_port, uint16_t *src_port_len, char **dst_port, uint16_t *dst_port_len);
 void uwsgi_async_queue_is_full(time_t);
 char *uwsgi_get_header(struct wsgi_request *, char *, uint16_t, uint16_t *);
 


### PR DESCRIPTION
Previously, this was only supported with http-socket.  If you're
using http-socket, you probably have a webserver on top of you--and if
you have that, then uWSGI isn't receiving the proxy protocol anyway.

This copies proxy1_parse directly from proto/http.c, which should
probably be moved to a shared location, but I'm not sure where that
is.
