### PR TITLE
Don't spin if we exhaust the async worker pool.

### DIFF
--- a/core/async.c
+++ b/core/async.c
@@ -21,7 +21,7 @@ extern struct uwsgi_server uwsgi;
 
 // this is called whenever a new connection is ready, but there are no cores to handle it
 void uwsgi_async_queue_is_full(time_t now) {
-	if (now > uwsgi.async_queue_is_full) {
+	if (now > uwsgi.async_queue_is_full && uwsgi.async_warn_if_queue_full) {
 		uwsgi_log_verbose("[DANGER] async queue is full !!!\n");
 		uwsgi.async_queue_is_full = now;
 	}

--- a/core/init.c
+++ b/core/init.c
@@ -107,6 +107,7 @@ void uwsgi_init_default() {
 	uwsgi.forkbomb_delay = 2;
 
 	uwsgi.async = 0;
+	uwsgi.async_warn_if_queue_full = 1;
 	uwsgi.listen_queue = 100;
 
 	uwsgi.cheaper_overload = 3;

--- a/core/uwsgi.c
+++ b/core/uwsgi.c
@@ -674,6 +674,7 @@ static struct uwsgi_option uwsgi_base_options[] = {
 	{"privileged-binary-patch-arg", required_argument, 0, "patch the uwsgi binary with a new command and arguments (before privileges drop)", uwsgi_opt_set_str, &uwsgi.privileged_binary_patch_arg, 0},
 	{"unprivileged-binary-patch-arg", required_argument, 0, "patch the uwsgi binary with a new command and arguments (after privileges drop)", uwsgi_opt_set_str, &uwsgi.unprivileged_binary_patch_arg, 0},
 	{"async", required_argument, 0, "enable async mode with specified cores", uwsgi_opt_set_int, &uwsgi.async, 0},
+	{"disable-async-warn-on-queue-full", no_argument, 0, "Disable printing 'async queue is full' warning messages.", uwsgi_opt_false, &uwsgi.async_warn_if_queue_full, 0},
 	{"max-fd", required_argument, 0, "set maximum number of file descriptors (requires root privileges)", uwsgi_opt_set_int, &uwsgi.requested_max_fd, 0},
 	{"logto", required_argument, 0, "set logfile/udp address", uwsgi_opt_set_str, &uwsgi.logfile, 0},
 	{"logto2", required_argument, 0, "log to specified file or udp address after privileges drop", uwsgi_opt_set_str, &uwsgi.logto2, 0},

--- a/plugins/gevent/gevent.c
+++ b/plugins/gevent/gevent.c
@@ -180,12 +180,14 @@ PyObject *py_uwsgi_gevent_main(PyObject * self, PyObject * args) {
 	// hack to retrieve the socket address
 	PyObject *py_uwsgi_sock = PyTuple_GetItem(args, 0);
         struct uwsgi_socket *uwsgi_sock = (struct uwsgi_socket *) PyLong_AsLong(py_uwsgi_sock);
+        long watcher_index = PyInt_AsLong(PyTuple_GetItem(args, 1));
 	struct wsgi_request *wsgi_req = NULL;
 edge:
 	wsgi_req = find_first_available_wsgi_req();
 
 	if (wsgi_req == NULL) {
 		uwsgi_async_queue_is_full(uwsgi_now());
+                PyObject_CallMethod(ugevent.watchers[watcher_index], "stop", NULL);
 		goto clear;
 	}
 
@@ -216,6 +218,9 @@ edge:
 
 	// hack to easily pass wsgi_req pointer to the greenlet
 	PyTuple_SetItem(ugevent.greenlet_args, 1, PyLong_FromLong((long)wsgi_req));
+	PyTuple_SetItem(ugevent.greenlet_args, 2, PyInt_FromLong(watcher_index));
+	PyTuple_SetItem(ugevent.greenlet_args, 3, py_uwsgi_sock);
+	Py_INCREF(py_uwsgi_sock);
 
 	// spawn the request greenlet
 	PyObject *new_gl = python_call(ugevent.spawn, ugevent.greenlet_args, 0, NULL);
@@ -233,11 +238,17 @@ clear:
 	return Py_None;
 }
 
+PyObject *uwsgi_gevent_main;
+void start_watcher(int i, struct uwsgi_socket* uwsgi_sock) {
+        PyObject_CallMethod(ugevent.watchers[i], "start", "Oli", uwsgi_gevent_main,(long)uwsgi_sock, i);
+}
 
 PyObject *py_uwsgi_gevent_request(PyObject * self, PyObject * args) {
 
 	PyObject *py_wsgi_req = PyTuple_GetItem(args, 0);
 	struct wsgi_request *wsgi_req = (struct wsgi_request *) PyLong_AsLong(py_wsgi_req);
+	long watcher_index = PyInt_AsLong(PyTuple_GetItem(args, 1));
+        struct uwsgi_socket *uwsgi_sock = (struct uwsgi_socket *) PyLong_AsLong(PyTuple_GetItem(args, 2));
 
 	PyObject *greenlet_switch = NULL;
 
@@ -249,7 +260,7 @@ PyObject *py_uwsgi_gevent_request(PyObject * self, PyObject * args) {
 	if (wsgi_req->socket->edge_trigger) {
 		int status = wsgi_req->socket->proto(wsgi_req);
 		if (status < 0) {
-			goto end2;
+			goto end;
 		}
 		goto request;
 	}
@@ -294,7 +305,7 @@ end:
 	if (greenlet_switch) {
 		Py_DECREF(greenlet_switch);
 	}
-end2:
+
 	Py_DECREF(current_greenlet);
 
 	uwsgi_close_request(wsgi_req);
@@ -304,22 +315,29 @@ end2:
 	if (uwsgi.workers[uwsgi.mywid].manage_next_request == 0) {
 		int running_cores = 0;
 		int i;
-          for(i=0;i<uwsgi.async;i++) {
-            if (uwsgi.workers[uwsgi.mywid].cores[i].in_request) {
-              running_cores++;
-            }
-          }
+                for(i=0;i<uwsgi.async;i++) {
+                        if (uwsgi.workers[uwsgi.mywid].cores[i].in_request) {
+                                running_cores++;
+                        }
+                }
 
-          if (running_cores == 0) {
-            // no need to worry about freeing memory
-            PyObject *uwsgi_dict = get_uwsgi_pydict("uwsgi");
-            if (uwsgi_dict) {
-              PyObject *ae = PyDict_GetItemString(uwsgi_dict, "atexit");
-              if (ae) {
-                python_call(ae, PyTuple_New(0), 0, NULL);
-              }
-            }
-          }
+                if (running_cores == 0) {
+                        // no need to worry about freeing memory
+                        PyObject *uwsgi_dict = get_uwsgi_pydict("uwsgi");
+                        if (uwsgi_dict) {
+                                PyObject *ae = PyDict_GetItemString(uwsgi_dict, "atexit");
+                                if (ae) {
+                                        python_call(ae, PyTuple_New(0), 0, NULL);
+                                }
+                        }
+                }
+        } else {
+                // If we stopped the watcher due to being out of async workers, restart it.
+                PyObject *py_watcher_active = PyObject_GetAttrString(ugevent.watchers[watcher_index], "active");
+                if (py_watcher_active && PyBool_Check(py_watcher_active) && !PyInt_AsLong(py_watcher_active)) {
+                        start_watcher(watcher_index, uwsgi_sock);
+                }
+                Py_DECREF(py_watcher_active);
         }
 
 	Py_INCREF(Py_None);
@@ -424,7 +442,7 @@ static void gevent_loop() {
 	if (!ugevent.hub_loop) uwsgi_pyexit;
 
 	// main greenlet waiting for connection (one greenlet per-socket)
-	PyObject *uwsgi_gevent_main = PyCFunction_New(uwsgi_gevent_main_def, NULL);
+	uwsgi_gevent_main = PyCFunction_New(uwsgi_gevent_main_def, NULL);
 	Py_INCREF(uwsgi_gevent_main);
 
 	// greenlet to run at each request
@@ -432,7 +450,7 @@ static void gevent_loop() {
 	Py_INCREF(uwsgi_request_greenlet);
 
 	// pre-fill the greenlet args
-	ugevent.greenlet_args = PyTuple_New(2);
+	ugevent.greenlet_args = PyTuple_New(4);
 	PyTuple_SetItem(ugevent.greenlet_args, 0, uwsgi_request_greenlet);
 		
 	if (uwsgi.signal_socket > -1) {
@@ -471,7 +489,7 @@ static void gevent_loop() {
 		if (!ugevent.watchers[i]) uwsgi_pyexit;
 	
 		// start the main greenlet
-		PyObject_CallMethod(ugevent.watchers[i], "start", "Ol", uwsgi_gevent_main,(long)uwsgi_sock);
+		start_watcher(i, uwsgi_sock);
 		uwsgi_sock = uwsgi_sock->next;
 		i++;
 	}

--- a/uwsgi.h
+++ b/uwsgi.h
@@ -2407,6 +2407,7 @@ struct uwsgi_server {
 	int async_running;
 	int async_queue;
 	int async_nevents;
+	int async_warn_if_queue_full;
 
 	time_t async_queue_is_full;
 


### PR DESCRIPTION
Scenario:

``` python
import flask
import gevent
import sys

app = flask.Flask('repro')

@app.route('/')
def index():
    gevent.sleep(3)
    return 'Hello\n'

if __name__ == '__main__':
    app.run(port=8080)
```

Running this with `--gevent 2` and starting 10 concurrent requests to the server puts uwsgi into a 100% cpu burn cycle. Gevent keeps notifying that there is a connection to accept and uwsgi ignores the signal due to async exhaustion. This isn't great behavior - in case of an outage of some other downstream server uwsgi burns all the cpu, not letting legitimate work get done.

This patch fixes the behavior by stopping the socket watcher if the async queue is exhausted. The worker threads then resume the watcher if it is not running as they exit.
