### PR TITLE
Don't define UWSGI_CFLAGS for coverity build profile

### DIFF
--- a/uwsgiconfig.py
+++ b/uwsgiconfig.py
@@ -347,7 +347,10 @@ def build_uwsgi(uc, print_only=False, gcll=None):
         for item in additional_sources.split(','):
             gcc_list.append(item)
 
-    cflags.append('-DUWSGI_CFLAGS=\\"%s\\"' % uwsgi_cflags)
+    if uc.filename.endswith('coverity.ini'):
+        cflags.append('-DUWSGI_CFLAGS=\\"\\"')
+    else:
+        cflags.append('-DUWSGI_CFLAGS=\\"%s\\"' % uwsgi_cflags)
     cflags.append('-DUWSGI_BUILD_DATE="\\"%s\\""' % time.strftime("%d %B %Y %H:%M:%S"))
 
     post_build = []
@@ -560,6 +563,7 @@ class uConf(object):
     def __init__(self, filename, mute=False):
         global GCC
 
+        self.filename = filename
         self.config = ConfigParser.ConfigParser()
         if not mute:
             print("using profile: %s" % filename)


### PR DESCRIPTION
coverity cli tools have supposedly a fixed buffer to contain each
compiler invocation. The embedding of UWSGI_CFLAGS of course breaks
that limit. The issue has been reported for more than a year and they
have not fixed that. So add this hack to make sure we don't define
UWSGI_CFLAGS if the build profile ends with 'coverity.ini'.