### PR TITLE
Add gridfs bucket option.

### DIFF
--- a/plugins/gridfs/gridfs.cc
+++ b/plugins/gridfs/gridfs.cc
@@ -21,6 +21,8 @@ struct uwsgi_gridfs_mountpoint {
 	uint16_t prefix_len;
 	char *username;
 	char *password;
+	char *bucket;
+	uint16_t bucket_len;
 };
 
 struct uwsgi_gridfs {
@@ -51,7 +53,7 @@ static void uwsgi_gridfs_do(struct wsgi_request *wsgi_req, struct uwsgi_gridfs_m
 					return;
 				}
 			}
-			mongo::GridFS gridfs((*conn).conn(), ugm->db);
+			mongo::GridFS gridfs((*conn).conn(), ugm->db, ugm->bucket);
 			mongo::GridFile gfile = gridfs.findFile(itemname);
 			if (need_free) {
 				free(itemname);
@@ -139,6 +141,7 @@ static struct uwsgi_gridfs_mountpoint *uwsgi_gridfs_add_mountpoint(char *arg, si
                         "server", &ugm->server,
                         "db", &ugm->db,
                         "prefix", &ugm->prefix,
+                        "bucket", &ugm->bucket,
                         "no_mime", &ugm->no_mime,
                         "timeout", &ugm->timeout_str,
                         "orig_filename", &ugm->orig_filename,
@@ -179,6 +182,14 @@ static struct uwsgi_gridfs_mountpoint *uwsgi_gridfs_add_mountpoint(char *arg, si
 
 	if (ugm->prefix) {
 		ugm->prefix_len = strlen(ugm->prefix);
+	}
+
+	if (!ugm->bucket) {
+		ugm->bucket = (char *)"fs";
+	}
+
+	if (ugm->bucket) {
+		ugm->bucket_len = strlen(ugm->bucket);
 	}
 
 	if (ugm->itemname) {


### PR DESCRIPTION
http://docs.mongodb.org/manual/core/gridfs/#gridfs-collections

> GridFS places the collections in a common bucket by prefixing each with the bucket name. By default, GridFS uses two collections with names prefixed by fs bucket:
> - fs.files
> - fs.chunks
> 
> You can choose a different bucket name than fs, and create multiple buckets in a single database.

MONGO_CLIENT_API GridFS constructor can take gridfs bucket parameter with name "prefix" and default value "fs".
https://github.com/mongodb/mongo/blob/master/src/mongo/client/gridfs.h#L76
