### PR TITLE
add store_delete option to cache. 

### DIFF
--- a/uwsgi.h
+++ b/uwsgi.h
@@ -832,6 +832,8 @@ struct uwsgi_cache {
 	int purge_lru;
 	uint64_t lru_head;
 	uint64_t lru_tail;
+
+	int store_delete;
 };
 
 struct uwsgi_option {


### PR DESCRIPTION
add store_delete for cache2. If the cache is stored in a file and you change the item or block size uwsgi exits with the message to delete this file. If this option is set it automatically removes the file.

Are there any tests i missed ?

If this gets accepted i can make another one for the doc.
