### PR TITLE
Allow call uwsgi websocket API in other greenlet (NOT the main callable)

### DIFF
--- a/plugins/python/uwsgi_python.h
+++ b/plugins/python/uwsgi_python.h
@@ -307,6 +307,8 @@ void uwsgi_python_set_thread_name(int);
 				return PyErr_Format(PyExc_SystemError, "you can call uwsgi api function only from the main callable");\
 			}
 
+PyObject *py_current_wsgi_req_with_input(struct wsgi_request **, PyObject *);
+
 #define uwsgi_pyexit {PyErr_Print();exit(1);}
 
 #ifdef __linux__

--- a/tests/websockets_chat_2.py
+++ b/tests/websockets_chat_2.py
@@ -1,0 +1,145 @@
+#!./uwsgi --http-socket :9090  --http-raw-body --gevent 100 --module tests.websockets_chat_2
+import uwsgi
+import time
+
+import gevent
+from gevent.queue import Queue
+
+class ClientManager(object):
+    clients = set()
+
+    @classmethod
+    def add(cls, client):
+        cls.clients.add(client)
+
+    @classmethod
+    def remove(cls, client):
+        cls.clients.remove(client)
+
+    @classmethod
+    def count(cls):
+        return len(cls.clients)
+
+    @classmethod
+    def broadcast(cls, data):
+        data = "{0} {1}".format(time.time(), data)
+        def do_broadcast():
+            for c in cls.clients:
+                c.send(data)
+
+        gevent.spawn(do_broadcast)
+
+
+class Client(object):
+    def __init__(self):
+        self.uwsgi_input = None
+        self.send_queue = Queue()
+        self.jobs = []
+
+
+    def _recv_job(self):
+        while True:
+            data = uwsgi.websocket_recv(uwsgi_input=self.uwsgi_input)
+            self.on_data(data)
+
+    def _send_job(self):
+        while True:
+            data = self.send_queue.get()
+            uwsgi.websocket_send(data, uwsgi_input=self.uwsgi_input)
+
+    def _exit(self, *args):
+        for j in self.jobs:
+            j.unlink(self._exit)
+
+        gevent.killall(self.jobs)
+        ClientManager.remove(self)
+        self.on_exit()
+
+
+    def on_data(self, data):
+        print "GOT: {0}".format(data)
+        ClientManager.broadcast(data)
+
+
+    def on_exit(self):
+        print "bye bye..."
+
+
+    def send(self, data):
+        self.send_queue.put(data)
+
+
+    def start(self):
+        uwsgi.websocket_handshake()
+        self.uwsgi_input = uwsgi.input_object()
+
+        ClientManager.add(self)
+
+        self.jobs.extend([
+            gevent.spawn(self._recv_job),
+            gevent.spawn(self._send_job),
+        ])
+
+        for j in self.jobs:
+            j.link(self._exit)
+
+        gevent.joinall(self.jobs)
+
+
+
+
+def application(env, sr):
+
+    ws_scheme = 'ws'
+    if 'HTTPS' in env or env['wsgi.url_scheme'] == 'https':
+        ws_scheme = 'wss'
+
+    if env['PATH_INFO'] == '/':
+        sr('200 OK', [('Content-Type', 'text/html')])
+        return """
+    <html>
+      <head>
+          <script language="Javascript">
+            var s = new WebSocket("%s://%s/foobar/");
+            s.onopen = function() {
+              alert("connected !!!");
+              s.send("ciao");
+            };
+            s.onmessage = function(e) {
+                var bb = document.getElementById('blackboard')
+                var html = bb.innerHTML;
+                bb.innerHTML = html + '<br/>' + e.data;
+            };
+
+            s.onerror = function(e) {
+                        alert(e);
+                }
+
+        s.onclose = function(e) {
+                alert("connection closed");
+        }
+
+            function invia() {
+              var value = document.getElementById('testo').value;
+              s.send(value);
+            }
+          </script>
+     </head>
+    <body>
+        <h1>WebSocket</h1>
+        <input type="text" id="testo"/>
+        <input type="button" value="invia" onClick="invia();"/>
+        <div id="blackboard" style="width:640px;height:480px;background-color:black;color:white;border: solid 2px red;overflow:auto">
+        </div>
+    </body>
+    </html>
+        """ % (ws_scheme, env['HTTP_HOST'])
+    elif env['PATH_INFO'] == '/favicon.ico':
+        return ""
+    elif env['PATH_INFO'] == '/foobar/':
+        print "websockets..."
+        client = Client()
+        client.start()
+
+        return ""
+


### PR DESCRIPTION
I add this feature for using uwsgi websocket with gevent more easy and convenient.

SEE  tests/websockets_chat_2.py 


Add a new API uwsgi.input_object() for get `uwsgi_Input` object in Python.
Modify uwsgi.websocket_recv/recv_nb/send/send_binary, add a kwarg: `uwsgi_input`.

If not provide the `uwsgi_input` kwarg, This function's behavior not changed.
When provide the `uwsgi_input` kwarg, This function will find `wsgi_req` from the `uwsgi_input`.

In this way, uwsgi websocket functions can be used in other greenlets.


NOTE:  uwsgi.websocket_handshake, uwsgi.input_object can only call from the main callback.