### PR TITLE
Fixes errors with Intel compiler for 64-bit

### DIFF
--- a/core/config.c
+++ b/core/config.c
@@ -785,12 +785,14 @@ char *uwsgi_manage_placeholder(char *key) {
 
 		switch(state) {
 			case concat:
+                            {
 				if (current_value) arg1 = current_value;
 				if (value) arg2 = value;
 				char *ret = uwsgi_concat2(arg1, arg2);
 				if (current_value) free(current_value);
 				current_value = ret;	
 				break;
+                            }
 			case sum:
 				if (current_value) arg1n = strtoll(current_value, NULL, 10);
 				if (value) arg2n = strtoll(value, NULL, 10);

--- a/core/emperor.c
+++ b/core/emperor.c
@@ -791,7 +791,7 @@ static void emperor_massive_reload(int signum) {
 }
 
 
-static void emperor_stats() {
+static void emperor_stats(int sig) {
 
 	struct uwsgi_instance *c_ui = ui->ui_next;
 
@@ -1921,7 +1921,7 @@ int uwsgi_emperor_scanner_event(int fd) {
 static void emperor_wakeup(int sn) {
 }
 
-static void emperor_cleanup() {
+static void emperor_cleanup(int sig) {
 	uwsgi_log_verbose("[uwsgi-emperor] cleaning up blacklist ...\n");
 	struct uwsgi_instance *ui_current = ui;
 	while (ui_current->ui_next) {

--- a/core/fifo.c
+++ b/core/fifo.c
@@ -26,18 +26,18 @@ static char *uwsgi_fifo_by_slot() {
 
 #define announce_fifo uwsgi_log_verbose("active master fifo is now %s\n", uwsgi_fifo_by_slot())
 
-static void uwsgi_fifo_set_slot_zero() { uwsgi.master_fifo_slot = 0; announce_fifo; }
-static void uwsgi_fifo_set_slot_one() { uwsgi.master_fifo_slot = 1; announce_fifo; }
-static void uwsgi_fifo_set_slot_two() { uwsgi.master_fifo_slot = 2; announce_fifo; }
-static void uwsgi_fifo_set_slot_three() { uwsgi.master_fifo_slot = 3; announce_fifo; }
-static void uwsgi_fifo_set_slot_four() { uwsgi.master_fifo_slot = 4; announce_fifo; }
-static void uwsgi_fifo_set_slot_five() { uwsgi.master_fifo_slot = 5; announce_fifo; }
-static void uwsgi_fifo_set_slot_six() { uwsgi.master_fifo_slot = 6; announce_fifo; }
-static void uwsgi_fifo_set_slot_seven() { uwsgi.master_fifo_slot = 7; announce_fifo; }
-static void uwsgi_fifo_set_slot_eight() { uwsgi.master_fifo_slot = 8; announce_fifo; }
-static void uwsgi_fifo_set_slot_nine() { uwsgi.master_fifo_slot = 9; announce_fifo; }
+static void uwsgi_fifo_set_slot_zero(int sig) { uwsgi.master_fifo_slot = 0; announce_fifo; }
+static void uwsgi_fifo_set_slot_one(int sig) { uwsgi.master_fifo_slot = 1; announce_fifo; }
+static void uwsgi_fifo_set_slot_two(int sig) { uwsgi.master_fifo_slot = 2; announce_fifo; }
+static void uwsgi_fifo_set_slot_three(int sig) { uwsgi.master_fifo_slot = 3; announce_fifo; }
+static void uwsgi_fifo_set_slot_four(int sig) { uwsgi.master_fifo_slot = 4; announce_fifo; }
+static void uwsgi_fifo_set_slot_five(int sig) { uwsgi.master_fifo_slot = 5; announce_fifo; }
+static void uwsgi_fifo_set_slot_six(int sig) { uwsgi.master_fifo_slot = 6; announce_fifo; }
+static void uwsgi_fifo_set_slot_seven(int sig) { uwsgi.master_fifo_slot = 7; announce_fifo; }
+static void uwsgi_fifo_set_slot_eight(int sig) { uwsgi.master_fifo_slot = 8; announce_fifo; }
+static void uwsgi_fifo_set_slot_nine(int sig) { uwsgi.master_fifo_slot = 9; announce_fifo; }
 
-static void subscriptions_blocker() {
+static void subscriptions_blocker(int sig) {
 	if (uwsgi.subscriptions_blocked) {
 		uwsgi_log_verbose("subscriptions re-enabled\n");
 		uwsgi.subscriptions_blocked = 0;
@@ -48,7 +48,7 @@ static void subscriptions_blocker() {
 	}
 }
 
-static void emperor_rescan() {
+static void emperor_rescan(int sig) {
 	if (uwsgi.emperor_pid > 0) {
 		if (kill(uwsgi.emperor_pid, SIGWINCH)) {
 			uwsgi_error("emperor_rescan()/kill()");

--- a/core/master_utils.c
+++ b/core/master_utils.c
@@ -2,7 +2,7 @@
 
 extern struct uwsgi_server uwsgi;
 
-void worker_wakeup() {
+void worker_wakeup(int sig) {
 }
 
 uint64_t uwsgi_worker_exceptions(int wid) {

--- a/core/spooler.c
+++ b/core/spooler.c
@@ -14,7 +14,7 @@ static void spooler_manage_task(struct uwsgi_spooler *, char *, char *);
 static uint64_t wakeup = 0;
 
 // function to allow waking up the spooler if blocked in event_wait
-void spooler_wakeup() {
+void spooler_wakeup(int sig) {
 	wakeup++;
 }
 

--- a/plugins/cache/cache.c
+++ b/plugins/cache/cache.c
@@ -263,6 +263,7 @@ static int uwsgi_cache_request(struct wsgi_request *wsgi_req) {
                         }
                         break;
 		case 6:
+                {
 			// dump
 			uc = uwsgi.caches;
 			if (wsgi_req->uh->_pktsize > 0) {
@@ -298,6 +299,7 @@ static int uwsgi_cache_request(struct wsgi_request *wsgi_req) {
 			uwsgi_response_write_body_do(wsgi_req, cache_dump->buf, cache_dump->pos);
 			uwsgi_buffer_destroy(cache_dump);
 			break;
+                }
 		case 17:
 			if (wsgi_req->uh->_pktsize == 0) break;
 			memset(&ucmc, 0, sizeof(struct uwsgi_cache_magic_context));

--- a/plugins/gevent/gevent.c
+++ b/plugins/gevent/gevent.c
@@ -385,7 +385,7 @@ static void gil_gevent_get() {
 }
 
 static void gil_gevent_release() {
-	PyGILState_Release((PyGILState_STATE) pthread_getspecific(up.upt_gil_key));
+	PyGILState_Release((PyGILState_STATE)(unsigned long) pthread_getspecific(up.upt_gil_key));
 }
 
 static void monkey_patch() {


### PR DESCRIPTION
Fixes some Intel compiler errors for 64-bit on Linux 

`core/spooler.c(105): error #167: argument of type "void (*)()" is incompatible with parameter of type "void (*)(int)"`
`                uwsgi_unix_signal(SIGUSR1, spooler_wakeup);`

`core/fifo.c(97): error #556: a value of type "void (*)()" cannot be assigned to an entity of type "void (*)(int)"`
`        uwsgi_fifo_table['S'] = subscriptions_blocker;`

`plugins/cache/cache.c(208): error #589: transfer of control bypasses initialization of:`
`            variable "cache_dump" (declared at line 275)`

`[thread 5][icc] core/sigplugins/gevent/gevent.c(369): error #810: conversion from "void *" to "PyGILState_STATE={enum <unnamed>}" may lose significant bits`
`        PyGILState_Release((PyGILState_STATE) pthread_getspecific(up.upt_gil_key));`