### PR TITLE
Update rados.c

### DIFF
--- a/plugins/rados/rados.c
+++ b/plugins/rados/rados.c
@@ -147,7 +147,7 @@ static int uwsgi_rados_put(struct wsgi_request *wsgi_req, rados_ioctx_t ctx, cha
                 char *body =  uwsgi_request_body_read(wsgi_req, UMIN(remains, 32768) , &body_len);
                 if (!body || body == uwsgi.empty) goto error;
 		if (uwsgi.async <= 1) {
-			if (rados_write(ctx, key, body, body_len, off) <= 0) {
+			if (rados_write(ctx, key, body, body_len, off) < 0) {
 				return -1;
 			}
 		}


### PR DESCRIPTION
According to http://ceph.com/docs/master/rados/api/librados/ rados_write Returns: 0 on success, negative error code on failure. When using <= comparsion, PUT method always ends with ISE 500.
