### PR TITLE
introduce uwsgi.binary_argc

### DIFF
--- a/core/init.c
+++ b/core/init.c
@@ -62,6 +62,7 @@ void uwsgi_init_default() {
 
 	uwsgi.cpus = 1;
 	uwsgi.new_argc = -1;
+	uwsgi.binary_argc = 1;
 
 	uwsgi.backtrace_depth = 64;
 	uwsgi.max_apps = 64;
@@ -261,11 +262,33 @@ void uwsgi_commandline_config() {
 	int argc = uwsgi.argc;
 	char **argv = uwsgi.argv;
 
+	// we might want to ignore some arguments not meant for us
+	char binary_argv0_pretty[256] = {'\0'};
+	char *binary_argv0_actual = NULL;
+
 	if (uwsgi.new_argc > -1 && uwsgi.new_argv) {
 		argc = uwsgi.new_argc;
 		argv = uwsgi.new_argv;
 	}
 
+	if (uwsgi.binary_argc > 1 && argc >= uwsgi.binary_argc) {
+		char *pretty = (char *)binary_argv0_pretty;
+		strncat(pretty, argv[0], 255);
+
+		for (i = 1; i < uwsgi.binary_argc; i++) {
+			if (strlen(pretty) + 1 + strlen(argv[i]) + 1 > 256)
+				break;
+
+			strcat(pretty, " ");
+			strcat(pretty, argv[i]);
+		}
+
+		argc -= uwsgi.binary_argc - 1;
+		argv += uwsgi.binary_argc - 1;
+
+		binary_argv0_actual = argv[0];
+		argv[0] = (char *)binary_argv0_pretty;
+	}
 
 	char *optname;
 	while ((i = getopt_long(argc, argv, uwsgi.short_options, uwsgi.long_options, &uwsgi.option_index)) != -1) {
@@ -289,6 +312,8 @@ void uwsgi_commandline_config() {
 		add_exported_option(optname, optarg, 0);
 	}
 
+	if (binary_argv0_actual != NULL)
+		argv[0] = binary_argv0_actual;
 
 #ifdef UWSGI_DEBUG
 	uwsgi_log("optind:%d argc:%d\n", optind, uwsgi.argc);

--- a/uwsgi.h
+++ b/uwsgi.h
@@ -2811,6 +2811,9 @@ struct uwsgi_server {
 	int spooler_signal_as_task;
 
 	int log_worker;
+
+	// number of args to consider part of binary_path
+	int binary_argc;
 };
 
 struct uwsgi_rpc {


### PR DESCRIPTION
if uWSGI is embedded in some way, part of argv might not be intended for processing by `uwsgi_commandline_config`, eg. consider the `pyuwsgi` plugin:

```
python2 -c 'import uwsgi as u; u.run()' --master -s@nil
```

in such cases, uWSGI should ignore some number of arguments (set by a plugin's `load()`, if necessary). this patch allows binary reloading to work again.

i have a working patch to `plugins/pyuwsgi/pyuwsgi.c` that makes use of this, but i want to clean it up a little prior to submitting. since this touches `uwsgi.h`, i mainly want to ensure it (or another solution) lands before 2.1 drops.

ASIDE: my work with `pyuwsgi` stems from a desire to do this: https://github.com/unbit/uwsgi/issues/564

`pyuwsgi` allows our apps to use their own settings (in python code) to configure uWSGI. while i think this is particularly elegant (and IMO, preferred), `--early-python-*` options also suggest `python://` as config might be possible now, and would achieve a similar effect. like i said, i prefer the current approach, and if acceptable, i will either add the `pyuwsgi` patch here or another ticket, whichever you prefer. once both of those land, i can update `pyuwsgi` to be python3 compatible.

thoughts?