### PR TITLE
Don't allow mules to send death notices to the legion

### DIFF
--- a/core/legion.c
+++ b/core/legion.c
@@ -1213,7 +1213,7 @@ next:
 	}
 
 	// this must be called only by the master !!!
-	if (uwsgi.mywid > 0) return;
+	if (uwsgi.mywid > 0 || uwsgi.muleid > 0) return;
 	uwsgi_legion_announce_death();
 }
 


### PR DESCRIPTION
If a mule dies (for example, via segfault) it will erroneously send a death notice to the legion. This should fix that, but I'm not sure if there are any other uwsgi processes that call this method when killed.
