### PR TITLE
python: add `spooler_pids` api for multi-spooler

### DIFF
--- a/plugins/python/uwsgi_pymodule.c
+++ b/plugins/python/uwsgi_pymodule.c
@@ -1993,6 +1993,16 @@ PyObject *py_uwsgi_spooler_pid(PyObject * self, PyObject * args) {
 	return PyInt_FromLong(uspool->pid);
 }
 
+PyObject *py_uwsgi_spooler_pids(PyObject * self, PyObject * args) {
+    PyObject *ret = PyList_New(0);
+    struct uwsgi_spooler *uspool = uwsgi.spoolers;
+    while (uspool) {
+        PyList_Append(ret, PyInt_FromLong(uspool->pid));
+        uspool = uspool->next;
+    }
+    return ret;
+}
+
 
 PyObject *py_uwsgi_connect(PyObject * self, PyObject * args) {
 
@@ -2425,6 +2435,7 @@ static PyMethodDef uwsgi_spooler_methods[] = {
 	{"set_spooler_frequency", py_uwsgi_spooler_freq, METH_VARARGS, ""},
 	{"spooler_jobs", py_uwsgi_spooler_jobs, METH_VARARGS, ""},
 	{"spooler_pid", py_uwsgi_spooler_pid, METH_VARARGS, ""},
+	{"spooler_pids", py_uwsgi_spooler_pids, METH_VARARGS, ""},
 	{NULL, NULL},
 };
 


### PR DESCRIPTION
the old `spooler_pid` api only returns the first spooler pid
