### PR TITLE
Removed file permissions, and let umask magic happen instead.

### DIFF
--- a/plugins/logfile/logfile.c
+++ b/plugins/logfile/logfile.c
@@ -43,7 +43,7 @@ static ssize_t uwsgi_file_logger(struct uwsgi_logger *ul, char *message, size_t 
 				logfile = ul->arg;
 			}
 
-			ul->fd = open(logfile, O_RDWR | O_CREAT | O_APPEND);
+			ul->fd = open(logfile, O_RDWR | O_CREAT | O_APPEND, S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH);
 			if (ul->fd >= 0) {
 				ul->configured = 1;
 			}	


### PR DESCRIPTION
Overwriting umask is not a good idea because it is preventing req-logger to create log file readable by everyone (nxlog, logstash, ... plenty of differents users).

Also, umask is already in global configuration so it will be good to use it !
