### PR TITLE
Feature:  Worker warehouse

### DIFF
--- a/core/master_utils.c
+++ b/core/master_utils.c
@@ -775,6 +775,8 @@ int uwsgi_respawn_worker(int wid) {
 			memset(uwsgi.workers[uwsgi.mywid].cores[i].buffer, 0, sizeof(struct uwsgi_header));
 		}
 
+		memset(uwsgi.workers[uwsgi.mywid].warehouse, '\0', sizeof(uwsgi.workers[uwsgi.mywid].warehouse));
+
 		uwsgi_fixup_fds(wid, 0, NULL);
 
 		uwsgi.my_signal_socket = uwsgi.workers[wid].signal_pipe[1];

--- a/plugins/python/uwsgi_pymodule.c
+++ b/plugins/python/uwsgi_pymodule.c
@@ -2239,7 +2239,18 @@ PyObject *py_uwsgi_total_requests(PyObject * self, PyObject * args) {
 }
 
 	/* uWSGI workers */
-PyObject *py_uwsgi_workers(PyObject * self, PyObject * args) {
+PyObject *py_uwsgi_workers(PyObject * self, PyObject * args, PyObject * kwargs) {
+    PyObject *warehouse = Py_False;
+    static char *kwlist[] = {"warehouse", NULL};
+
+    if (!PyArg_ParseTupleAndKeywords(args, kwargs, "|O:workers", kwlist, &warehouse)) {
+            return NULL;
+    }
+
+    int show_warehouse = PyObject_IsTrue(warehouse);
+    if (show_warehouse == -1) {
+        return PyErr_Format(PyExc_ValueError, "invalid argument!");
+    }
 
 	PyObject *worker_dict, *apps_dict, *apps_tuple, *zero;
 	int i, j;
@@ -2360,6 +2371,14 @@ PyObject *py_uwsgi_workers(PyObject * self, PyObject * args) {
 		}
 		Py_DECREF(zero);
 
+		if(show_warehouse) {
+            zero = PyString_FromString(uwsgi.workers[i + 1].warehouse);
+            if (PyDict_SetItemString(worker_dict, "warehouse", zero)) {
+                goto clear;
+            }
+            Py_DECREF(zero);
+		}
+
 		apps_tuple = PyTuple_New(uwsgi.workers[i+1].apps_cnt);
 
 		for(j=0;j<uwsgi.workers[i+1].apps_cnt;j++) {
@@ -2425,6 +2444,65 @@ PyObject *py_uwsgi_workers(PyObject * self, PyObject * args) {
 	Py_INCREF(Py_None);
 	return Py_None;
 
+}
+
+PyObject *py_uwsgi_worker_warehouse_set(PyObject * self, PyObject * args) {
+    char *value;
+    Py_ssize_t valuelen;
+    if (!PyArg_ParseTuple(args, "s#:worker_warehouse_set", &value, &valuelen)) {
+        return NULL;
+    }
+
+    if (valuelen > UWSGI_WORKER_WAREHOUSE_MAX_SIZE) {
+        return PyErr_Format(PyExc_ValueError, "argument too long!");
+    }
+
+    UWSGI_RELEASE_GIL
+
+    memset(uwsgi.workers[uwsgi.mywid].warehouse, '\0', sizeof(uwsgi.workers[uwsgi.mywid].warehouse));
+    memcpy(uwsgi.workers[uwsgi.mywid].warehouse, value, valuelen);
+
+    UWSGI_GET_GIL
+
+    Py_INCREF(Py_None);
+    return Py_None;
+}
+
+PyObject *py_uwsgi_worker_warehouse_get(PyObject * self, PyObject * args) {
+    return PyString_FromString(uwsgi.workers[uwsgi.mywid].warehouse);
+}
+
+PyObject *py_uwsgi_worker_warehouse_clear(PyObject * self, PyObject * args) {
+    UWSGI_RELEASE_GIL
+
+    memset(uwsgi.workers[uwsgi.mywid].warehouse, '\0', sizeof(uwsgi.workers[uwsgi.mywid].warehouse));
+
+    UWSGI_GET_GIL
+
+    Py_INCREF(Py_None);
+    return Py_None;
+}
+
+PyObject *py_uwsgi_workers_warehouse(PyObject * self, PyObject * args) {
+    int i;
+    PyObject * warehouse = PyTuple_New(uwsgi.numproc);
+
+    if (warehouse == NULL) {
+        uwsgi_error("PyTuple_New() error!");
+        return PyErr_Format(PyExc_SystemError, "can not create tuple");
+    }
+
+    for (i = 0; i < uwsgi.numproc; i++) {
+        if(PyTuple_SetItem(warehouse, i, PyString_FromString(uwsgi.workers[i + 1].warehouse))) {
+            goto clear;
+        }
+    }
+
+    return warehouse;
+
+clear:
+    Py_DECREF(warehouse);
+    return NULL;
 }
 
 
@@ -2654,7 +2732,7 @@ PyObject *py_uwsgi_suspend(PyObject * self, PyObject * args) {
 static PyMethodDef uwsgi_advanced_methods[] = {
 	{"reload", py_uwsgi_reload, METH_VARARGS, ""},
 	{"stop", py_uwsgi_stop, METH_VARARGS, ""},
-	{"workers", py_uwsgi_workers, METH_VARARGS, ""},
+	{"workers", (PyCFunction)py_uwsgi_workers, METH_VARARGS|METH_KEYWORDS, ""},
 	{"masterpid", py_uwsgi_masterpid, METH_VARARGS, ""},
 	{"total_requests", py_uwsgi_total_requests, METH_VARARGS, ""},
 	{"request_id", py_uwsgi_request_id, METH_VARARGS, ""},
@@ -2749,6 +2827,11 @@ static PyMethodDef uwsgi_advanced_methods[] = {
 	{"add_var", py_uwsgi_add_var, METH_VARARGS, ""},
 
 	{"micros", py_uwsgi_micros, METH_VARARGS, ""},
+
+	{"worker_warehouse_set", py_uwsgi_worker_warehouse_set, METH_VARARGS, ""},
+	{"worker_warehouse_get", py_uwsgi_worker_warehouse_get, METH_VARARGS, ""},
+	{"worker_warehouse_clear", py_uwsgi_worker_warehouse_clear, METH_VARARGS, ""},
+	{"workers_warehouse", py_uwsgi_workers_warehouse, METH_VARARGS, ""},
 
 	{NULL, NULL},
 };

--- a/tests/worker_warehouse.py
+++ b/tests/worker_warehouse.py
@@ -1,0 +1,110 @@
+#!./uwsgi --http-socket :9090 --module tests.worker_warehouse --master --processes 4 --buffer-size 32768
+
+# /                 return all workers warehouse
+# /get              return this worker warehouse
+# /set?data=xxx     set xxx in this worker warehouse
+# /clean            clean this worker warehouse
+
+### test client ###
+
+# import os
+# import base64
+# import urllib
+#
+# import requests
+#
+# WAREHOUSE = {}
+#
+#
+# # test set
+# for i in range(10000):
+#     data = urllib.quote_plus(base64.b64encode(os.urandom(1000)))
+#     req = requests.get("http://127.0.0.1:9090/set?data=%s" % data)
+#     assert req.ok is True
+#
+#     worker_id = req.content
+#     WAREHOUSE[worker_id] = data
+#
+#     req = requests.get("http://127.0.0.1:9090")
+#     server_warehouse = req.json()
+#
+#     for k, v in WAREHOUSE.iteritems():
+#         assert WAREHOUSE[k] == server_warehouse[k]
+#
+# # test clean
+# for i in range(1000):
+#     if not WAREHOUSE:
+#         break
+#
+#     req = requests.get("http://127.0.0.1:9090/clear")
+#     assert req.ok is True
+#
+#     worker_id = req.content
+#     if worker_id in WAREHOUSE:
+#         WAREHOUSE.pop(worker_id)
+#
+#         req = requests.get("http://127.0.0.1:9090")
+#         server_warehouse = req.json()
+#
+#         assert server_warehouse[worker_id] == ''
+
+
+import json
+import urllib
+import urlparse
+import uwsgi
+
+
+def warehouse_get(*args):
+    return uwsgi.worker_warehouse_get()
+
+def warehouse_set(*args):
+    data = args[0]
+    uwsgi.worker_warehouse_set(data)
+    uwsgi.log("set {0} in worker {1}".format(data, uwsgi.worker_id()))
+    return str(uwsgi.worker_id())
+
+def warehouse_clear(*args):
+    uwsgi.worker_warehouse_clear()
+    uwsgi.log("warehouse clean in worker {0}".format(uwsgi.worker_id()))
+    return str(uwsgi.worker_id())
+
+def all_workers_warehouse(*args):
+    warehouse = uwsgi.workers_warehouse()
+    warehouse_dict = {}
+    for index, data in enumerate(warehouse):
+        warehouse_dict[index+1] = data
+
+    return warehouse_dict
+
+
+routes = {
+    '': all_workers_warehouse,
+    '/get': warehouse_get,
+    '/set': warehouse_set,
+    '/clear': warehouse_clear,
+}
+
+
+def application(env, sr):
+    path = env['PATH_INFO'].rstrip('/')
+
+    try:
+        handler = routes[path]
+    except KeyError:
+        sr('404 NOT FOUND', [('Content-Type', 'text/plain')])
+        return "NOT FOUND"
+
+    sr('200 OK', [('Content-Type', 'text/plain')])
+    try:
+        data = urlparse.parse_qs(env['QUERY_STRING'])['data'][0]
+        data = urllib.quote_plus(data)
+    except:
+        data = ""
+
+    value = handler(data)
+    if isinstance(value, str):
+        return value
+
+    return json.dumps(value)
+

--- a/uwsgi.h
+++ b/uwsgi.h
@@ -85,6 +85,8 @@ extern "C" {
 #define MAX_TIMERS 64
 #define MAX_CRONS 64
 
+#define UWSGI_WORKER_WAREHOUSE_MAX_SIZE 1024 * 128  // 128KB
+
 #define UWSGI_VIA_SENDFILE	1
 #define UWSGI_VIA_ROUTE	2
 #define UWSGI_VIA_OFFLOAD	3
@@ -3028,6 +3030,9 @@ struct uwsgi_worker {
 	int accepting;
 
 	char name[0xff];
+
+	// user can put custom value in the warehouse.
+	char warehouse[UWSGI_WORKER_WAREHOUSE_MAX_SIZE + 1];
 };
 
 


### PR DESCRIPTION

Add a warehouse (128KB) in worker, for worker store data, 

(e.g. worker can save any thing (string) in it's warehouse. and all workers warehouse data can be obtained convenient. so this makes do statistics simply)
    
#### NEW:
*   `uwsgi.worker_warehouse_set(data)`
    set data(string) in this worker warehouse
    
*   `uwsgi.worker_warehouse_get()`
    get data from this worker warehouse
    
*   `uwsgi.worker_warehouse_clear()`
    clear this worker warehouse
    
*   `uwsgi.workers_warehouse()`
    get all workers warehouse data.
    return as tuple, data ordered by worker id
    
#### CHANGE:
*   `uwsgi.workers()`
    now this api add an optional keyword argument: `warehouse`
    if no argument, or warehouse=False,
    the return value does't change
    
    if warehouse=True,
    the return value also contains `warehouse` in all workers



#### TEST

see `tests/worker_warehouse.py`

I have tested many times to ensure that this APIs are working correctly and no memory leak.





