### PR TITLE
Added replica set support to emperor_mongodb and fixed uwsgi_instance attribute setup

### DIFF
--- a/core/emperor.c
+++ b/core/emperor.c
@@ -2684,12 +2684,19 @@ next:
 }
 
 void uwsgi_emperor_simple_do_with_attrs(struct uwsgi_emperor_scanner *ues, char *name, char *config, time_t ts, uid_t uid, gid_t gid, char *socket_name, struct uwsgi_dyn_dict *attrs) {
-	if (!uwsgi_emperor_is_valid(name))
+	if (!uwsgi_emperor_is_valid(name)) {
+		if (attrs)
+			uwsgi_dyn_dict_free(&attrs);
 		return;
+	}
 
 	struct uwsgi_instance *ui_current = emperor_get(name);
 
 	if (ui_current) {
+		if (ui_current->attrs) {
+			uwsgi_dyn_dict_free(&ui_current->attrs);
+		}
+		ui_current->attrs = attrs;
 
 		// skip in case the instance is going down...
 		if (ui_current->status > 0)

--- a/core/utils.c
+++ b/core/utils.c
@@ -2209,6 +2209,19 @@ void uwsgi_dyn_dict_del(struct uwsgi_dyn_dict *item) {
 	free(item);
 }
 
+void uwsgi_dyn_dict_free(struct uwsgi_dyn_dict **dd) {
+	struct uwsgi_dyn_dict *attr = *dd;
+
+	while(attr) {
+		struct uwsgi_dyn_dict *tmp = attr;
+		attr = attr->next;
+		if (tmp->value) free(tmp->value);
+		free(tmp);
+	}
+
+	*dd = NULL;
+}
+
 void *uwsgi_malloc_shared(size_t size) {
 
 	void *addr = mmap(NULL, size, PROT_READ | PROT_WRITE, MAP_SHARED | MAP_ANON, -1, 0);

--- a/plugins/emperor_mongodb/emperor_mongodb.cc
+++ b/plugins/emperor_mongodb/emperor_mongodb.cc
@@ -195,6 +195,7 @@ extern "C" void uwsgi_imperial_monitor_mongodb_init2(struct uwsgi_emperor_scanne
 	uems->address = (char *) "127.0.0.1:27017";
 	uems->collection = (char *) "uwsgi.emperor.vassals";
 	uems->json = (char *) "";
+	uems->defaults = (char *) "";
 	char *args = NULL;
 	if (arg_len <= 11) goto done;
 	args = ues->arg+11;

--- a/plugins/emperor_mongodb/emperor_mongodb.cc
+++ b/plugins/emperor_mongodb/emperor_mongodb.cc
@@ -158,7 +158,7 @@ extern "C" void uwsgi_imperial_monitor_mongodb(struct uwsgi_emperor_scanner *ues
 
 // setup a new mongodb imperial monitor
 extern "C" void uwsgi_imperial_monitor_mongodb_init(struct uwsgi_emperor_scanner *ues) {
-
+	mongo::client::initialize();
 	// allocate a new state
 	ues->data = uwsgi_calloc(sizeof(struct uwsgi_emperor_mongodb_state));
 	size_t arg_len = strlen(ues->arg);

--- a/plugins/emperor_mongodb/uwsgiplugin.py
+++ b/plugins/emperor_mongodb/uwsgiplugin.py
@@ -13,5 +13,7 @@ if 'UWSGI_MONGODB_NOLIB' not in os.environ:
     LIBS.append('-lmongoclient')
     LIBS.append('-lboost_thread')
     LIBS.append('-lboost_filesystem')
+    LIBS.append('-lboost_regex')
+    
 
 GCC_LIST = ['plugin', 'emperor_mongodb.cc']

--- a/plugins/emperor_mongodb/uwsgiplugin.py
+++ b/plugins/emperor_mongodb/uwsgiplugin.py
@@ -13,7 +13,8 @@ if 'UWSGI_MONGODB_NOLIB' not in os.environ:
     LIBS.append('-lmongoclient')
     LIBS.append('-lboost_thread')
     LIBS.append('-lboost_filesystem')
+    LIBS.append('-lboost_system')
     LIBS.append('-lboost_regex')
-    
+
 
 GCC_LIST = ['plugin', 'emperor_mongodb.cc']

--- a/plugins/emperor_mongodb/uwsgiplugin.py
+++ b/plugins/emperor_mongodb/uwsgiplugin.py
@@ -4,7 +4,9 @@ NAME = 'emperor_mongodb'
 
 CFLAGS = [
     '-I/usr/include/mongo',
-    '-I/usr/local/include/mongo'
+    '-I/usr/local/include/mongo',
+    '-std=c++11',
+    '-Wno-error'
 ]
 LDFLAGS = []
 

--- a/uwsgi.h
+++ b/uwsgi.h
@@ -3616,6 +3616,7 @@ int uwsgi_simple_parse_vars(struct wsgi_request *, char *, char *);
 void uwsgi_build_mime_dict(char *);
 struct uwsgi_dyn_dict *uwsgi_dyn_dict_new(struct uwsgi_dyn_dict **, char *, int, char *, int);
 void uwsgi_dyn_dict_del(struct uwsgi_dyn_dict *);
+void uwsgi_dyn_dict_free(struct uwsgi_dyn_dict **);
 
 
 void uwsgi_apply_config_pass(char symbol, char *(*)(char *));


### PR DESCRIPTION
In emperor_mongodb plugin i added support for two arguments: replica and default. The `default` argument is used to set vassal attributes, which is not specified in document. It does not complete the required document fields (name, config and ts).

Also, i tried to make emperor_mongodb and docker plugin work together, and uncovered following problem:
If plugin tries to initialize on `vassal_before_exec` and configure something using vassal attributes, it will fail, because attribute setup is done *after* it's creation:
`uwsgi_emperor_simple_do_with_attrs` calls `uwsgi_emperor_simple_do`, which calls `emperor_add` and so on; then `ui->attrs` was set.
I rewrote `uwsgi_emperor_simple_do` and moved it's logic to `uwsgi_emperor_simple_do_with_attrs`.

I've realized that this pull request covers two different tasks too late, but i can try to split it if needed.