### PR TITLE
load python mule from callable, eg. --mule=package.module:callable

### DIFF
--- a/plugins/python/python_plugin.c
+++ b/plugins/python/python_plugin.c
@@ -1821,6 +1821,20 @@ int uwsgi_python_mule(char *opt) {
 		UWSGI_RELEASE_GIL;
 		return 1;
 	}
+    else if (strchr(opt, ':')) {
+        UWSGI_GET_GIL;
+        PyObject *result = NULL;
+        PyObject *arglist = Py_BuildValue("()");
+        PyObject *callable = up.loaders[LOADER_MOUNT](opt);
+        if (callable) {
+            result = PyEval_CallObject(callable, arglist);
+        }
+        Py_XDECREF(result);
+        Py_XDECREF(arglist);
+        Py_XDECREF(callable);
+        UWSGI_RELEASE_GIL;
+        return 1;
+    }
 	
 	return 0;
 	


### PR DESCRIPTION
closer to `--mount` and simpler to work with! entry points are defined by apps instead of clobbering `__main__`