### PR TITLE
Changed abs to labs because offset is declared as a long

### DIFF
--- a/plugins/psgi/psgi_loader.c
+++ b/plugins/psgi/psgi_loader.c
@@ -144,7 +144,7 @@ XS(XS_input_read) {
 			else {
 				long orig_offset = 0;
 				 // first of all get the new orig_len;   
-                                offset = abs(offset);
+                                offset = labs(offset);
                                 if (offset > (long) orig_len) {
                                         new_size = offset;
 					orig_offset = offset - orig_len;


### PR DESCRIPTION
uwsgi with the psgi plugin fails to compile on OS X because offset is declared as a long, then passed to abs.

abs is defined as:

     int
     abs(int i);

where labs is defined as:

     long
     labs(long i);