### PR TITLE
Avoiding #ifdefs that break statements.

### DIFF
--- a/core/utils.c
+++ b/core/utils.c
@@ -1819,13 +1819,16 @@ void *uwsgi_calloc(size_t size) {
 char *uwsgi_resolve_ip(char *domain) {
 
 	struct hostent *he;
+	int checker;
 
 	he = gethostbyname(domain);
-	if (!he || !*he->h_addr_list || (he->h_addrtype != AF_INET
+	checker = (!he || !*he->h_addr_list);
 #ifdef AF_INET6
-					 && he->h_addrtype != AF_INET6
+	checker = checker || (he->h_addrtype != AF_INET && he->h_addrtype != AF_INET6);
+#else
+	checker = checker || (he->h_addrtype != AF_INET);
 #endif
-	    )) {
+	if (checker) {
 		return NULL;
 	}
 


### PR DESCRIPTION
A suggestion to compile entire statements and expressions, as suggested by code style guidelines from the Linux Kernel and practitioners.

- https://git.kernel.org/cgit/linux/kernel/git/torvalds/linux.git/tree/Documentation/CodingStyle#n892
- https://www.cqse.eu/en/blog/living-in-the-ifdef-hell/

It might improve code understanding, maintainability and error-proneness.