### PR TITLE
wrap newXS lines with CvNODEBUG_on to allow perl debugging

### DIFF
--- a/plugins/psgi/psgi_loader.c
+++ b/plugins/psgi/psgi_loader.c
@@ -246,20 +246,20 @@ xs_init(pTHX)
 
 	if (!uperl.tmp_input_stash) goto nonworker;
 
-        newXS("uwsgi::input::new", XS_input, "uwsgi::input");
-        newXS("uwsgi::input::read", XS_input_read, "uwsgi::input");
-        newXS("uwsgi::input::seek", XS_input_seek, "uwsgi::input");
+        CvNODEBUG_on( newXS("uwsgi::input::new", XS_input, "uwsgi::input") );
+        CvNODEBUG_on( newXS("uwsgi::input::read", XS_input_read, "uwsgi::input") );
+        CvNODEBUG_on( newXS("uwsgi::input::seek", XS_input_seek, "uwsgi::input") );
 
         uperl.tmp_input_stash[uperl.tmp_current_i] = gv_stashpv("uwsgi::input", 0);
 
-        newXS("uwsgi::error::new", XS_error, "uwsgi::error");
-        newXS("uwsgi::error::print", XS_error_print, "uwsgi::print");
+        CvNODEBUG_on( newXS("uwsgi::error::new", XS_error, "uwsgi::error") );
+        CvNODEBUG_on( newXS("uwsgi::error::print", XS_error_print, "uwsgi::print") );
         uperl.tmp_error_stash[uperl.tmp_current_i] = gv_stashpv("uwsgi::error", 0);
 	uperl.tmp_psgix_logger[uperl.tmp_current_i] = newXS("uwsgi::psgix_logger", XS_psgix_logger, "uwsgi");
         uperl.tmp_stream_responder[uperl.tmp_current_i] = newXS("uwsgi::stream", XS_stream, "uwsgi");
 
-        newXS("uwsgi::streaming::write", XS_streaming_write, "uwsgi::streaming");
-        newXS("uwsgi::streaming::close", XS_streaming_close, "uwsgi::streaming");
+        CvNODEBUG_on( newXS("uwsgi::streaming::write", XS_streaming_write, "uwsgi::streaming") );
+        CvNODEBUG_on( newXS("uwsgi::streaming::close", XS_streaming_close, "uwsgi::streaming") );
 
         uperl.tmp_streaming_stash[uperl.tmp_current_i] = gv_stashpv("uwsgi::streaming", 0);
 


### PR DESCRIPTION
It is possible to use the perl debugger with a running uwsgi instance by attaching to it with gdb, then using the CPAN module Enbugger.  (See Enbugger CPAN docs for details: http://search.cpan.org/~jjore/Enbugger-2.016/lib/Enbugger.pod#From_gdb.)

However, when data is POSTed, for some reason the $env->{'psgi.input'} value is mashed into a 1 when the debugger is active.  It appears that for some reason the call to newXS("uwsgi::input::new") fails, or at least the return value is converted to a simple scalar.  Wrapping the method call in CvNODEBUG_on works around this issue.  This has no negative side effects, and basically (as I understand it) just tells the compiler to set a flag to prevent debugging into the method call.  It would be pointless to try to debug into that call anyway, which is why I say there are no negative side effects of this change.

To prevent this happening elsewhere this pull requests wraps all of the "newXS" calls with CvNODEBUG_on.
