### PR TITLE
Add :use_ssl=>true to extconf.rb

### DIFF
--- a/ext/uwsgi/extconf.rb
+++ b/ext/uwsgi/extconf.rb
@@ -1,6 +1,6 @@
 require 'net/http'
 
-Net::HTTP.start("uwsgi.it") do |http|
+Net::HTTP.start("uwsgi.it", :use_ssl=>true) do |http|
   resp = http.get("/install")
   open("install.sh", "wb") do |file|
       file.write(resp.body)


### PR DESCRIPTION
It seems the installer is on https://uwsgi.it/install (as of Jan 14, 2015). Without this change, "gem install uwsgi" does almost nothing.