### PR TITLE
lua_plugin: --lazy-apps, --threads and other

### DIFF
--- a/plugins/lua/lua_plugin.c
+++ b/plugins/lua/lua_plugin.c
@@ -1230,7 +1230,7 @@ static void uwsgi_lua_hijack(void) {
 static void uwsgi_lua_init_apps() {
 	int i;
 
-	if (uwsgi.lazy || uwsgi.lazy_apps) {
+	if (uwsgi.mywid > 0) {
 		uwsgi_lua_init_state(uwsgi.mywid);
 	} else {
 		for(i=1;i<=uwsgi.numproc;i++){

--- a/plugins/lua/lua_plugin.c
+++ b/plugins/lua/lua_plugin.c
@@ -99,8 +99,8 @@ static int uwsgi_api_rpc(lua_State *L) {
 		
 	if (argc > 0) {
 		uint8_t i;
-		argv = (char **) uwsgi_malloc(sizeof(char **)*argc);
-		argvs = (uint16_t *) uwsgi_malloc(sizeof(uint16_t *)*argc);
+		argv = (char **) uwsgi_malloc(sizeof(char *)*argc);
+		argvs = (uint16_t *) uwsgi_malloc(sizeof(uint16_t)*argc);
 		
 		for(i = 0; i < argc; i++) {
 			argv[i] = (char *) lua_tolstring(L, i + 3, (size_t *) &argvs[i]); 
@@ -718,7 +718,7 @@ static int uwsgi_lua_init(){
 	ulua.wsapi_ref = uwsgi_malloc(sizeof(int) * uwsgi.numproc);
 	
 	for (i=0;i<uwsgi.numproc;i++) {
-		ulua.state[i] = uwsgi_malloc(sizeof(lua_State**) * uwsgi.cores);
+		ulua.state[i] = uwsgi_malloc(sizeof(lua_State*) * uwsgi.cores);
 	}
 	
 	uwsgi_log("%d lua_States (with %d lua_Threads)\n", uwsgi.numproc, uwsgi.cores);


### PR DESCRIPTION
our workers now init lua states on .post_fork:
- better rpc/signal registration logic
- faster loading (mutlicpu)
- avoiding some strange seg_fault event during heavy load (oops that was luajit-2.1alpha's problem)
- worker respawn also respawns lua_state

Also:
- our app can now work without wsapi app, it will just send 500 error code
- detecting dead coroutines in async mode without additional switch
- 'lua-gc-full = 1' option to perform a full gc instead of incremental