### PR TITLE
Python sdist via setup.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,7 @@ core/dot_h.c
 +# coverity
 +/cov-int/
 +uwsgi.tar.xz
+
+# Python build side-effects
+dist
+/*.egg*

--- a/setup.py
+++ b/setup.py
@@ -107,4 +107,5 @@ setup(name='uWSGI',
       license='GPL2',
       py_modules=['uwsgidecorators'],
       distclass=uWSGIDistribution,
+      setup_requires=['setuptools-git'],
      )


### PR DESCRIPTION
With this change we can create an 'sdist' (tar.gz) for Python distribution with `python setup.py sdist`.

If PR will be accepter I will create a backport PR for `master`.