### PR TITLE
Add reasons to worker self-shutdown messages.

### DIFF
--- a/core/utils.c
+++ b/core/utils.c
@@ -1196,15 +1196,24 @@ void uwsgi_close_request(struct wsgi_request *wsgi_req) {
 
 	if (uwsgi.max_requests > 0 && uwsgi.workers[uwsgi.mywid].delta_requests >= (uwsgi.max_requests + ((uwsgi.mywid-1) * uwsgi.max_requests_delta))
 	    && (end_of_request - (uwsgi.workers[uwsgi.mywid].last_spawn * 1000000) >= uwsgi.min_worker_lifetime * 1000000)) {
-		goodbye_cruel_world();
+		goodbye_cruel_world("max requests reached (%llu >= %llu)",
+			(unsigned long long) uwsgi.workers[uwsgi.mywid].delta_requests,
+			(unsigned long long) (uwsgi.max_requests + ((uwsgi.mywid-1) * uwsgi.max_requests_delta))
+		);
 	}
 
 	if (uwsgi.reload_on_as && (rlim_t) vsz >= uwsgi.reload_on_as && (end_of_request - (uwsgi.workers[uwsgi.mywid].last_spawn * 1000000) >= uwsgi.min_worker_lifetime * 1000000)) {
-		goodbye_cruel_world();
+		goodbye_cruel_world("reload-on-as limit reached (%llu >= %llu)",
+			(unsigned long long) (rlim_t) vsz,
+			(unsigned long long) uwsgi.reload_on_as
+		);
 	}
 
 	if (uwsgi.reload_on_rss && (rlim_t) rss >= uwsgi.reload_on_rss && (end_of_request - (uwsgi.workers[uwsgi.mywid].last_spawn * 1000000) >= uwsgi.min_worker_lifetime * 1000000)) {
-		goodbye_cruel_world();
+		goodbye_cruel_world("reload-on-rss limit reached (%llu >= %llu)",
+			(unsigned long long) (rlim_t) rss,
+			(unsigned long long) uwsgi.reload_on_rss
+		);
 	}
 
 

--- a/core/uwsgi.c
+++ b/core/uwsgi.c
@@ -4059,6 +4059,11 @@ void uwsgi_opt_set_16bit(char *opt, char *value, void *key) {
 
 void uwsgi_opt_set_megabytes(char *opt, char *value, void *key) {
 	uint64_t *ptr = (uint64_t *) key;
+	if(strchr(value, '.') != NULL) {
+		double megabytes = atof(value);
+		*ptr = (uint64_t)(megabytes * 1024 * 1024);
+		return;
+	}
 	*ptr = (uint64_t)strtoul(value, NULL, 10) * 1024 * 1024;
 }
 

--- a/core/uwsgi.c
+++ b/core/uwsgi.c
@@ -1264,25 +1264,31 @@ void end_me(int signum) {
 	exit(UWSGI_END_CODE);
 }
 
-void simple_goodbye_cruel_world() {
+static void simple_goodbye_cruel_world(const char *reason) {
 
 	if (uwsgi.threads > 1 && !uwsgi_instance_is_dying) {
 		wait_for_threads();
 	}
 
 	uwsgi.workers[uwsgi.mywid].manage_next_request = 0;
-	uwsgi_log("...The work of process %d is done. Seeya!\n", getpid());
+	uwsgi_log("...The work of process %d is done (%s). Seeya!\n", getpid(), (reason != NULL ? reason : "no reason given"));
 	exit(0);
 }
 
-void goodbye_cruel_world() {
+void goodbye_cruel_world(const char *reason_fmt, ...) {
+	char reason[64];
+	va_list args;
+	va_start(args, reason_fmt);
+	vsnprintf(reason, 64, reason_fmt, args);
+	va_end(args);
+
 	uwsgi_curse(uwsgi.mywid, 0);
 
 	if (!uwsgi.gbcw_hook) {
-		simple_goodbye_cruel_world();
+		simple_goodbye_cruel_world(reason);
 	}
 	else {
-		uwsgi.gbcw_hook();
+		uwsgi.gbcw_hook(reason);
 	}
 }
 

--- a/plugins/gevent/gevent.c
+++ b/plugins/gevent/gevent.c
@@ -126,12 +126,12 @@ PyObject *py_uwsgi_gevent_int(PyObject *self, PyObject *args) {
 }
 
 
-static void uwsgi_gevent_gbcw() {
+static void uwsgi_gevent_gbcw(const char *reason) {
 
 	// already running
 	if (ugevent.destroy) return;
 
-	uwsgi_log("...The work of process %d is done. Seeya!\n", getpid());
+	uwsgi_log("...The work of process %d is done (reason: %s). Seeya!\n", getpid(), (reason != NULL ? reason : "no reason given"));
 
 	uwsgi_time_bomb(uwsgi.worker_reload_mercy, 0);
 	

--- a/plugins/psgi/psgi_plugin.c
+++ b/plugins/psgi/psgi_plugin.c
@@ -720,7 +720,7 @@ void uwsgi_perl_after_request(struct wsgi_request *wsgi_req) {
 
 		// mark the request as ended (otherwise the atexit hook will be skipped)
 		uwsgi.workers[uwsgi.mywid].cores[wsgi_req->async_id].in_request = 0;
-		goodbye_cruel_world();
+		goodbye_cruel_world("async plagued");
 	}
 
 	// now we can check for changed files

--- a/uwsgi.h
+++ b/uwsgi.h
@@ -2572,7 +2572,7 @@ struct uwsgi_server {
 	void (*schedule_to_req) (void);
 	void (*schedule_fix) (struct wsgi_request *);
 
-	void (*gbcw_hook) (void);
+	void (*gbcw_hook) (const char *);
 
 	int close_on_exec;
 	int close_on_exec2;
@@ -3053,7 +3053,7 @@ char *uwsgi_get_cwd(void);
 
 void warn_pipe(void);
 void what_i_am_doing(void);
-void goodbye_cruel_world(void);
+void goodbye_cruel_world(const char *, ...);
 void gracefully_kill(int);
 void reap_them_all(int);
 void kill_them_all(int);


### PR DESCRIPTION
This should make it easier to understand why a worker is shutting down.

New hotness:

> ...The work of process 18381 is done (reload-on-rss limit reached (11251712 >= 1048576)). Seeya!
> ...The work of process 18860 is done (max requests reached (1 >= 1)). Seeya!

vs the old and busted

> ...The work of process 13371 is done. Seeya!

We're allocating heap memory for the message, but since the process will unconditionally die just after using the memory, I don't think not cleaning it up is a problem?

## ABI change!

Also, this _does_ involve an ABI change for the `goodbye_cruel_world` function.

I tried to search Github for possible third-party uses of the function (and `gbcw_hook` too) and couldn't find any (other than stray copies of old versions of uWSGI source), so I figure it _should_ be safeish to change.

Also, considering the fact that the `uwsgi_log()` that _might_ access a bogus pointer and cause a segfault is the very last thing that's done before exiting the process, segfaulting _maybe_ isn't that bad?

@unbit, if you deem the ABI change a stupid idea, I'm more than willing to rewrite this in a form that adds a new API function, say, `goodbye_cruel_world_reason(const char *reason)` (and not pass the reason argument to `gbcw_hook()` to retain that ABI compatibility).