### PR TITLE
Add timer interface with millisecond resolution to python plugin

### DIFF
--- a/core/master.c
+++ b/core/master.c
@@ -720,7 +720,7 @@ int master_loop(char **argv, char **environ) {
 			// locking is not needed as timers can only increase
 			for (i = 0; i < ushared->timers_cnt; i++) {
 				if (!ushared->timers[i].registered) {
-					ushared->timers[i].fd = event_queue_add_timer(uwsgi.master_queue, &ushared->timers[i].id, ushared->timers[i].value);
+					ushared->timers[i].fd = event_queue_add_timer_hr(uwsgi.master_queue, &ushared->timers[i].id, ushared->timers[i].value, ushared->timers[i].nsvalue);
 					ushared->timers[i].registered = 1;
 				}
 			}

--- a/core/signal.c
+++ b/core/signal.c
@@ -180,7 +180,7 @@ int uwsgi_add_file_monitor(uint8_t sig, char *filename) {
 
 }
 
-int uwsgi_add_timer(uint8_t sig, int secs) {
+int uwsgi_add_timer_hr(uint8_t sig, int secs, long nsecs) {
 
 	if (!uwsgi.master_process) return -1;
 
@@ -192,6 +192,7 @@ int uwsgi_add_timer(uint8_t sig, int secs) {
 		ushared->timers[ushared->timers_cnt].value = secs;
 		ushared->timers[ushared->timers_cnt].registered = 0;
 		ushared->timers[ushared->timers_cnt].sig = sig;
+		ushared->timers[ushared->timers_cnt].nsvalue = nsecs;
 		ushared->timers_cnt++;
 	}
 	else {
@@ -204,6 +205,10 @@ int uwsgi_add_timer(uint8_t sig, int secs) {
 
 	return 0;
 
+}
+
+int uwsgi_add_timer(uint8_t sig, int secs) {
+	return uwsgi_add_timer_hr(sig, secs, 0);
 }
 
 int uwsgi_signal_add_rb_timer(uint8_t sig, int secs, int iterations) {

--- a/plugins/python/uwsgi_pymodule.c
+++ b/plugins/python/uwsgi_pymodule.c
@@ -311,6 +311,25 @@ static PyObject *py_uwsgi_add_timer(PyObject * self, PyObject * args) {
 	return Py_None;
 }
 
+static PyObject *py_uwsgi_add_ms_timer(PyObject * self, PyObject * args) {
+
+	uint8_t uwsgi_signal;
+	long msecs;
+	int secs;
+
+	if (!PyArg_ParseTuple(args, "Bl:add_ms_timer", &uwsgi_signal, &msecs)) {
+		return NULL;
+	}
+
+	secs = msecs / 1000;
+	msecs = msecs - secs * 1000;
+	if (uwsgi_add_timer_hr(uwsgi_signal, secs, msecs * 1000000))
+		return PyErr_Format(PyExc_ValueError, "unable to add timer");
+
+	Py_INCREF(Py_None);
+	return Py_None;
+}
+
 PyObject *py_uwsgi_add_rb_timer(PyObject * self, PyObject * args) {
 
         uint8_t uwsgi_signal;
@@ -2736,6 +2755,7 @@ static PyMethodDef uwsgi_advanced_methods[] = {
 	{"signal_received", py_uwsgi_signal_received, METH_VARARGS, ""},
 	{"add_file_monitor", py_uwsgi_add_file_monitor, METH_VARARGS, ""},
 	{"add_timer", py_uwsgi_add_timer, METH_VARARGS, ""},
+	{"add_ms_timer", py_uwsgi_add_ms_timer, METH_VARARGS, ""},
 	{"add_rb_timer", py_uwsgi_add_rb_timer, METH_VARARGS, ""},
 	{"add_cron", py_uwsgi_add_cron, METH_VARARGS, ""},
 

--- a/t/python/timers.py
+++ b/t/python/timers.py
@@ -1,0 +1,6 @@
+# uwsgi --wsgi-file t/python/timers.py --http :8080 --master
+from uwsgidecorators import mstimer
+
+@mstimer(500)
+def ms_timer(signum):
+    print("500 ms timer")

--- a/uwsgi.h
+++ b/uwsgi.h
@@ -1609,6 +1609,7 @@ struct uwsgi_timer {
 	int id;
 	int registered;
 	uint8_t sig;
+	long nsvalue;
 };
 
 struct uwsgi_signal_rb_timer {
@@ -3318,6 +3319,7 @@ int event_queue_interesting_fd_is_read(void *, int);
 int event_queue_interesting_fd_is_write(void *, int);
 
 int event_queue_add_timer(int, int *, int);
+int event_queue_add_timer_hr(int, int *, int, long);
 struct uwsgi_timer *event_queue_ack_timer(int);
 
 int event_queue_add_file_monitor(int, char *, int *);
@@ -3327,6 +3329,7 @@ struct uwsgi_fmon *event_queue_ack_file_monitor(int, int);
 int uwsgi_register_signal(uint8_t, char *, void *, uint8_t);
 int uwsgi_add_file_monitor(uint8_t, char *);
 int uwsgi_add_timer(uint8_t, int);
+int uwsgi_add_timer_hr(uint8_t, int, long);
 int uwsgi_signal_add_rb_timer(uint8_t, int, int);
 int uwsgi_signal_handler(struct wsgi_request *, uint8_t);
 

--- a/uwsgidecorators.py
+++ b/uwsgidecorators.py
@@ -327,6 +327,19 @@ class timer(object):
         return f
 
 
+class mstimer(object):
+
+    def __init__(self, msecs, **kwargs):
+        self.num = kwargs.get('signum', get_free_signal())
+        self.msecs = msecs
+        self.target = kwargs.get('target', '')
+
+    def __call__(self, f):
+        uwsgi.register_signal(self.num, self.target, f)
+        uwsgi.add_ms_timer(self.num, self.msecs)
+        return f
+
+
 class cron(object):
 
     def __init__(self, minute, hour, day, month, dayweek, **kwargs):


### PR DESCRIPTION
We extend uwsgi timer api to handle a nanosecond value in order to support timer with finer grained resolution than the current second. Then we add interface to use timers with millisecond resolution is added to the python plugin. I've extended the decorators with another decorator mstimer. Alternatively we can add a resolution parameter to the current timer decorator. It's fine for me either way.
Eventually external plugins that used that interface of course need to be updated.
Please note this has NOT ever been compiled on kqueue systems.
