### PR TITLE
Eliminate blind excepts

### DIFF
--- a/examples/uwsgistatus.py
+++ b/examples/uwsgistatus.py
@@ -26,12 +26,12 @@ def application(env, start_response):
 
     try:
         yield "mode: <b>%s</b><br/>" % uwsgi.mode
-    except:
+    except Exception:
         pass
 
     try:
         yield "pidfile: <b>%s</b><br/>" % uwsgi.pidfile
-    except:
+    except Exception:
         pass
 
     yield "<h2>Hooks</h2>"

--- a/examples/welcome.py
+++ b/examples/welcome.py
@@ -14,11 +14,8 @@ print(sys.modules)
 print(sys.argv)
 
 try:
-    if sys.argv[1] == 'debug':
-        DEBUG = True
-    else:
-        raise
-except:
+    DEBUG = sys.argv[1] == 'debug'
+except IndexError:
     DEBUG = False
 
 
@@ -73,7 +70,7 @@ def setprocname():
 def application(env, start_response):
     try:
         uwsgi.mule_msg(env['REQUEST_URI'], 1)
-    except:
+    except Exception:
         pass
 
     req = uwsgi.workers()[uwsgi.worker_id()-1]['requests']
@@ -82,7 +79,7 @@ def application(env, start_response):
 
     try:
         gc.collect(2)
-    except:
+    except Exception:
         pass
     if DEBUG:
         print(env['wsgi.input'].fileno())
@@ -95,7 +92,7 @@ def application(env, start_response):
 
     try:
         gc.collect(2)
-    except:
+    except Exception:
         pass
 
     if DEBUG:

--- a/plugins/fiber/uwsgiplugin.py
+++ b/plugins/fiber/uwsgiplugin.py
@@ -2,10 +2,7 @@ import os
 
 NAME = 'fiber'
 
-try:
-    RUBYPATH = os.environ['UWSGICONFIG_RUBYPATH']
-except:
-    RUBYPATH = 'ruby'
+RUBYPATH = os.environ.get('UWSGICONFIG_RUBYPATH', 'ruby')
 
 
 CFLAGS = os.popen(RUBYPATH + " -e \"require 'rbconfig';print RbConfig::CONFIG['CFLAGS']\"").read().rstrip().split()

--- a/plugins/jvm/uwsgiplugin.py
+++ b/plugins/jvm/uwsgiplugin.py
@@ -10,7 +10,7 @@ operating_system = os.uname()[0].lower()
 
 try:
     arch = os.environ['JVM_ARCH']
-except:
+except KeyError:
     arch = os.uname()[4].lower()
 
 if arch in ('i686', 'x86', 'x86_32'):
@@ -45,12 +45,12 @@ else:
 
 try:
     JVM_INCPATH = ['-I"' + os.environ['UWSGICONFIG_JVM_INCPATH'] + '"']
-except:
+except KeyError:
     pass
 
 try:
     JVM_LIBPATH = ['-L"' + os.environ['UWSGICONFIG_JVM_LIBPATH'] + '"']
-except:
+except KeyError:
     pass
 
 if not JVM_INCPATH or not JVM_LIBPATH:

--- a/plugins/jwsgi/uwsgiplugin.py
+++ b/plugins/jwsgi/uwsgiplugin.py
@@ -5,7 +5,7 @@ jvm_path = 'plugins/jvm'
 up = {}
 try:
     execfile('%s/uwsgiplugin.py' % jvm_path, up)
-except:
+except Exception:
     f = open('%s/uwsgiplugin.py' % jvm_path)
     exec(f.read(), up)
     f.close()

--- a/plugins/lua/uwsgiplugin.py
+++ b/plugins/lua/uwsgiplugin.py
@@ -13,7 +13,7 @@ if LUAINC:
 else:
     try:
         CFLAGS = os.popen('pkg-config --cflags %s' % LUAPC).read().rstrip().split()
-    except:
+    except Exception:
         CFLAGS = ['-I/usr/include/lua5.1']
 
 if LUALIB:
@@ -21,7 +21,7 @@ if LUALIB:
 else:
     try:
         LIBS = os.popen('pkg-config --libs %s' % LUAPC).read().rstrip().split()
-    except:
+    except Exception:
         LIBS = ['-llua5.1']
 
 if LUALIBPATH:

--- a/plugins/pypy/uwsgiplugin.py
+++ b/plugins/pypy/uwsgiplugin.py
@@ -11,5 +11,5 @@ try:
     import __pypy__  # NOQA
     import sys
     CFLAGS.append('-DUWSGI_PYPY_HOME="\\"%s\\""' % sys.prefix)
-except:
+except ImportError:
     pass

--- a/plugins/python/uwsgiplugin.py
+++ b/plugins/python/uwsgiplugin.py
@@ -8,7 +8,7 @@ def get_python_version():
     version = sysconfig.get_config_var('VERSION')
     try:
         version = version + sys.abiflags
-    except:
+    except Exception:
         pass
     return version
 
@@ -72,7 +72,7 @@ if 'UWSGI_PYTHON_NOLIB' not in os.environ:
     else:
         try:
             libdir = sysconfig.get_config_var('LIBDIR')
-        except:
+        except Exception:
             libdir = "%s/lib" % sysconfig.PREFIX
 
         LDFLAGS.append("-L%s" % libdir)

--- a/plugins/rack/uwsgiplugin.py
+++ b/plugins/rack/uwsgiplugin.py
@@ -2,10 +2,7 @@ import os
 
 NAME = 'rack'
 
-try:
-    RUBYPATH = os.environ['UWSGICONFIG_RUBYPATH']
-except:
-    RUBYPATH = 'ruby'
+RUBYPATH = os.environ.get('UWSGICONFIG_RUBYPATH', 'ruby')
 
 rbconfig = 'Config'
 

--- a/plugins/rbthreads/uwsgiplugin.py
+++ b/plugins/rbthreads/uwsgiplugin.py
@@ -2,10 +2,7 @@ import os
 
 NAME = 'rbthreads'
 
-try:
-    RUBYPATH = os.environ['UWSGICONFIG_RUBYPATH']
-except:
-    RUBYPATH = 'ruby'
+RUBYPATH = os.environ.get('UWSGICONFIG_RUBYPATH', 'ruby')
 
 
 CFLAGS = os.popen(RUBYPATH + " -e \"require 'rbconfig';print RbConfig::CONFIG['CFLAGS']\"").read().rstrip().split()

--- a/plugins/ring/uwsgiplugin.py
+++ b/plugins/ring/uwsgiplugin.py
@@ -8,7 +8,7 @@ jvm_path = 'plugins/jvm'
 up = {}
 try:
     execfile('%s/uwsgiplugin.py' % jvm_path, up)
-except:
+except Exception:
     f = open('%s/uwsgiplugin.py' % jvm_path)
     exec(f.read(), up)
     f.close()

--- a/plugins/ruby19/uwsgiplugin.py
+++ b/plugins/ruby19/uwsgiplugin.py
@@ -2,10 +2,7 @@ import os
 
 NAME = 'ruby19'
 
-try:
-    RUBYPATH = os.environ['UWSGICONFIG_RUBYPATH']
-except:
-    RUBYPATH = 'ruby'
+RUBYPATH = os.environ.get('UWSGICONFIG_RUBYPATH', 'ruby')
 
 rbconfig = 'Config'
 

--- a/plugins/servlet/uwsgiplugin.py
+++ b/plugins/servlet/uwsgiplugin.py
@@ -5,7 +5,7 @@ jvm_path = 'plugins/jvm'
 up = {}
 try:
     execfile('%s/uwsgiplugin.py' % jvm_path, up)
-except:
+except Exception:
     f = open('%s/uwsgiplugin.py' % jvm_path)
     exec(f.read(), up)
     f.close()

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ def patch_bin_path(cmd, conf):
                 os.makedirs(cmd.install_scripts)
             conf.set('bin_name',
                      os.path.join(cmd.install_scripts, conf.get('bin_name')))
-        except:
+        except Exception:
             conf.set('bin_name', sys.prefix + '/bin/' + bin_name)
 
 

--- a/tests/badwrites.py
+++ b/tests/badwrites.py
@@ -13,7 +13,7 @@ def application(e, sr):
 
     try:
         time.sleep(2)
-    except:
+    except Exception:
         print("CLIENT DISCONNECTED !!!")
     print("2 seconds elapsed")
 
@@ -21,7 +21,7 @@ def application(e, sr):
 
     try:
         time.sleep(2)
-    except:
+    except Exception:
         print("CLIENT DISCONNECTED !!!")
     print("2 seconds elapsed")
 

--- a/tests/staticfile.py
+++ b/tests/staticfile.py
@@ -5,12 +5,12 @@ filename = 'logo_uWSGI.png'
 
 try:
     filename = sys.argv[1]
-except:
+except IndexError:
     pass
 
 try:
     content_type = sys.argv[2]
-except:
+except IndexError:
     pass
 
 

--- a/tests/testapp.py
+++ b/tests/testapp.py
@@ -127,7 +127,7 @@ def reload(env, start_response):
 #        print 4/0
 #
 #        print uwsgi.pippo
-#    except:
+#    except Exception:
 #        print "bah"
 
 #    print "ok"

--- a/tests/websockets.py
+++ b/tests/websockets.py
@@ -67,6 +67,6 @@ def application(env, sr):
                     try:
                         msg = queue.get_nowait()
                         uwsgi.websocket_send(msg)
-                    except:
+                    except Exception:
                         pass
     return ""

--- a/uwsgidecorators.py
+++ b/uwsgidecorators.py
@@ -4,7 +4,7 @@ from threading import Thread
 
 try:
     import cPickle as pickle
-except:
+except ImportError:
     import pickle
 
 import uwsgi
@@ -246,7 +246,7 @@ class mule_brain(object):
         if uwsgi.mule_id() == self.num:
             try:
                 self.f()
-            except:
+            except BaseException:
                 exc = sys.exc_info()
                 sys.excepthook(exc[0], exc[1], exc[2])
                 sys.exit(1)
@@ -259,7 +259,7 @@ class mule_brainloop(mule_brain):
             while True:
                 try:
                     self.f()
-                except:
+                except BaseException:
                     exc = sys.exc_info()
                     sys.excepthook(exc[0], exc[1], exc[2])
                     sys.exit(1)


### PR DESCRIPTION
I don't think any of the blind excepts in this code matters as far as
reliability is concerned but I believe it's worth making the code more
explicit even if it's only for the educational value or in case someone
uses the code as an example.

* Where I was fairly certain what exception is expected I replaced
  "except:" with "except SomeConcreteClass:" (or otherwise simplified
  the code)
* Where I wasn't sure what exaclty is being expected I just put
  "except Exception:" to at least skip the "special" exceptions
* Two remaining cases I replaced with "except BaseException:" which I
  believe makes the code tiny bit more explicit.