### PR TITLE
Fix symbol lookup error in the Mono plugin on OS X.

### DIFF
--- a/plugins/mono/uwsgiplugin.py
+++ b/plugins/mono/uwsgiplugin.py
@@ -6,6 +6,9 @@ LDFLAGS = []
 LIBS = os.popen('pkg-config --libs mono-2').read().rstrip().split() 
 GCC_LIST = ['mono_plugin']
 
+if os.uname()[0] == 'Darwin':
+	LIBS.append('-framework Foundation')
+
 def post_build(config):
     if os.system("sn -k plugins/mono/uwsgi.key") != 0:
         os._exit(1)


### PR DESCRIPTION
On OS X, mono libraries have to link against the Foundation framework, otherwise trying to load the plugin will result in `dyld: Symbol not found: k_CFLocaleCountryCode`.
