### PR TITLE
buffer over-read fix in magic_sub

### DIFF
--- a/core/utils.c
+++ b/core/utils.c
@@ -1839,7 +1839,7 @@ char *magic_sub(char *buffer, size_t len, size_t * size, char *magic_table[]) {
 	for (i = 0; i < len; i++) {
 		if (buffer[i] == '%' && (i + 1) < len && magic_table[(unsigned char) buffer[i + 1]]) {
 			old_magic_buf = magic_buf;
-			magic_buf = uwsgi_concat3n(old_magic_buf, magic_len, magic_table[(unsigned char) buffer[i + 1]], strlen(magic_table[(unsigned char) buffer[i + 1]]), buffer + i + 2, len - i);
+			magic_buf = uwsgi_concat3n(old_magic_buf, magic_len, magic_table[(unsigned char) buffer[i + 1]], strlen(magic_table[(unsigned char) buffer[i + 1]]), buffer + i + 2, len - i - 2);
 			free(old_magic_buf);
 			magic_len += strlen(magic_table[(unsigned char) buffer[i + 1]]);
 			magic_ptr = magic_buf + magic_len;


### PR DESCRIPTION
We're over-reading the buffer by 2 bytes here.
I'm not assuming 'buffer' is null terminated. If it is, the call to uwsgi_concat3n will return a buffer that's 1 byte too long but it's safe.
