### PR TITLE
plugins/greenlet: hack on uwsgiconfig.py to support venv

### DIFF
--- a/plugins/greenlet/greenlet.c
+++ b/plugins/greenlet/greenlet.c
@@ -1,5 +1,9 @@
 #include "../python/uwsgi_python.h"
+#ifndef GREENLET_HEADER_HACK
 #include <greenlet/greenlet.h>
+#else
+#include <greenlet.h>
+#endif
 
 extern struct uwsgi_server uwsgi;
 extern struct uwsgi_python up;

--- a/uwsgiconfig.py
+++ b/uwsgiconfig.py
@@ -1279,6 +1279,13 @@ class uConf(object):
         if self.get('unbit'):
             self.cflags.append("-DUNBIT")
 
+        if 'VIRTUAL_ENV' in os.environ:
+            venv_include = '{0}/include/site/python{1}.{2}'.format(
+                sys.prefix, sys.version_info.major, sys.version_info.minor)
+            self.cflags.append('-I{0}'.format(venv_include))
+            self.include_path.append(venv_include)
+            if self.has_include('greenlet.h'):
+                self.cflags.append("-DGREENLET_HEADER_HACK")
         return self.gcc_list, self.cflags, self.ldflags, self.libs
 
 


### PR DESCRIPTION
Either <greenlet.h> or <greenlet/greenlet.h> is available would be
tested in uwsgiconfig.py. Then tune plugins/greenlet/greenlet.c to
include the correct one by c macro.

With system repo provided python-greenlet-dev or equivalent greenlet.h 
is available at <greenlet/greenlet.h>. In contrast a virtual environment
pip installed greenlet would provide greenlet.h as <greenlet.h>. This is
the reason current uwsgi would always fail to build with 
`UWSGI_PROFILE='asyncio' pip install uwsgi` in a venv.