### PR TITLE
Fix forkptyrouter plugin compilation on Hurd

### DIFF
--- a/plugins/forkptyrouter/forkptyrouter.c
+++ b/plugins/forkptyrouter/forkptyrouter.c
@@ -16,14 +16,14 @@
 
 extern struct uwsgi_server uwsgi;
 
-#if defined(__linux__) || defined(__GNU_kFreeBSD__)
+#if defined(__linux__) || defined(__GNU_kFreeBSD__) || defined(__HURD__)
 #include <pty.h>
 #elif defined(__APPLE__) || defined(__OpenBSD__) || defined(__NetBSD__)
 #include <util.h>
-#elif defined(__FreeBSD__)
+#elif defined(__FreeBSD__) || defined(__DragonFly__)
 #include <libutil.h>
 #endif
-#ifndef __FreeBSD__
+#if !defined(__FreeBSD__) || !defined(__DragonFly__)
 #include <utmp.h>
 #endif
 

--- a/plugins/forkptyrouter/uwsgiplugin.py
+++ b/plugins/forkptyrouter/uwsgiplugin.py
@@ -1,7 +1,13 @@
+import os
+uwsgi_os = os.uname()[0]
+
 NAME='forkptyrouter'
 CFLAGS = []
 LDFLAGS = []
-LIBS = []
+if uwsgi_os in ('Linux', 'FreeBSD', 'GNU', 'NetBSD', 'DragonFly'):
+    LIBS = ['-lutil']
+else:
+    LIBS = []
 
 REQUIRES = ['corerouter']
 


### PR DESCRIPTION
While at it add missing linkage to libutil on other platforms
and fix compilation on DragonFlyBSD.

OpenBSD and MacOSX manpages does not cite the need to link to libutil

Possibly Fix #694
