### PR TITLE
core/xmlconf: initialize libxml2

### DIFF
--- a/core/xmlconf.c
+++ b/core/xmlconf.c
@@ -22,6 +22,8 @@ void uwsgi_xml_config(char *filename, struct wsgi_request *wsgi_req, char *magic
 	char *xml_content;
 	size_t xml_size = 0;
 
+	LIBXML_TEST_VERSION
+
 	if (uwsgi_check_scheme(filename)) {
 		colon = uwsgi_get_last_char(filename, '/');
 		colon = uwsgi_get_last_char(colon, ':');


### PR DESCRIPTION
Call LIBXML_TEST_VERSION before parsing which would call xmlInitParser
which is required on multi-threaded programs. It also checks the
linked library is compatible with the one it has been compiled
againt which i'm sure cannot hurt.

Hopefully fix #779