### PR TITLE
Fix latent refcounting error in the PSGI plugin

### DIFF
--- a/plugins/psgi/psgi_loader.c
+++ b/plugins/psgi/psgi_loader.c
@@ -30,6 +30,7 @@ XS(XS_error) {
 	else {
         	ST(0) = sv_bless(newRV_noinc(newSV(0)), ((HV **)wi->error)[0]);
 	}
+        sv_2mortal(ST(0));
         XSRETURN(1);
 }
 
@@ -46,6 +47,7 @@ XS(XS_input) {
 	else {
         	ST(0) = sv_bless(newRV_noinc(newSV(0)), ((HV **)wi->input)[0]);
 	}
+        sv_2mortal(ST(0));
         XSRETURN(1);
 }
 
@@ -85,6 +87,7 @@ XS(XS_stream)
 		else {
                 	ST(0) = sv_bless(newRV_noinc(newSV(0)), ((HV **)wi->stream)[0]);
 		}
+                sv_2mortal(ST(0));
                 XSRETURN(1);
 	}
 	else {

--- a/plugins/psgi/psgi_plugin.c
+++ b/plugins/psgi/psgi_plugin.c
@@ -156,7 +156,7 @@ SV *uwsgi_perl_obj_new(char *class, size_t class_len) {
 
 	SPAGAIN;
 
-	newobj = POPs;	
+	newobj = SvREFCNT_inc(POPs);
 	PUTBACK;
 	FREETMPS;
 	LEAVE;


### PR DESCRIPTION
Can be reproduced under the Perl debugger, see the commit message for a full explanation.
