### PR TITLE
Covert most chmod users to fchmod

### DIFF
--- a/core/emperor.c
+++ b/core/emperor.c
@@ -222,7 +222,7 @@ static int on_demand_bind(char *socket_name) {
 	}
 
 	if (!is_tcp) {
-		if (chmod(socket_name, 0666)) {
+		if (fchmod(fd, 0666)) {
 			goto error;
 		}
 	}

--- a/core/logging.c
+++ b/core/logging.c
@@ -291,8 +291,8 @@ void logto(char *logfile) {
 		uwsgi.logfile = logfile;
 
 		if (uwsgi.chmod_logfile_value) {
-			if (chmod(uwsgi.logfile, uwsgi.chmod_logfile_value)) {
-				uwsgi_error("chmod()");
+			if (fchmod(fd, uwsgi.chmod_logfile_value)) {
+				uwsgi_error("fchmod()");
 			}
 		}
 	}

--- a/core/master.c
+++ b/core/master.c
@@ -429,8 +429,8 @@ int master_loop(char **argv, char **environ) {
 		if (uwsgi.emperor_proxy) {
 			uwsgi.emperor_fd_proxy = bind_to_unix(uwsgi.emperor_proxy, uwsgi.listen_queue, 0, 0);
 			if (uwsgi.emperor_fd_proxy < 0) exit(1);
-			if (chmod(uwsgi.emperor_proxy, S_IRUSR|S_IWUSR)) {
-				uwsgi_error("[emperor-proxy] chmod()");
+			if (fchmod(uwsgi.emperor_fd_proxy, S_IRUSR|S_IWUSR)) {
+				uwsgi_error("[emperor-proxy] fchmod()");
 				exit(1);
 			}
 			event_queue_add_fd_read(uwsgi.master_queue, uwsgi.emperor_fd_proxy);
@@ -444,8 +444,8 @@ int master_loop(char **argv, char **environ) {
 	if (uwsgi.setns_socket) {
 		uwsgi.setns_socket_fd = bind_to_unix(uwsgi.setns_socket, uwsgi.listen_queue, 0, 0);
 		if (uwsgi.setns_socket_fd < 0) exit(1);
-		if (chmod(uwsgi.setns_socket, S_IRUSR|S_IWUSR)) {
-                	uwsgi_error("[setns-socket] chmod()");
+		if (fchmod(uwsgi.setns_socket_fd, S_IRUSR|S_IWUSR)) {
+			uwsgi_error("[setns-socket] fchmod()");
                         exit(1);
                 }
                 event_queue_add_fd_read(uwsgi.master_queue, uwsgi.setns_socket_fd);

--- a/core/socket.c
+++ b/core/socket.c
@@ -243,14 +243,14 @@ int bind_to_unix(char *socket_name, int listen_queue, int chmod_socket, int abst
 	// chmod unix socket for lazy users
 	if (chmod_socket == 1 && abstract_socket == 0) {
 		if (uwsgi.chmod_socket_value) {
-			if (chmod(socket_name, uwsgi.chmod_socket_value) != 0) {
-				uwsgi_error("chmod()");
+			if (fchmod(serverfd, uwsgi.chmod_socket_value) != 0) {
+				uwsgi_error("fchmod()");
 			}
 		}
 		else {
-			uwsgi_log("chmod() socket to 666 for lazy and brave users\n");
-			if (chmod(socket_name, S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP | S_IROTH | S_IWOTH) != 0) {
-				uwsgi_error("chmod()");
+			uwsgi_log("fchmod() socket to 666 for lazy and brave users\n");
+			if (fchmod(serverfd, S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP | S_IROTH | S_IWOTH) != 0) {
+				uwsgi_error("fchmod()");
 			}
 		}
 	}
@@ -1766,14 +1766,14 @@ void uwsgi_bind_sockets() {
                                 	}
 					if (uwsgi.chmod_socket) {
                 				if (uwsgi.chmod_socket_value) {
-                        				if (chmod(uwsgi_sock->name, uwsgi.chmod_socket_value) != 0) {
-                                				uwsgi_error("inherit fd0: chmod()");
+							if (fchmod(uwsgi_sock->fd, uwsgi.chmod_socket_value) != 0) {
+								uwsgi_error("inherit fd0: fchmod()");
                         				}
                 				}
                 				else {
-                        				uwsgi_log("chmod() fd0 socket to 666 for lazy and brave users\n");
-                        				if (chmod(uwsgi_sock->name, S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP | S_IROTH | S_IWOTH) != 0) {
-                                				uwsgi_error("inherit fd0: chmod()");
+							uwsgi_log("fchmod() fd0 socket to 666 for lazy and brave users\n");
+							if (fchmod(uwsgi_sock->fd, S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP | S_IROTH | S_IWOTH) != 0) {
+								uwsgi_error("inherit fd0: fchmod()");
                         				}
 						}
                 			}


### PR DESCRIPTION
The plan is to avoid toctouc races, i've converted the user where the fd of the path was nearly available. There are a couple of hooks which plays with chmod which may be hard to convert and chmod on cgroup dir in core/utils.c:222 which can be coverted with some code reordering. Please review.