### PR TITLE
Fix a log message.

### DIFF
--- a/proto/http.c
+++ b/proto/http.c
@@ -50,7 +50,7 @@ static uint64_t http_add_uwsgi_header(struct wsgi_request *wsgi_req, char *hh, s
 	if (buffer + keylen + hvlen + 2 + 2 >= watermark) {
 		if (keylen <= 0xff && hvlen <= 0xff) {
 			if (has_prefix) {
-				uwsgi_log("[WARNING] unable to add HTTP_%.*s=%.*s to uwsgi packet, consider increasing buffer size\n", keylen, hh, hvlen, hv);
+				uwsgi_log("[WARNING] unable to add HTTP_%.*s=%.*s to uwsgi packet, consider increasing buffer size\n", keylen - 5, hh, hvlen, hv);
 			}
 			else {
 				uwsgi_log("[WARNING] unable to add %.*s=%.*s to uwsgi packet, consider increasing buffer size\n", keylen, hh, hvlen, hv);


### PR DESCRIPTION
if there is a header:
Some-Header: abcdef

Message gonna be:
[WARNING] unable to add HTTP_SOME_HEADER: abc=abcdef to uwsgi packet, consider increasing buffer size
