### PR TITLE
Introduce a new api: reload_worker

### DIFF
--- a/plugins/python/uwsgi_pymodule.c
+++ b/plugins/python/uwsgi_pymodule.c
@@ -2454,6 +2454,32 @@ PyObject *py_uwsgi_stop(PyObject * self, PyObject * args) {
         return Py_True;
 }
 
+/* reload one worker */
+PyObject *py_uwsgi_reload_worker(PyObject * self, PyObject * args) {
+    int wid = 0;
+
+    if (!PyArg_ParseTuple(args, "|i:reload_worker", &wid)) {
+        return NULL;
+    }
+
+    if (wid > uwsgi.numproc) {
+        return PyErr_Format(PyExc_ValueError, "invalid worker id");
+    }
+
+    if (wid == 0) {
+        wid = uwsgi.mywid;
+    }
+
+    if (kill(uwsgi.workers[wid].pid, SIGHUP)) {
+        uwsgi_error("kill()");
+        Py_INCREF(Py_None);
+        return Py_None;
+    }
+
+    Py_INCREF(Py_True);
+    return Py_True;
+}
+
 PyObject *py_uwsgi_request_id(PyObject * self, PyObject * args) {
 	struct wsgi_request *wsgi_req = py_current_wsgi_req();
 	return PyLong_FromUnsignedLongLong(uwsgi.workers[uwsgi.mywid].cores[wsgi_req->async_id].requests);
@@ -2654,6 +2680,7 @@ PyObject *py_uwsgi_suspend(PyObject * self, PyObject * args) {
 static PyMethodDef uwsgi_advanced_methods[] = {
 	{"reload", py_uwsgi_reload, METH_VARARGS, ""},
 	{"stop", py_uwsgi_stop, METH_VARARGS, ""},
+	{"reload_worker", py_uwsgi_reload_worker, METH_VARARGS, ""},
 	{"workers", py_uwsgi_workers, METH_VARARGS, ""},
 	{"masterpid", py_uwsgi_masterpid, METH_VARARGS, ""},
 	{"total_requests", py_uwsgi_total_requests, METH_VARARGS, ""},


### PR DESCRIPTION
with the new api, we not only can reload whole uwsgi server (via `uwsgi.reload()`) ,
but also can reload one worker.

`uwsgi.reload_worker()` with no argument will reload the worker which call the api.
`uwsgi.reload_worker(worker_id)` call with `worker_id` argument will reload the special worker.

when `worker_id` is not valid, ValueError raised.