### PR TITLE
systemd_logger: fix build with recent systemd

### DIFF
--- a/plugins/systemd_logger/uwsgiplugin.py
+++ b/plugins/systemd_logger/uwsgiplugin.py
@@ -3,6 +3,8 @@ import os
 NAME = 'systemd_logger'
 
 CFLAGS = os.popen('pkg-config --cflags libsystemd-journal').read().rstrip().split()
+CFLAGS += os.popen('pkg-config --cflags libsystemd').read().rstrip().split()
 LDFLAGS = []
 LIBS = os.popen('pkg-config --libs libsystemd-journal').read().rstrip().split()
+LIBS += os.popen('pkg-config --libs libsystemd').read().rstrip().split()
 GCC_LIST = ['systemd_logger']


### PR DESCRIPTION
Since systemd 209 all the functionalities of libsystemd-* have
been merged in libsystemd.