### PR TITLE
Add a missing use case on `reset_after_push`

### DIFF
--- a/plugins/carbon/carbon.c
+++ b/plugins/carbon/carbon.c
@@ -382,7 +382,7 @@ metrics_loop:
 				uwsgi_rwunlock(uwsgi.metrics_lock);
 				if (um->reset_after_push){
 					uwsgi_wlock(uwsgi.metrics_lock);
-					*um->value = 0;
+					*um->value = um->initial_value;
 					uwsgi_unlock(uwsgi.metrics_lock);
 				}
 				if (!wok) goto clear;

--- a/plugins/rrdtool/rrdtool.c
+++ b/plugins/rrdtool/rrdtool.c
@@ -152,7 +152,7 @@ static void rrdtool_push(struct uwsgi_stats_pusher_instance *uspi, time_t now, c
 		uwsgi_rwunlock(uwsgi.metrics_lock);
 		if (um->reset_after_push){
 			uwsgi_wlock(uwsgi.metrics_lock);
-			*um->value = 0;
+			*um->value = um->initial_value;
 			uwsgi_unlock(uwsgi.metrics_lock);
 		}
 		if (ret < 3 || ret >= 1024) {

--- a/plugins/stats_pusher_socket/plugin.c
+++ b/plugins/stats_pusher_socket/plugin.c
@@ -94,7 +94,7 @@ static void stats_pusher_socket(struct uwsgi_stats_pusher_instance *uspi, time_t
 		uwsgi_rwunlock(uwsgi.metrics_lock);
 		if (um->reset_after_push){
 			uwsgi_wlock(uwsgi.metrics_lock);
-			*um->value = 0;
+			*um->value = um->initial_value;
 			uwsgi_unlock(uwsgi.metrics_lock);
 		}
 		um = um->next;

--- a/plugins/stats_pusher_statsd/plugin.c
+++ b/plugins/stats_pusher_statsd/plugin.c
@@ -97,7 +97,7 @@ static void stats_pusher_statsd(struct uwsgi_stats_pusher_instance *uspi, time_t
 		uwsgi_rwunlock(uwsgi.metrics_lock);
 		if (um->reset_after_push){
 			uwsgi_wlock(uwsgi.metrics_lock);
-			*um->value = 0;
+			*um->value = um->initial_value;
 			uwsgi_unlock(uwsgi.metrics_lock);
 		}
 		um = um->next;

--- a/plugins/zabbix/plugin.c
+++ b/plugins/zabbix/plugin.c
@@ -96,7 +96,7 @@ static void stats_pusher_zabbix(struct uwsgi_stats_pusher_instance *uspi, time_t
 		if (uwsgi_buffer_append(zn->ub, "\"}", 2)) { error = 1; goto end;} 	
 		if (um->reset_after_push){
 			uwsgi_wlock(uwsgi.metrics_lock);
-			*um->value = 0;
+			*um->value = um->initial_value;
 			uwsgi_unlock(uwsgi.metrics_lock);
 		}
 		um = um->next;


### PR DESCRIPTION
Add a missing use case on `reset_after_push`, 
reset the value at `initial_value` if this option is used instead of 0.
