### PR TITLE
Fix pypy-setup on OSX

### DIFF
--- a/plugins/pypy/pypy_plugin.c
+++ b/plugins/pypy/pypy_plugin.c
@@ -167,15 +167,6 @@ ready:
 	if (upypy.setup) {
 		buffer = uwsgi_open_and_read(upypy.setup, &rlen, 1, NULL);
 	}
-#if defined(__APPLE__)
-	else {
-		unsigned long setup_size = 0;
-		char *setup_data = (char*)getsectiondata(&_mh_execute_header, "__DATA", "pypy_setup", &setup_size);
-		if (setup_data) {
-			buffer = uwsgi_concat2n(setup_data, setup_size, "", 0);
-		}
-	}
-#else
 	else {
 		char *start = dlsym(RTLD_DEFAULT, "uwsgi_pypy_setup_start");
 		if (!start) {
@@ -188,8 +179,16 @@ ready:
 		if (start && end) {
 			buffer = uwsgi_concat2n(start, end-start, "", 0);
 		}
-	}
+#if defined(__APPLE__)
+		else {
+			unsigned long setup_size = 0;
+			char *setup_data = (char*)getsectiondata(&_mh_execute_header, "__DATA", "pypy_setup", &setup_size);
+			if (setup_data) {
+				buffer = uwsgi_concat2n(setup_data, setup_size, "", 0);
+			}
+		}
 #endif
+	}
 
 	if (!buffer) {
 		uwsgi_log("you have to load a pypy setup file with --pypy-setup\n");

--- a/plugins/pypy/pypy_plugin.c
+++ b/plugins/pypy/pypy_plugin.c
@@ -167,6 +167,15 @@ ready:
 	if (upypy.setup) {
 		buffer = uwsgi_open_and_read(upypy.setup, &rlen, 1, NULL);
 	}
+#if defined(__APPLE__)
+	else {
+		unsigned long setup_size = 0;
+		char *setup_data = (char*)getsectiondata(&_mh_execute_header, "__DATA", "pypy_setup", &setup_size);
+		if (setup_data) {
+			buffer = uwsgi_concat2n(setup_data, setup_size, "", 0);
+		}
+	}
+#else
 	else {
 		char *start = dlsym(RTLD_DEFAULT, "uwsgi_pypy_setup_start");
 		if (!start) {
@@ -180,6 +189,7 @@ ready:
 			buffer = uwsgi_concat2n(start, end-start, "", 0);
 		}
 	}
+#endif
 
 	if (!buffer) {
 		uwsgi_log("you have to load a pypy setup file with --pypy-setup\n");

--- a/plugins/pypy/pypy_setup.py
+++ b/plugins/pypy/pypy_setup.py
@@ -24,13 +24,13 @@ ssize_t read(int, void *, size_t);
 ssize_t write(int, const void *, size_t);
 int close(int);
 
-void (*uwsgi_pypy_hook_execute_source)(char *);
-void (*uwsgi_pypy_hook_loader)(char *);
-void (*uwsgi_pypy_hook_file_loader)(char *);
-void (*uwsgi_pypy_hook_paste_loader)(char *);
-void (*uwsgi_pypy_hook_pythonpath)(char *);
-void (*uwsgi_pypy_hook_request)(struct wsgi_request *);
-void (*uwsgi_pypy_post_fork_hook)(void);
+extern void (*uwsgi_pypy_hook_execute_source)(char *);
+extern void (*uwsgi_pypy_hook_loader)(char *);
+extern void (*uwsgi_pypy_hook_file_loader)(char *);
+extern void (*uwsgi_pypy_hook_paste_loader)(char *);
+extern void (*uwsgi_pypy_hook_pythonpath)(char *);
+extern void (*uwsgi_pypy_hook_request)(struct wsgi_request *);
+extern void (*uwsgi_pypy_post_fork_hook)(void);
 '''
 
 # here we load CFLAGS and uwsgi.h from the binary

--- a/uwsgi.h
+++ b/uwsgi.h
@@ -275,6 +275,8 @@ extern int pivot_root(const char *new_root, const char *put_old);
 #define MAC_OS_X_VERSION_MIN_REQUIRED MAC_OS_X_VERSION_10_4
 #endif
 #include <mach-o/dyld.h>
+#include <mach-o/getsect.h>
+#include <mach-o/ldsyms.h>
 #endif
 
 #include <dlfcn.h>


### PR DESCRIPTION
- `ld` on OSX does not support the `-b` flag, so use `-sectcreate` to embed the Python resource in the executable
- Mach-o section names are truncated to 16 characters, so remove the `_uwsgi_` prefix
- Use `getsectiondata()` to load the Python resource from the new section
- Compile the CFFI lib with hooks declared `extern` to ensure the correct pointers are referenced from the Python script

The PyPy plugin is not able to load the default pypy-setup script on OSX. This fixes the bug.