### PR TITLE
lua: Fix malloc allocation size mismatch

### DIFF
--- a/plugins/lua/lua_plugin.c
+++ b/plugins/lua/lua_plugin.c
@@ -718,7 +718,7 @@ static int uwsgi_lua_init(){
 	int i;
 	
 	for(i=0;i<uwsgi.numproc;i++) {
-		ulua.state[i] = (lua_State**) uwsgi_malloc( sizeof(lua_State**) * uwsgi.cores );
+		ulua.state[i] = (lua_State**) uwsgi_malloc( sizeof(lua_State*) * uwsgi.cores );
 	}
 	
 	uwsgi_log("%d lua_States (with %d lua_Threads)\n", uwsgi.numproc, uwsgi.cores);

--- a/plugins/lua/lua_plugin.c
+++ b/plugins/lua/lua_plugin.c
@@ -98,8 +98,8 @@ static int uwsgi_api_rpc(lua_State *L) {
 		
 	if (argc > 0) {
 		uint8_t i;
-		argv = (char **) uwsgi_malloc(sizeof(char **)*argc);
-		argvs = (uint16_t *) uwsgi_malloc(sizeof(uint16_t *)*argc);
+		argv = (char **) uwsgi_malloc(sizeof(char *)*argc);
+		argvs = (uint16_t *) uwsgi_malloc(sizeof(uint16_t)*argc);
 		
 		for(i = 0; i < argc; i++) {
 			argv[i] = (char *) lua_tolstring(L, i + 3, (size_t *) &argvs[i]); 


### PR DESCRIPTION
argv is of type char** so it should its size should be the size of
n char pointers. argvs instead is of type uint16_t * so its size
should be of an array of uint16_t.

This has been only compile tested.