### PR TITLE
Pass LIBDIR to linker in Python plugin

### DIFF
--- a/plugins/python/uwsgiplugin.py
+++ b/plugins/python/uwsgiplugin.py
@@ -71,11 +71,14 @@ if 'UWSGI_PYTHON_NOLIB' not in os.environ:
             LIBS.append('-lutil')
     else:
         try:
-            LDFLAGS.append("-L%s" % sysconfig.get_config_var('LIBDIR'))
-            os.environ['LD_RUN_PATH'] = "%s" % (sysconfig.get_config_var('LIBDIR'))
+            libdir = sysconfig.get_config_var('LIBDIR')
         except:
-            LDFLAGS.append("-L%s/lib" % sysconfig.PREFIX)
-            os.environ['LD_RUN_PATH'] = "%s/lib" % sysconfig.PREFIX
+            libdir = "%s/lib" % sysconfig.PREFIX
+
+        LDFLAGS.append("-L%s" % libdir)
+        LDFLAGS.append("-Wl,-rpath=%s" % libdir)
+
+        os.environ['LD_RUN_PATH'] = "%s" % libdir
 
         LIBS.append('-lpython%s' % get_python_version())
 else:


### PR DESCRIPTION
To make it compile properly when `LD_RUN_PATH` is ignored.

AFAIK `LD_RUN_PATH` could be ignored on some systems or if any run-time search directories are given on the command line.

In my environment (CentOS 6.5) I have Python in `/opt/python-3.4` and I have its `/bin` in `$PATH` - it's not present in other vars.  When I tried to install & run uWSGI in virtualenv I ended up with an error:
```
$ mktmpenv -p python3.4
...
$ pip install uwsgi
...
Successfully installed uwsgi-2.0.11.1
$ uwsgi
uwsgi: error while loading shared libraries: libpython3.4m.so.1.0: cannot open shared object file: No such file or directory
```

In order to deal with this I had to do:
```
$ export LDFLAGS="-Wl,-rpath=/opt/python-3.4/lib"
$ pip install uwsgi
```
and this time it worked.

So this patch is fixing this issue to uWSGI can be installed without any issues on such systems.