### PR TITLE
Patch spooler signal as task

### DIFF
--- a/core/signal.c
+++ b/core/signal.c
@@ -467,8 +467,7 @@ cycle:
 	return received_signal;
 }
 
-void uwsgi_receive_signal(struct wsgi_request *wsgi_req, int fd, char *name, int id) {
-
+pid_t uwsgi_receive_signal(struct wsgi_request *wsgi_req, int fd, char *name, int id) {
 	uint8_t uwsgi_signal;
 
 	ssize_t ret = read(fd, &uwsgi_signal, 1);
@@ -487,13 +486,15 @@ void uwsgi_receive_signal(struct wsgi_request *wsgi_req, int fd, char *name, int
 		if (uwsgi_signal_handler(wsgi_req, uwsgi_signal)) {
 			uwsgi_log_verbose("error managing signal %d on %s %d\n", uwsgi_signal, name, id);
 		}
+		return getpid();
 	}
 
-	return;
+	return -1;
 
 destroy:
 	// better to kill the whole worker...
 	uwsgi_log_verbose("uWSGI %s %d screams: UAAAAAAH my master disconnected: I will kill myself!!!\n", name, id);
 	end_me(0);
-
+	// never here
+	return -1;
 }

--- a/core/signal.c
+++ b/core/signal.c
@@ -467,7 +467,7 @@ cycle:
 	return received_signal;
 }
 
-pid_t uwsgi_receive_signal(struct wsgi_request *wsgi_req, int fd, char *name, int id) {
+int uwsgi_receive_signal(struct wsgi_request *wsgi_req, int fd, char *name, int id) {
 	uint8_t uwsgi_signal;
 
 	ssize_t ret = read(fd, &uwsgi_signal, 1);
@@ -486,15 +486,15 @@ pid_t uwsgi_receive_signal(struct wsgi_request *wsgi_req, int fd, char *name, in
 		if (uwsgi_signal_handler(wsgi_req, uwsgi_signal)) {
 			uwsgi_log_verbose("error managing signal %d on %s %d\n", uwsgi_signal, name, id);
 		}
-		return getpid();
+		return 1;
 	}
 
-	return -1;
+	return 0;
 
 destroy:
 	// better to kill the whole worker...
 	uwsgi_log_verbose("uWSGI %s %d screams: UAAAAAAH my master disconnected: I will kill myself!!!\n", name, id);
 	end_me(0);
 	// never here
-	return -1;
+	return 0;
 }

--- a/core/spooler.c
+++ b/core/spooler.c
@@ -423,8 +423,6 @@ void spooler(struct uwsgi_spooler *uspool) {
 
 	int spooler_event_queue = event_queue_init();
 	int interesting_fd = -1;
-	// determining which spooler process is working on signal events
-	pid_t working_spooler_pid = -1;
 
 	if (uwsgi.master_process) {
 		event_queue_add_fd_read(spooler_event_queue, uwsgi.shared->spooler_signal_pipe[1]);
@@ -467,8 +465,7 @@ void spooler(struct uwsgi_spooler *uspool) {
 		if (event_queue_wait(spooler_event_queue, timeout, &interesting_fd) > 0) {
 			if (uwsgi.master_process) {
 				if (interesting_fd == uwsgi.shared->spooler_signal_pipe[1]) {
-					working_spooler_pid = uwsgi_receive_signal(NULL, interesting_fd, "spooler", (int) getpid());
-					if (uwsgi.spooler_signal_as_task && working_spooler_pid == uwsgi.mypid) {
+					if (uwsgi_receive_signal(NULL, interesting_fd, "spooler", (int) getpid())) {
 					    uspool->tasks++;
 					    if (uwsgi.spooler_max_tasks > 0 && uspool->tasks >= (uint64_t) uwsgi.spooler_max_tasks) {
 					        uwsgi_log("[spooler %s pid: %d] maximum number of tasks reached (%d) recycling ...\n", uspool->dir, (int) uwsgi.mypid, uwsgi.spooler_max_tasks);

--- a/core/spooler.c
+++ b/core/spooler.c
@@ -423,6 +423,8 @@ void spooler(struct uwsgi_spooler *uspool) {
 
 	int spooler_event_queue = event_queue_init();
 	int interesting_fd = -1;
+	// determining which spooler process is working on signal events
+	pid_t working_spooler_pid = -1;
 
 	if (uwsgi.master_process) {
 		event_queue_add_fd_read(spooler_event_queue, uwsgi.shared->spooler_signal_pipe[1]);
@@ -465,7 +467,14 @@ void spooler(struct uwsgi_spooler *uspool) {
 		if (event_queue_wait(spooler_event_queue, timeout, &interesting_fd) > 0) {
 			if (uwsgi.master_process) {
 				if (interesting_fd == uwsgi.shared->spooler_signal_pipe[1]) {
-					uwsgi_receive_signal(NULL, interesting_fd, "spooler", (int) getpid());
+					working_spooler_pid = uwsgi_receive_signal(NULL, interesting_fd, "spooler", (int) getpid());
+					if (uwsgi.spooler_signal_as_task && working_spooler_pid == uwsgi.mypid) {
+					    uspool->tasks++;
+					    if (uwsgi.spooler_max_tasks > 0 && uspool->tasks >= (uint64_t) uwsgi.spooler_max_tasks) {
+					        uwsgi_log("[spooler %s pid: %d] maximum number of tasks reached (%d) recycling ...\n", uspool->dir, (int) uwsgi.mypid, uwsgi.spooler_max_tasks);
+					        end_me(0);
+					    }
+					}
 				}
 			}
 		}

--- a/core/spooler.c
+++ b/core/spooler.c
@@ -466,10 +466,12 @@ void spooler(struct uwsgi_spooler *uspool) {
 			if (uwsgi.master_process) {
 				if (interesting_fd == uwsgi.shared->spooler_signal_pipe[1]) {
 					if (uwsgi_receive_signal(NULL, interesting_fd, "spooler", (int) getpid())) {
-					    uspool->tasks++;
-					    if (uwsgi.spooler_max_tasks > 0 && uspool->tasks >= (uint64_t) uwsgi.spooler_max_tasks) {
-					        uwsgi_log("[spooler %s pid: %d] maximum number of tasks reached (%d) recycling ...\n", uspool->dir, (int) uwsgi.mypid, uwsgi.spooler_max_tasks);
-					        end_me(0);
+					    if (uwsgi.spooler_signal_as_task) {
+					        uspool->tasks++;
+					        if (uwsgi.spooler_max_tasks > 0 && uspool->tasks >= (uint64_t) uwsgi.spooler_max_tasks) {
+					            uwsgi_log("[spooler %s pid: %d] maximum number of tasks reached (%d) recycling ...\n", uspool->dir, (int) uwsgi.mypid, uwsgi.spooler_max_tasks);
+					            end_me(0);
+					        }
 					    }
 					}
 				}

--- a/core/uwsgi.c
+++ b/core/uwsgi.c
@@ -326,6 +326,7 @@ static struct uwsgi_option uwsgi_base_options[] = {
 	{"spooler-processes", required_argument, 0, "set the number of processes for spoolers", uwsgi_opt_set_int, &uwsgi.spooler_numproc, UWSGI_OPT_IMMEDIATE},
 	{"spooler-quiet", no_argument, 0, "do not be verbose with spooler tasks", uwsgi_opt_true, &uwsgi.spooler_quiet, 0},
 	{"spooler-max-tasks", required_argument, 0, "set the maximum number of tasks to run before recycling a spooler", uwsgi_opt_set_int, &uwsgi.spooler_max_tasks, 0},
+	{"spooler-signal-as-task", no_argument, 0, "treat signal events as tasks in spooler, combine used with spooler-max-tasks", uwsgi_opt_true, &uwsgi.spooler_signal_as_task, 0},
 	{"spooler-harakiri", required_argument, 0, "set harakiri timeout for spooler tasks", uwsgi_opt_set_int, &uwsgi.harakiri_options.spoolers, 0},
 	{"spooler-frequency", required_argument, 0, "set spooler frequency", uwsgi_opt_set_int, &uwsgi.spooler_frequency, 0},
 	{"spooler-freq", required_argument, 0, "set spooler frequency", uwsgi_opt_set_int, &uwsgi.spooler_frequency, 0},

--- a/uwsgi.h
+++ b/uwsgi.h
@@ -2374,6 +2374,7 @@ struct uwsgi_server {
 	int spooler_ordered;
 	int spooler_quiet;
 	int spooler_frequency;
+	int spooler_signal_as_task;
 
 	int snmp;
 	char *snmp_addr;
@@ -4000,7 +4001,7 @@ int uwsgi_is_file2(char *, struct stat *);
 int uwsgi_is_dir(char *);
 int uwsgi_is_link(char *);
 
-void uwsgi_receive_signal(struct wsgi_request *, int, char *, int);
+pid_t uwsgi_receive_signal(struct wsgi_request *, int, char *, int);
 void uwsgi_exec_atexit(void);
 
 struct uwsgi_stats {

--- a/uwsgi.h
+++ b/uwsgi.h
@@ -2374,7 +2374,7 @@ struct uwsgi_server {
 	int spooler_ordered;
 	int spooler_quiet;
 	int spooler_frequency;
-	int spooler_signal_as_task;
+
 
 	int snmp;
 	char *snmp_addr;
@@ -2809,6 +2809,8 @@ struct uwsgi_server {
 
 	char *emperor_trigger_socket;
 	int emperor_trigger_socket_fd;
+
+    int spooler_signal_as_task;
 };
 
 struct uwsgi_rpc {
@@ -4001,7 +4003,7 @@ int uwsgi_is_file2(char *, struct stat *);
 int uwsgi_is_dir(char *);
 int uwsgi_is_link(char *);
 
-pid_t uwsgi_receive_signal(struct wsgi_request *, int, char *, int);
+int uwsgi_receive_signal(struct wsgi_request *, int, char *, int);
 void uwsgi_exec_atexit(void);
 
 struct uwsgi_stats {


### PR DESCRIPTION
## Background

We heavily use uWSGI  in our products.
There are many jobs managed by uWSGI cron system. 
this jobs are run in spooler.
so the workers can handle requests from our clients efficiently.

## Problem

Some job will loads a lots of data in memory,  In this case, 
the spooler processes will use lots of memory.

Like this:

![memory-day1](https://cloud.githubusercontent.com/assets/2081686/9336414/0fd60fe0-460c-11e5-92ef-4b8f3645bd42.png)

We want to spooler auto restart like workers, (limit-as ...)
We find an option  `spooler-max-tasks`   in the [doc](http://uwsgi-docs.readthedocs.org/en/latest/Spooler.html)

But, unfortunately, it only works for spool tasks. 

## Solution
This patch introduce a new option `spooler-signal-as-task`.
when set this option, uwsgi will treat signal events (cron, timer) as tasks.
when the `signal events times + tasks times >= spooler-max-tasks`, 
the spool process will restart, to alleviate memory leaks.


## Example
#### app.py

```python
# -*- coding: utf-8 -*-

import os
import time
import arrow
from bottle import Bottle

import uwsgidecorators

now = lambda: arrow.now().format("YYYY-MM-DD HH:mm:ss")

@uwsgidecorators.cron(-1, -1, -1, -1, -1, target="spooler")
def mycron(signum):
    print "[PYTHON CRON] {0}. PID {1}".format(now(), os.getpid())
    time.sleep(5)
    print "[PYTHON CRON] done"

@uwsgidecorators.timer(20, target="spooler")
def mytimer(signum):
    print "[PYTHON TIMER] {0}, PID {1}".format(now(), os.getpid())
    time.sleep(5)
    print "[PYTHON TIMER] done"


application = Bottle()

@application.get("/")
def index():
    return "OK"
```
#### uwsgi.ini

```
[uwsgi]
module = app:application
master = true
processes = 1

http = 0.0.0.0:8000
spooler = .
spooler-processes = 4
spooler-max-tasks = 2
spooler-signal-as-task = true
```

#### log

```
*** Operational MODE: single process ***
[uwsgi-signal] signum 0 registered (wid: 0 modifier1: 0 target: spooler)
[uwsgi-signal] signum 1 registered (wid: 0 modifier1: 0 target: spooler)
WSGI app 0 (mountpoint='') ready in 0 seconds on interpreter 0x9d00948 pid: 9746 (default app)
*** uWSGI is running in multiple interpreter mode ***
spawned uWSGI master process (pid: 9746)
spawned the uWSGI spooler on dir /home/wang/learn/uwsgi/spool with pid 9747
spawned the uWSGI spooler on dir /home/wang/learn/uwsgi/spool with pid 9748
spawned the uWSGI spooler on dir /home/wang/learn/uwsgi/spool with pid 9749
spawned the uWSGI spooler on dir /home/wang/learn/uwsgi/spool with pid 9750
spawned uWSGI worker 1 (pid: 9751, cores: 1)
spawned uWSGI http 1 (pid: 9752)
[PYTHON CRON] 2015-08-19 00:59:48. PID 9748
[PYTHON CRON] done
[PYTHON TIMER] 2015-08-19 01:00:07, PID 9748
[PYTHON TIMER] done
[spooler /home/wang/learn/uwsgi/spool pid: 9748] maximum number of tasks reached (2) recycling ...
OOOPS the spooler is no more...trying respawn...
spawned the uWSGI spooler on dir /home/wang/learn/uwsgi/spool with pid 9753
[PYTHON TIMER] 2015-08-19 01:00:27, PID 9750
[PYTHON TIMER] done
[PYTHON TIMER] 2015-08-19 01:00:47, PID 9753
[PYTHON CRON] 2015-08-19 01:00:48. PID 9749
[PYTHON TIMER] done
[PYTHON CRON] done
[PYTHON TIMER] 2015-08-19 01:01:07, PID 9750
[PYTHON TIMER] done
[spooler /home/wang/learn/uwsgi/spool pid: 9750] maximum number of tasks reached (2) recycling ...
OOOPS the spooler is no more...trying respawn...
spawned the uWSGI spooler on dir /home/wang/learn/uwsgi/spool with pid 9760
[PYTHON TIMER] 2015-08-19 01:01:27, PID 9753
[PYTHON TIMER] done
[spooler /home/wang/learn/uwsgi/spool pid: 9753] maximum number of tasks reached (2) recycling ...
OOOPS the spooler is no more...trying respawn...
spawned the uWSGI spooler on dir /home/wang/learn/uwsgi/spool with pid 9763
```




