### PR TITLE
fix logging when --logger is used, regression from #636

### DIFF
--- a/core/uwsgi.c
+++ b/core/uwsgi.c
@@ -2231,7 +2231,7 @@ void uwsgi_setup(int argc, char *argv[], char *envp[]) {
 		uwsgi_opt_flock(NULL, uwsgi.flock_wait2, NULL);
 
 	// setup master logging
-	if (uwsgi.log_master && !uwsgi.daemonize2 && uwsgi.logfile)
+	if (uwsgi.log_master && !uwsgi.daemonize2 && (uwsgi.logfile || !uwsgi.logto2))
 		uwsgi_setup_log_master();
 
 	// setup offload engines


### PR DESCRIPTION
#636 fixed one thing but broken another, I'm not sure if we should check for the absence of --logto2, or for presence of --logger. There are so many combinations, what if someone uses --logfile with --logto2 and --logger? Or --logto2 with --logger? What is the order of importance here?
