### PR TITLE
Fix client certificate validation. Log verification errors

### DIFF
--- a/core/ssl.c
+++ b/core/ssl.c
@@ -30,15 +30,15 @@ void uwsgi_ssl_info_cb(SSL const *ssl, int where, int ret) {
 }
 
 int uwsgi_ssl_verify_callback(int ok, X509_STORE_CTX * x509_store) {
-        char buf[256];
-        X509 *err_cert;
-        int depth;
-        int err;
-        depth = X509_STORE_CTX_get_error_depth(x509_store);
-        err_cert = X509_STORE_CTX_get_current_cert(x509_store);
-        X509_NAME_oneline(X509_get_subject_name(err_cert), buf, 256);
-        err = X509_STORE_CTX_get_error(x509_store);
         if (!ok) {
+                char buf[256];
+                X509 *err_cert;
+                int depth;
+                int err;
+                depth = X509_STORE_CTX_get_error_depth(x509_store);
+                err_cert = X509_STORE_CTX_get_current_cert(x509_store);
+                X509_NAME_oneline(X509_get_subject_name(err_cert), buf, 256);
+                err = X509_STORE_CTX_get_error(x509_store);
                 uwsgi_log("[uwsgi-ssl] client certificate verify error: num=%d:%s:depth=%d:%s\n", err, X509_verify_cert_error_string(err), depth, buf);
         }
         return ok;

--- a/core/ssl.c
+++ b/core/ssl.c
@@ -30,7 +30,18 @@ void uwsgi_ssl_info_cb(SSL const *ssl, int where, int ret) {
 }
 
 int uwsgi_ssl_verify_callback(int ok, X509_STORE_CTX * x509_store) {
-        return 1;
+        char buf[256];
+        X509 *err_cert;
+        int depth;
+        int err;
+        depth = X509_STORE_CTX_get_error_depth(x509_store);
+        err_cert = X509_STORE_CTX_get_current_cert(x509_store);
+        X509_NAME_oneline(X509_get_subject_name(err_cert), buf, 256);
+        err = X509_STORE_CTX_get_error(x509_store);
+        if (!ok) {
+                uwsgi_log("[uwsgi-ssl] client certificate verify error: num=%d:%s:depth=%d:%s\n", err, X509_verify_cert_error_string(err), depth, buf);
+        }
+        return ok;
 }
 
 int uwsgi_ssl_session_new_cb(SSL *ssl, SSL_SESSION *sess) {


### PR DESCRIPTION
Hi, guys. 

It looks like client authentication via SSL certificate is completely broken now. 

You provide own verification callback (uwsgi_ssl_verify_callback) to OpenSSL via SSL_CTX_set_verify function. But in this callback uwsgi always returns 1 (success). 

From OpenSSL documentation:
>If verify_callback always returns 1, the TLS/SSL handshake will not be terminated with respect to verification failures and the connection will be established. The calling process can however retrieve the error code of the last verification error using SSL_get_verify_result or by maintaining its own error storage managed by verify_callback.

Since uwsgi doesn't use SSL_get_verify_result function then it accepts ANY client certificate. It can be easily reproducible - configure uwsgi to perform client authentication via SSL certificate and send https request using certificate not signed by trusted CA. 

Also I added some basic logging of validation errors. Tell me if I should remove it. Though from my point of view it is important information that should be logged. 