### PR TITLE
Pass LIBDIR to linker in python plugin

### DIFF
--- a/plugins/python/uwsgiplugin.py
+++ b/plugins/python/uwsgiplugin.py
@@ -51,11 +51,14 @@ if not 'UWSGI_PYTHON_NOLIB' in os.environ:
             LIBS.append('-lutil')
     else:
         try:
-            LDFLAGS.append("-L%s" % sysconfig.get_config_var('LIBDIR'))
-            os.environ['LD_RUN_PATH'] = "%s" % (sysconfig.get_config_var('LIBDIR'))
+            libdir = sysconfig.get_config_var('LIBDIR')
         except:
-            LDFLAGS.append("-L%s/lib" % sysconfig.PREFIX)
-            os.environ['LD_RUN_PATH'] = "%s/lib" % sysconfig.PREFIX
+            libdir = "%s/lib" % sysconfig.PREFIX
+
+        LDFLAGS.append("-L%s" % libdir)
+        LDFLAGS.append("-Wl,-rpath=%s" % libdir)
+
+        os.environ['LD_RUN_PATH'] = "%s" % libdir
 
         LIBS.append('-lpython%s' % get_python_version())
 else:


### PR DESCRIPTION
Backport PR #1021 to uwsgi-2.0.

To make it compile properly when LD_RUN_PATH is ignored.