### PR TITLE
also remove all master fifo if vacuum is true

### DIFF
--- a/core/uwsgi.c
+++ b/core/uwsgi.c
@@ -1695,6 +1695,18 @@ next:
                                         }
 				}
 			}
+			if (uwsgi.master_fifo) {
+				// also remove all master fifo
+				struct uwsgi_string_list *usl;
+				uwsgi_foreach(usl, uwsgi.master_fifo) {
+					if (unlink(usl->value)) {
+						uwsgi_error("unlink()");
+					}
+					else {
+						uwsgi_log("VACUUM: master fifo %s removed.\n", usl->value);
+					}
+				}
+			}
 		}
 	}
 }


### PR DESCRIPTION
since vacuum option 'try to remove all of the generated file/sockets', the fifo(s) generated by uwsgi should also  be removed.