### PR TITLE
 catch exception in executing post fork chain so that exceptions dont

### DIFF
--- a/uwsgidecorators.py
+++ b/uwsgidecorators.py
@@ -70,7 +70,11 @@ def manage_spool_request(vars):
 
 def postfork_chain_hook():
     for f in postfork_chain:
-        f()
+        try:
+            f()
+        except Exception as e:
+            print e
+
 
 uwsgi.spooler = manage_spool_request
 uwsgi.post_fork_hook = postfork_chain_hook


### PR DESCRIPTION
Right now, if any function in the fork chain throws an exception, the exception is not caught, and the rest of the functions never get called. while just printing an exception is not desirable, it should allow the rest of the decorators to continue, agree?