### PR TITLE
mod_proxy_uwsgi: fix apache 2.4 integration with unix domain sockets

### DIFF
--- a/apache2/mod_proxy_uwsgi.c
+++ b/apache2/mod_proxy_uwsgi.c
@@ -67,19 +67,17 @@ static int uwsgi_canon(request_rec *r, char *url)
     }
     url += sizeof(UWSGI_SCHEME); /* Keep slashes */
 
-    // is it a unix socket ?
-    if (strlen(url) == 2) {
-	*sport = 0;
+    err = ap_proxy_canon_netloc(r->pool, &url, NULL, NULL, &host, &port);
+    if (err) {
+        ap_log_rerror(APLOG_MARK, APLOG_ERR, 0, r,
+                    "error parsing URL %s: %s", url, err);
+        return HTTP_BAD_REQUEST;
     }
-    else {
-        err = ap_proxy_canon_netloc(r->pool, &url, NULL, NULL, &host, &port);
-        if (err) {
-            ap_log_rerror(APLOG_MARK, APLOG_ERR, 0, r,
-                      "error parsing URL %s: %s", url, err);
-            return HTTP_BAD_REQUEST;
-        }
-	apr_snprintf(sport, sizeof(sport), ":%u", port);
-    }
+
+    if (port != UWSGI_DEFAULT_PORT)
+        apr_snprintf(sport, sizeof(sport), ":%u", port);
+    else
+        sport[0] = '\0';
 
     if (ap_strchr(host, ':')) { /* if literal IPv6 address */
         host = apr_pstrcat(r->pool, "[", host, "]", NULL);


### PR DESCRIPTION
There is no way I could make this to work using the existing code and ```uwsgi://``` syntax as said in the docs.

The proposed patch makes this work.

Example usage in apache conf:

    ProxyPass "/foo"  "unix:/var/run/uwsgi/foo.socket|uwsgi://uwsgi-uds-foo/"

Note: I use uwsgi-uds-foo as hostname instead of localhost because if
you have multiple entrie like these in the same apache conf, apache
thinks it is the same backend even though the unix socket path is
different. So it is mandatory to use different hostnames if you have
multiple app sockets.

Some references:
- https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=752783
- https://github.com/unbit/uwsgi/issues/973
- maybe https://github.com/unbit/uwsgi/issues/912
- https://github.com/unbit/uwsgi/issues/890