### PR TITLE
OSX 10.11 supports TCP_FASTOPEN

### DIFF
--- a/core/socket.c
+++ b/core/socket.c
@@ -710,6 +710,11 @@ int bind_to_tcp(char *socket_name, int listen_queue, char *tcp_port) {
 
 	if (uwsgi.tcp_fast_open) {
 #ifdef TCP_FASTOPEN
+
+    #ifndef SOL_TCP
+    #define SOL_TCP IPPROTO_TCP
+    #endif
+
 		if (setsockopt(serverfd, SOL_TCP, TCP_FASTOPEN, (const void *) &uwsgi.tcp_fast_open, sizeof(int)) < 0) {
 			uwsgi_error("TCP_FASTOPEN setsockopt()");
 		}


### PR DESCRIPTION
But does not define SOL_TCP.
IPPROTO_TCP is the equivalent.

xrmx: Backport from b608eb1772641d525bfde268fe9d6d8d0d5efde7
Fix #1056