### PR TITLE
post_buffering: fix bug which led to needless post-buffering to disk

### DIFF
--- a/core/protocol.c
+++ b/core/protocol.c
@@ -677,8 +677,8 @@ next:
 
 	// manage post buffering (if needed as post_file could be created before)
 	if (uwsgi.post_buffering > 0 && !wsgi_req->post_file) {
-		// read to disk if post_cl > post_buffering (it will eventually do upload progress...)
-		if (wsgi_req->post_cl >= uwsgi.post_buffering) {
+		// read to disk if post_cl > post_buffering_bufsize (it will eventually do upload progress...)
+		if (wsgi_req->post_cl >= uwsgi.post_buffering_bufsize) {
 			if (uwsgi_postbuffer_do_in_disk(wsgi_req)) {
 				return -1;
 			}

--- a/core/reader.c
+++ b/core/reader.c
@@ -89,8 +89,8 @@ void uwsgi_request_body_seek(struct wsgi_request *wsgi_req, off_t pos) {
 			wsgi_req->post_pos -= pos;
 			return;
 		}
-		if (pos >= (off_t) uwsgi.post_buffering) {
-			pos = uwsgi.post_buffering - 1;	
+		if (pos >= (off_t) uwsgi.post_buffering_bufsize) {
+			pos = uwsgi.post_buffering_bufsize - 1;
 		}
 		wsgi_req->post_pos = pos;
 	}

--- a/core/uwsgi.c
+++ b/core/uwsgi.c
@@ -584,7 +584,7 @@ static struct uwsgi_option uwsgi_base_options[] = {
 	{"no-orphans", no_argument, 0, "automatically kill workers if master dies (can be dangerous for availability)", uwsgi_opt_true, &uwsgi.no_orphans, 0},
 	{"prio", required_argument, 0, "set processes/threads priority", uwsgi_opt_set_rawint, &uwsgi.prio, 0},
 	{"cpu-affinity", required_argument, 0, "set cpu affinity", uwsgi_opt_set_int, &uwsgi.cpu_affinity, 0},
-	{"post-buffering", required_argument, 0, "enable post buffering", uwsgi_opt_set_64bit, &uwsgi.post_buffering, 0},
+	{"post-buffering", required_argument, 0, "enable post buffering and set buffer size", uwsgi_opt_set_64bit, &uwsgi.post_buffering, 0},
 	{"post-buffering-bufsize", required_argument, 0, "set buffer size for read() in post buffering mode", uwsgi_opt_set_64bit, &uwsgi.post_buffering_bufsize, 0},
 	{"body-read-warning", required_argument, 0, "set the amount of allowed memory allocation (in megabytes) for request body before starting printing a warning", uwsgi_opt_set_64bit, &uwsgi.body_read_warning, 0},
 	{"upload-progress", required_argument, 0, "enable creation of .json files in the specified directory during a file upload", uwsgi_opt_set_str, &uwsgi.upload_progress, 0},


### PR DESCRIPTION
uwsgi has two settings:
--post-buffering - enable post buffering
--post-buffering-bufsize - set buffer size for read() in post buffering mode

According to the documentation the first one is just a flag, while the
later one defines size of in-memory buffer. If request's POST data is
within this number it is buffered in memory. Otherwise, the data dumped
to disk.

However, uwsgi.post_buffering variable is used not as the flag in the
code but rather as a variable containing actual buffer size. In other
words it duplicates functionality of uwsgi.post_buffering_bufsize.
uwsgi.post_buffering and uwsgi.post_buffering_bufsize are
(semi-)synchronized in uwsgi_setup_post_buffering().

    void uwsgi_setup_post_buffering() {
        if (!uwsgi.post_buffering_bufsize)
            uwsgi.post_buffering_bufsize = 8192;

        if (uwsgi.post_buffering_bufsize < uwsgi.post_buffering) {
            uwsgi.post_buffering_bufsize = uwsgi.post_buffering;
            uwsgi_log("setting request body buffering size to %lu bytes\n",
                      (unsigned long) uwsgi.post_buffering_bufsize);
        }
    }

As you can see if uwsgi.post_buffering bigger than
uwsgi.post_buffering_bufsize theirs values are the same. However, in the
opposite case they can keep different values.

This lead to subtle issue cauing uwsgi to buffer data on disk while
there is enough preallocated memory. Here is a part of uwsgi_parse_vars():

    // manage post buffering (if needed as post_file could be created before)
    if (uwsgi.post_buffering > 0 && !wsgi_req->post_file) {
        // read to disk if post_cl > post_buffering (it will eventually do upload progress...)
        if (wsgi_req->post_cl >= uwsgi.post_buffering) {
            ...
        }
        // on tiny post use memory
        ...
    }

So, the code compares POST size against uwsgi.post_buffering, not
uwsgi.post_buffering_bufsize. And if uwsgi.post_buffering=1 (which is a
sane value since documentation says it's a flag) uwsgi dumps *all* POST
bodies to disk.

I used following way to verify the issue (perhaps not the easiest one):

    $ cat app.psgi
    my $app = sub {
        return [ '200', [ 'Content-Type' => 'text/plain' ], [ 'Hello world!' ] ];
    };

    $ python uwsgiconfig.py --build psgi
    $ TMPDIR=/none-existent-dir ./uwsgi --master --http 127.0.0.1:8080 --psgi app.psgi --post-buffering=1 --post-buffering-bufsize=1024

    (in parallel shell)
    $ wget --post-data=short-string -O- http://localhost:8080 2>/dev/null

Without the patch uwsgi generates error like

    Thu Jun 11 00:34:46 2015 - uwsgi_postbuffer_do_in_disk()/uwsgi_tmpfile(): No such file or directory [core/reader.c line 535] during POST / (127.0.0.1)

because it tried to create a temp file in none existent folder. This
should not happen because --post-buffering-bufsize is explicetly set to
1K which is big enough to keep 'short-string'.

This commit fix this issue by using uwsgi.post_buffering_bufsize in
appropriate places.

Need to note that uwsgi.post_buffering_bufsize is correctly used for
allocating the buffer.