### PR TITLE
Check whether *value is indeed an SvRV before casting it

### DIFF
--- a/plugins/psgi/psgi_loader.c
+++ b/plugins/psgi/psgi_loader.c
@@ -285,7 +285,7 @@ nonworker:
 				uwsgi_log("[perl] WARNING !!! unable to build uwsgi::opt hash !!!\n");
 				goto end;
 			}
-			if (SvTYPE(SvRV(*value)) == SVt_PVAV) {
+			if (SvROK(*value) && SvTYPE(SvRV(*value)) == SVt_PVAV) {
 				if (uwsgi.exported_opts[i]->value == NULL) {
                                         av_push((AV *)SvRV(*value), newSViv(1));
                                 }


### PR DESCRIPTION
I compiled uwsgi with psgi and ran it, and it segfaulted. Apparently, line 288 of plugins/psgi/psgi_loader.c casts *value to a SvRV and tries to get its type, even when *value is not an SvRV.