### PR TITLE
Fix invalid 'args' and 'kwargs' decoding in python3

### DIFF
--- a/t/python/spooler_decorators/spooler_decorator_tests.py
+++ b/t/python/spooler_decorators/spooler_decorator_tests.py
@@ -20,8 +20,10 @@ class BitmapTest(unittest.TestCase):
         spooler_handlers.controlled_task.spool(arg='barbis')
         spooler_handlers.controlled_raw_task.spool(arg='alive', ghost='world')
         spooler_handlers.controlled_raw_task.spool(arg='barbis')
+        spooler_handlers.controlled_arguments_task.spool(
+            {'key': 'value'}, 2, key1='value1')
 
-        for i in range(4):
+        for i in range(5):
             uwsgi.signal_wait(20)
         print("Signal received!")
 

--- a/t/python/spooler_decorators/spooler_handlers.py
+++ b/t/python/spooler_decorators/spooler_handlers.py
@@ -6,6 +6,14 @@ import uwsgi
 ghostpath = "/tmp/ghost"
 
 
+@spool(pass_arguments=True)
+def controlled_arguments_task(*args, **kwargs):
+    if args != ({'key': 'value'}, 2) or kwargs != {'key1': 'value1'}:
+        print("We have a problem!")
+        open(ghostpath, 'w').close()
+    uwsgi.signal(20)
+
+
 @spool
 def controlled_task(arguments):
     if arguments['arg'] != 'alive' and 'ghost' in arguments:

--- a/uwsgidecorators.py
+++ b/uwsgidecorators.py
@@ -50,17 +50,22 @@ def get_free_signal():
 
 
 def manage_spool_request(vars):
+    # To check whether 'args' is in vals or not - decode the keys first,
+    # because in python3 all keys in 'vals' are have 'byte' types
+    vars = dict((_decode1(K), V) for (K, V) in vars.items())
+    if 'args' in vars:
+        for k in ('args', 'kwargs'):
+            vars[k] = pickle.loads(vars.pop(k))
+
     vars = _decode_from_spooler(vars)
     f = spooler_functions[vars['ud_spool_func']]
+
     if 'args' in vars:
-        args = pickle.loads(vars.pop('args'))
-        kwargs = pickle.loads(vars.pop('kwargs'))
-        ret = f(*args, **kwargs)
+        ret = f(*vars['args'], **vars['kwargs'])
     else:
         ret = f(vars)
-    if not 'ud_spool_ret' in vars:
-        return ret
-    return int(vars['ud_spool_ret'])
+
+    return int(vars.get('ud_spool_ret', ret))
 
 
 def postfork_chain_hook():


### PR DESCRIPTION
When we set pass_arguments=True, we should unpickle
'args' and 'kwargs' first.

Without it '_decode_from_spooler' will fail on 'decoding' their
packed by pickle data, because pickled data has 'bytes' type.
