### PR TITLE
Don't lower security standards with recent gcc

### DIFF
--- a/uwsgiconfig.py
+++ b/uwsgiconfig.py
@@ -655,7 +655,7 @@ class uConf(object):
             self.cflags = self.cflags + ['-fno-strict-aliasing']
         if gcc_major >= 4:
             self.cflags = self.cflags + [ '-Wextra', '-Wno-unused-parameter', '-Wno-missing-field-initializers' ]
-        if (gcc_major == 4 and gcc_minor >= 8) or gcc_major > 4:
+        if gcc_major == 4 and gcc_minor < 9:
             self.cflags.append('-Wno-format -Wno-format-security')
 
         self.ldflags = os.environ.get("LDFLAGS", "").split()


### PR DESCRIPTION
For some reason since e4d65c07cee90461caad8b24f069fc93a82c3877
we started compiling -Wno-format, possibly because of plugins
dependencies not compiling.
Fedora (and Debian to some degrees) are starting to default to
-Wformat -Werror=format-security which is something sensible for
uwsgi. So let the distro handle the situation since they probably
know better.
