### PR TITLE
Fishy coverity fixes

### DIFF
--- a/core/cache.c
+++ b/core/cache.c
@@ -242,7 +242,6 @@ static void uwsgi_cache_add_items(struct uwsgi_cache *uc) {
                                 goto next;
                         }
                         key = space+1;
-                        key_len = usl->len - ((space-usl->value)+1);
                 }
 		char *value = strchr(key, '=');
 		if (!value) {

--- a/core/utils.c
+++ b/core/utils.c
@@ -3884,7 +3884,6 @@ int uwsgi_kvlist_parse(char *src, size_t len, char list_separator, char kv_separ
 					}
 				}
 				va_end(ap);
-				base = ptr;
 				break;
 			}
 			else if (usl->value[i] == '\\' && !escaped) {

--- a/plugins/xslt/xslt.c
+++ b/plugins/xslt/xslt.c
@@ -203,7 +203,6 @@ static int uwsgi_request_xslt(struct wsgi_request *wsgi_req) {
 		if (value) {
 			memcpy(stylesheet, value, rlen);
 			stylesheet[rlen] = 0;
-			stylesheet_len = rlen;
 			found = 1;
 			break;
 		}


### PR DESCRIPTION
These three are fixes for assigments to variables that are never read later. I think these require a bit of scrutiny since they can be symptoms of misplaced code. Or hopefully just leftovers.