### PR TITLE
use _full write methods in rados plugin to truncate PUT request objects

### DIFF
--- a/plugins/rados/rados.c
+++ b/plugins/rados/rados.c
@@ -147,7 +147,7 @@ static int uwsgi_rados_put(struct wsgi_request *wsgi_req, rados_ioctx_t ctx, cha
                 char *body =  uwsgi_request_body_read(wsgi_req, UMIN(remains, 32768) , &body_len);
                 if (!body || body == uwsgi.empty) goto error;
 		if (uwsgi.async < 1) {
-			if (rados_write(ctx, key, body, body_len, off) < 0) {
+			if (rados_write_full(ctx, key, body, body_len) < 0) {
 				return -1;
 			}
 		}
@@ -169,7 +169,7 @@ static int uwsgi_rados_put(struct wsgi_request *wsgi_req, rados_ioctx_t ctx, cha
                 		free(urcb);
                 		goto error;
         		}
-        		if (rados_aio_write(ctx, key, comp, body, body_len, off) < 0) {
+        		if (rados_aio_write_full(ctx, key, comp, body, body_len) < 0) {
                 		free(urcb);
                 		rados_aio_release(comp);
                 		goto error;


### PR DESCRIPTION
Use librados rados_write_full and rados_aio_write_full methods to ensure that PUT requests to existing objects are truncated if they are smaller than the original objects.  Mainly this change will reduce disk utilization on the ceph cluster.  The *_full methods do also offer atomic truncate and update operations.  As the offset is anchored at 0 in the current code there is no difference in behavior for the client.
