### PR TITLE
Fix mmap error check in 1.4.

### DIFF
--- a/core/cache.c
+++ b/core/cache.c
@@ -59,7 +59,7 @@ void uwsgi_init_cache() {
 		}
 		uwsgi.cache_items = (struct uwsgi_cache_item *) mmap(NULL, uwsgi.cache_filesize, PROT_READ | PROT_WRITE, MAP_SHARED, cache_fd, 0);
 		if (uwsgi.cache_items == MAP_FAILED) {
-			uwsgi_log("Unable to mmap %llu bytes.\n", uwsgi.cache_store);
+			uwsgi_log("Unable to mmap %llu bytes.\n", uwsgi.cache_filesize);
 			uwsgi_error("mmap()");
 			exit(1);
 		}


### PR DESCRIPTION
Hello,

I'm not sure what the policy is for 1.4 but I noticed that the mmap call can fail and the check on the return code didn't work causing uwsgi to segfault. I know this is all fixed in 2.x but I thought it would be good to fix it in 1.4.

Derrick
