### PR TITLE
uwsgi_lock_fast_init fails on Linux 3.14 on BeagleBone Black

### DIFF
--- a/core/lock.c
+++ b/core/lock.c
@@ -94,11 +94,11 @@ retry:
 #ifndef PTHREAD_MUTEX_ROBUST
 #define PTHREAD_MUTEX_ROBUST PTHREAD_MUTEX_ROBUST_NP
 #endif
-	if (pthread_mutexattr_setprotocol(&attr, PTHREAD_PRIO_INHERIT)) {
-		uwsgi_log("unable to set PTHREAD_PRIO_INHERIT\n");
-		exit(1);
-	}
 	if (uwsgi_pthread_robust_mutexes_enabled) {
+		if (pthread_mutexattr_setprotocol(&attr, PTHREAD_PRIO_INHERIT)) {
+			uwsgi_log("unable to set PTHREAD_PRIO_INHERIT\n");
+			exit(1);
+		}
 		if (pthread_mutexattr_setrobust_np(&attr, PTHREAD_MUTEX_ROBUST)) {
 			uwsgi_log("unable to make the mutex 'robust'\n");
 			exit(1);


### PR DESCRIPTION
Linux 3.14 on the BeagleBone Black doesn't support robust shared mutex, syscall set_robust_list fails with ENOSYS.  When uwsgi_lock_fast_init retries with a standard shared mutex it sets the protocol to PTHREAD_PRIO_INHERIT, which makes pthread_mutex_init fail again.

The change just makes it so the protocol isn't set again.  It still complains about not having robust a mutex, but succeeds making a standard mutex.
