### PR TITLE
Lua plugin and uWSGI application counter

### DIFF
--- a/plugins/lua/lua_plugin.c
+++ b/plugins/lua/lua_plugin.c
@@ -3102,6 +3102,8 @@ static void uwsgi_lua_init_apps() {
 			ulua_log("inited %d lua_State(s) for worker %d", uwsgi.threads, j + 1);
 		}
 	}
+
+	uwsgi_apps_cnt++;
 }
 
 static int uwsgi_lua_mule_msg(char *msg, size_t len) {

--- a/plugins/lua/lua_plugin.c
+++ b/plugins/lua/lua_plugin.c
@@ -3103,7 +3103,9 @@ static void uwsgi_lua_init_apps() {
 		}
 	}
 
-	uwsgi_apps_cnt++;
+	if (ulua.wsapi) {
+		uwsgi_apps_cnt++;
+	}
 }
 
 static int uwsgi_lua_mule_msg(char *msg, size_t len) {


### PR DESCRIPTION
Lua plugin doesn't increment application counter while performing initialization. This cause `need-app` option to abort if only Lua applications are loaded/used.