### PR TITLE
Be more helpful when a request has an unknown modifier1

### DIFF
--- a/core/known_plugins.c
+++ b/core/known_plugins.c
@@ -1,0 +1,70 @@
+#include "uwsgi.h"
+
+typedef struct {
+    int modifier;
+    const char *usage;
+    const char *plugin_name;
+} map_entry_t;
+
+#define BEGIN_KNOWN_MODIFIER_MAP(name) static map_entry_t* name[] = {
+#define END_KNOWN_MODIFIER_MAP() NULL };
+#define KNOWN_MODIFIER(modifier, usage, plugin_name) &(map_entry_t){modifier, usage, plugin_name},
+
+BEGIN_KNOWN_MODIFIER_MAP(known_modifier1_map)
+    KNOWN_MODIFIER(0, "Python apps", "python")
+    KNOWN_MODIFIER(5, "Perl/PSGI apps", "psgi")
+    KNOWN_MODIFIER(6, "Lua apps", "lua")
+    KNOWN_MODIFIER(7, "Ruby/Rack apps", "rack")
+    KNOWN_MODIFIER(8, "JVM apps", "jvm")
+    KNOWN_MODIFIER(9, "CGI apps", "cgi")
+    KNOWN_MODIFIER(11, "Go (gccgo) apps", "gccgo")
+    KNOWN_MODIFIER(14, "PHP", "php")
+    KNOWN_MODIFIER(15, "Mono apps", "mono")
+    KNOWN_MODIFIER(17, "uWSGI Spooler", NULL)
+    KNOWN_MODIFIER(18, "Symcall", "symcall")
+    KNOWN_MODIFIER(19, "SSI", "ssi")
+    KNOWN_MODIFIER(23, "XSLT", "xslt")
+    KNOWN_MODIFIER(24, "V8 (JavaScript) apps", "v8")
+    KNOWN_MODIFIER(25, "GridFS", "gridfs")
+    KNOWN_MODIFIER(27, "GlusterFS", "glusterfs")
+    KNOWN_MODIFIER(28, "Rados", "rados")
+    KNOWN_MODIFIER(35, "WebDAV", "webdav")
+    KNOWN_MODIFIER(100, "uWSGI Ping", "ping")
+    KNOWN_MODIFIER(101, "Echo", "echo")
+    KNOWN_MODIFIER(109, "uWSGI Legion", NULL)
+    KNOWN_MODIFIER(110, "uWSGI Remote Signal", NULL)
+    KNOWN_MODIFIER(111, "uWSGI Cache", NULL)
+    KNOWN_MODIFIER(115, "uWSGI Emperor", NULL)
+    KNOWN_MODIFIER(173, "uWSGI RPC", NULL)
+    KNOWN_MODIFIER(250, "C++", "cplusplus")
+END_KNOWN_MODIFIER_MAP()
+
+/**
+ * Find an entry for a given modifier in a given modifier map list.
+ * @return The map entry or NULL if not found.
+ */
+static const map_entry_t *find_hint_for_modifier(map_entry_t** list, const int modifier) {
+    while(*list) {
+        if((*list)->modifier == modifier) return *list;
+        list++;
+    }
+    return NULL;
+}
+
+/**
+ * Log message about an unavailable modifier, trying to be
+ * helpful by looking it up in the table of known modifiers.
+ * 
+ * If the modifier is well and truly unknown, revert to a less
+ * helpful message.
+ * 
+ * @param modifier1 The modifier1 value requested.
+ */
+void log_modifier1_hint(int modifier1) {
+    const map_entry_t *ent = find_hint_for_modifier(known_modifier1_map, modifier1);
+    if(ent != NULL) {
+        uwsgi_log("-- unavailable modifier requested: %d (\"%s\", try `--plugin %s`?) --\n", modifier1, ent->usage, ent->plugin_name);
+    } else {
+        uwsgi_log("-- unavailable modifier requested: %d (are you missing a plugin?) --\n", modifier1);
+    }
+}

--- a/core/uwsgi.c
+++ b/core/uwsgi.c
@@ -1543,7 +1543,7 @@ int unconfigured_hook(struct wsgi_request *wsgi_req) {
 			}
 		}
 	}
-	uwsgi_log("-- unavailable modifier requested: %d --\n", wsgi_req->uh->modifier1);
+	log_modifier1_hint(wsgi_req->uh->modifier1);
 	return -1;
 }
 

--- a/uwsgi.h
+++ b/uwsgi.h
@@ -3975,6 +3975,8 @@ int uwsgi_socket_is_already_bound(char *name);
 char *uwsgi_expand_path(char *, int, char *);
 int uwsgi_try_autoload(char *);
 
+void log_modifier1_hint(int modifier1);
+
 uint64_t uwsgi_micros(void);
 int uwsgi_is_file(char *);
 int uwsgi_is_file2(char *, struct stat *);

--- a/uwsgiconfig.py
+++ b/uwsgiconfig.py
@@ -570,7 +570,7 @@ class uConf(object):
             'core/notify', 'core/mule', 'core/subscription', 'core/stats', 'core/sendfile', 'core/async', 'core/master_checks', 'core/fifo',
             'core/offload', 'core/io', 'core/static', 'core/websockets', 'core/spooler', 'core/snmp', 'core/exceptions', 'core/config',
             'core/setup_utils', 'core/clock', 'core/init', 'core/buffer', 'core/reader', 'core/writer', 'core/alarm', 'core/cron', 'core/hooks',
-            'core/plugins', 'core/lock', 'core/cache', 'core/daemons', 'core/errors', 'core/hash', 'core/master_events', 'core/chunked',
+            'core/known_plugins', 'core/plugins', 'core/lock', 'core/cache', 'core/daemons', 'core/errors', 'core/hash', 'core/master_events', 'core/chunked',
             'core/queue', 'core/event', 'core/signal', 'core/strings', 'core/progress', 'core/timebomb', 'core/ini', 'core/fsmon', 'core/mount',
             'core/metrics', 'core/plugins_builder', 'core/sharedarea', 'core/fork_server', 'core/webdav', 'core/zeus',
             'core/rpc', 'core/gateway', 'core/loop', 'core/cookie', 'core/querystring', 'core/rb_timers', 'core/transformations', 'core/uwsgi']


### PR DESCRIPTION
Adds a list of "well-known" modifier1 values and changes the

> -- unavailable modifier requested: %d --

message to add a hint about which plugin might be needed to
fix the situation.

(Missing plugins seems to be a common enough problem.)
