### PR TITLE
Remove leading and trailing quotation marks when processing yaml keys and values

### DIFF
--- a/core/yaml.c
+++ b/core/yaml.c
@@ -16,7 +16,7 @@ void yaml_rstrip(char *line) {
 	off_t i;
 
 	for (i = strlen(line) - 1; i >= 0; i--) {
-		if (line[i] == ' ' || line[i] == '\t') {
+		if (line[i] == ' ' || line[i] == '\t' || line[i] == '"') {
 			line[i] = 0;
 			continue;
 		}
@@ -30,7 +30,7 @@ char *yaml_lstrip(char *line) {
 	char *ptr = line;
 
 	for (i = 0; i < (int) strlen(line); i++) {
-		if (line[i] == ' ' || line[i] == '\t' || line[i] == '\r') {
+		if (line[i] == ' ' || line[i] == '\t' || line[i] == '\r' || line[i] == '"') {
 			ptr++;
 			continue;
 		}


### PR DESCRIPTION
I would like to correct the situation mentioned in these two posts:

http://lists.unbit.it/pipermail/uwsgi/2014-April/007278.html

http://serverfault.com/questions/688317/uwsgi-chdir-no-such-file-or-directory

I believe the simple changes I've made will allow me to use lines like:

chdir: "%d" 

In my .yaml file while still allowing PyYaml to process the file as well.

Thanks
