### PR TITLE
Update psgi_plugin.c

### DIFF
--- a/plugins/psgi/psgi_plugin.c
+++ b/plugins/psgi/psgi_plugin.c
@@ -709,6 +709,7 @@ void uwsgi_perl_after_request(struct wsgi_request *wsgi_req) {
 	}
 
 	// Free the $env hash
+	wsgi_req->async_environ = NULL; 
 	SvREFCNT_dec(wsgi_req->async_environ);
 
 	// async plagued could be defined in other areas...


### PR DESCRIPTION
In uWSGI setup where we have to mount more than one app dynamically depending on uwsgi_params passed from nginx , we get following error.  setting  wsgi_req->async_environ to NULL before calling SvREFCNT_dec seems to stop following error messages. 
I am not if this is the correct way to do it.  

Attempt to free non-existent shared string 'psgi.input', Perl interpreter: 0x1e07fc0.
Attempt to free non-existent shared string 'HTTP_HOST', Perl interpreter: 0x1e07fc0.
Attempt to free non-existent shared string 'psgix.harakiri', Perl interpreter: 0x1e07fc0.
Attempt to free non-existent shared string 'psgi.url_scheme', Perl interpreter: 0x1e07fc0.
Attempt to free non-existent shared string 'psgi.nonblocking', Perl interpreter: 0x1e07fc0.
Attempt to free non-existent shared string 'psgi.errors', Perl interpreter: 0x1e07fc0.
Attempt to free non-existent shared string 'REQUEST_URI', Perl interpreter: 0x1e07fc0.
Attempt to free non-existent shared string 'SERVER_PROTOCOL', Perl interpreter: 0x1e07fc0.
Attempt to free non-existent shared string 'REMOTE_ADDR', Perl interpreter: 0x1e07fc0.
Attempt to free non-existent shared string 'HTTP_COOKIE', Perl interpreter: 0x1e07fc0.
Attempt to free non-existent shared string 'SERVER_PORT', Perl interpreter: 0x1e07fc0.
Attempt to free non-existent shared string 'psgix.logger', Perl interpreter: 0x1e07fc0.
Attempt to free non-existent shared string 'CONTENT_LENGTH', Perl interpreter: 0x1e07fc0.
Attempt to free non-existent shared string 'HTTP_CONNECTION', Perl interpreter: 0x1e07fc0.
Attempt to free non-existent shared string 'HTTP_ACCEPT_ENCODING', Perl interpreter: 0x1e07fc0.
Attempt to free non-existent shared string 'HTTP_REFERER', Perl interpreter: 0x1e07fc0.
Attempt to free non-existent shared string 'SERVER_NAME', Perl interpreter: 0x1e07fc0.

Regards
Rohit