### PR TITLE
Add cache length parameter to the PHP parameter parsing.

### DIFF
--- a/plugins/php/php_plugin.c
+++ b/plugins/php/php_plugin.c
@@ -254,8 +254,9 @@ PHP_FUNCTION(uwsgi_cache_exists) {
         char *key = NULL;
         int keylen = 0;
         char *cache = NULL;
+        int cachelen = 0;
 
-        if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "s|s", &key, &keylen, &cache) == FAILURE) {
+        if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "s|s", &key, &keylen, &cache, &cachelen) == FAILURE) {
                 RETURN_NULL();
         }
 
@@ -269,8 +270,9 @@ PHP_FUNCTION(uwsgi_cache_exists) {
 PHP_FUNCTION(uwsgi_cache_clear) {
 
         char *cache = NULL;
+        int cachelen = 0;
 
-        if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "|s", &cache) == FAILURE) {
+        if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "|s", &cache, &cachelen) == FAILURE) {
                 RETURN_NULL();
         }
 
@@ -287,8 +289,9 @@ PHP_FUNCTION(uwsgi_cache_del) {
 	char *key = NULL;
         int keylen = 0;
 	char *cache = NULL;
+	int cachelen = 0;
 
-        if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "s|s", &key, &keylen, &cache) == FAILURE) {
+        if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "s|s", &key, &keylen, &cache, &cachelen) == FAILURE) {
                 RETURN_NULL();
         }
 
@@ -304,12 +307,13 @@ PHP_FUNCTION(uwsgi_cache_get) {
 	char *key = NULL;
 	int keylen = 0;
 	char *cache = NULL;
+	int cachelen = 0;
 	uint64_t valsize;
 
 	if (!uwsgi.caches)
 		RETURN_NULL();
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "s|s", &key, &keylen, &cache) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "s|s", &key, &keylen, &cache, &cachelen) == FAILURE) {
                 RETURN_NULL();
         }
 
@@ -329,11 +333,12 @@ PHP_FUNCTION(uwsgi_cache_set) {
 	int vallen;
 	uint64_t expires = 0;
 	char *cache = NULL;
+	int cachelen = 0;
 
 	if (!uwsgi.caches)
 		RETURN_NULL();
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "ss|ls", &key, &keylen, &value, &vallen, &expires, &cache) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "ss|ls", &key, &keylen, &value, &vallen, &expires, &cache, &cachelen) == FAILURE) {
                 RETURN_NULL();
         }
 
@@ -351,11 +356,12 @@ PHP_FUNCTION(uwsgi_cache_update) {
         int vallen;
         uint64_t expires = 0;
         char *cache = NULL;
+        int cachelen = 0;
 
         if (!uwsgi.caches)
                 RETURN_NULL();
 
-        if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "ss|ls", &key, &keylen, &value, &vallen, &expires, &cache) == FAILURE) {
+        if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "ss|ls", &key, &keylen, &value, &vallen, &expires, &cache, &cachelen) == FAILURE) {
                 RETURN_NULL();
         }
 


### PR DESCRIPTION
The PHP plugin segfaults when passing a cache name parameter.

```
Mon Jul  7 12:14:36 2014 - !!! uWSGI process 3000 got Segmentation Fault !!!
Mon Jul  7 12:14:36 2014 - *** backtrace of 3000 ***
/usr/bin/uwsgi(uwsgi_backtrace+0x2e) [0x46028e]
/usr/bin/uwsgi(uwsgi_segfault+0x21) [0x460411]
/lib/x86_64-linux-gnu/libc.so.6(+0x35480) [0x7f6518d9c480]
/usr/lib/libphp5.so(+0x41786b) [0x7f65179c986b]
/usr/lib/libphp5.so(execute_ex+0x40) [0x7f65179983e0]
/usr/lib/libphp5.so(dtrace_execute_ex+0x68) [0x7f651794cad8]
/usr/lib/libphp5.so(zend_execute_scripts+0x170) [0x7f651795ed90]
/usr/lib/libphp5.so(php_execute_script+0x1eb) [0x7f65178fdfab]
/usr/lib/uwsgi/plugins/php_plugin.so(uwsgi_php_request+0x682) [0x7f6518128772]
/usr/bin/uwsgi(wsgi_req_recv+0xa4) [0x416d44]
/usr/bin/uwsgi(simple_loop_run+0xc4) [0x45c964]
/usr/bin/uwsgi(uwsgi_ignition+0x205) [0x460915]
/usr/bin/uwsgi(uwsgi_worker_run+0x2bd) [0x463b8d]
/usr/bin/uwsgi(uwsgi_run+0x3a2) [0x464092]
/usr/bin/uwsgi(_start+0) [0x41637e]
/lib/x86_64-linux-gnu/libc.so.6(__libc_start_main+0xf5) [0x7f6518d88b45]
/usr/bin/uwsgi() [0x4163a7]
*** end of backtrace ***
```
