### PR TITLE
Add new method to read spooler file from python

### DIFF
--- a/core/spooler.c
+++ b/core/spooler.c
@@ -535,6 +535,60 @@ static void spooler_readdir(struct uwsgi_spooler *uspool, char *dir) {
 	}
 }
 
+int uwsgi_spooler_read_header(char *task, int spool_fd, struct uwsgi_header *uh) {
+
+	// check if the file is locked by another process
+	if (uwsgi_fcntl_is_locked(spool_fd)) {
+		uwsgi_protected_close(spool_fd);
+		return -1;
+	}
+
+	// unlink() can destroy the lock !!!
+	if (access(task, R_OK|W_OK)) {
+		uwsgi_protected_close(spool_fd);
+		return -1;
+	}
+
+	ssize_t rlen = uwsgi_protected_read(spool_fd, uh, 4);
+
+	if (rlen != 4) {
+		// it could be here for broken file or just opened one
+		if (rlen < 0)
+			uwsgi_error("spooler_manage_task()/read()");
+		uwsgi_protected_close(spool_fd);
+		return -1;
+	}
+
+#ifdef __BIG_ENDIAN__
+	uh->_pktsize = uwsgi_swap16(uh->_pktsize);
+#endif
+
+	return 0;
+}
+
+int uwsgi_spooler_read_content(int spool_fd, char *spool_buf, char **body, size_t *body_len, struct uwsgi_header *uh, struct stat *sf_lstat) {
+
+	if (uwsgi_protected_read(spool_fd, spool_buf, uh->_pktsize) != uh->_pktsize) {
+		uwsgi_error("spooler_manage_task()/read()");
+		uwsgi_protected_close(spool_fd);
+		return 1;
+	}
+
+	// body available ?
+	if (sf_lstat->st_size > (uh->_pktsize + 4)) {
+		*body_len = sf_lstat->st_size - (uh->_pktsize + 4);
+		*body = uwsgi_malloc(*body_len);
+		if ((size_t) uwsgi_protected_read(spool_fd, *body, *body_len) != *body_len) {
+			uwsgi_error("spooler_manage_task()/read()");
+			uwsgi_protected_close(spool_fd);
+			free(*body);
+			return 1;
+		}
+	}
+
+	return 0;
+}
+
 void spooler_manage_task(struct uwsgi_spooler *uspool, char *dir, char *task) {
 
 	int i, ret;
@@ -584,7 +638,6 @@ void spooler_manage_task(struct uwsgi_spooler *uspool, char *dir, char *task) {
 		}
 		if (!access(task, R_OK | W_OK)) {
 
-
 			spool_fd = open(task, O_RDWR);
 
 			if (spool_fd < 0) {
@@ -593,51 +646,12 @@ void spooler_manage_task(struct uwsgi_spooler *uspool, char *dir, char *task) {
 				return;
 			}
 
-			// check if the file is locked by another process
-			if (uwsgi_fcntl_is_locked(spool_fd)) {
-				uwsgi_protected_close(spool_fd);
+			if (uwsgi_spooler_read_header(task, spool_fd, &uh))
 				return;
-			}
 
-			// unlink() can destroy the lock !!!
-			if (access(task, R_OK | W_OK)) {
-				uwsgi_protected_close(spool_fd);
-				return;
-			}
-
-
-			ssize_t rlen = uwsgi_protected_read(spool_fd, &uh, 4);
-
-			if (rlen != 4) {
-				// it could be here for broken file or just opened one
-				if (rlen < 0)
-					uwsgi_error("spooler_manage_task()/read()");
-				uwsgi_protected_close(spool_fd);
-				return;
-			}
-
-#ifdef __BIG_ENDIAN__
-			uh._pktsize = uwsgi_swap16(uh._pktsize);
-#endif
-
-			if (uwsgi_protected_read(spool_fd, spool_buf, uh._pktsize) != uh._pktsize) {
-				uwsgi_error("spooler_manage_task()/read()");
+			if (uwsgi_spooler_read_content(spool_fd, spool_buf, &body, &body_len, &uh, &sf_lstat)) {
 				destroy_spool(dir, task);
-				uwsgi_protected_close(spool_fd);
 				return;
-			}
-
-			// body available ?
-			if (sf_lstat.st_size > (uh._pktsize + 4)) {
-				body_len = sf_lstat.st_size - (uh._pktsize + 4);
-				body = uwsgi_malloc(body_len);
-				if ((size_t) uwsgi_protected_read(spool_fd, body, body_len) != body_len) {
-					uwsgi_error("spooler_manage_task()/read()");
-					destroy_spool(dir, task);
-					uwsgi_protected_close(spool_fd);
-					free(body);
-					return;
-				}
 			}
 
 			// now the task is running and should not be woken up

--- a/plugins/python/python_plugin.c
+++ b/plugins/python/python_plugin.c
@@ -1664,6 +1664,26 @@ void uwsgi_python_add_item(char *key, uint16_t keylen, char *val, uint16_t valle
 	Py_DECREF(zero);
 }
 
+PyObject *uwsgi_python_dict_from_spooler_content(char *filename, char *buf, uint16_t len, char *body, size_t body_len) {
+
+	PyObject *spool_dict = PyDict_New();
+
+	PyObject *value = PyString_FromString(filename);
+	PyDict_SetItemString(spool_dict, "spooler_task_name", value);
+	Py_DECREF(value);
+
+	if (uwsgi_hooked_parse(buf, len, uwsgi_python_add_item, spool_dict))
+		return NULL;
+
+	if (body && body_len > 0) {
+		PyObject *value = PyString_FromStringAndSize(body, body_len);
+		PyDict_SetItemString(spool_dict, "body", value);
+		Py_DECREF(value);
+	}
+
+	return spool_dict;
+}
+
 int uwsgi_python_spooler(char *filename, char *buf, uint16_t len, char *body, size_t body_len) {
 
 	static int random_seed_reset = 0;
@@ -1689,25 +1709,15 @@ int uwsgi_python_spooler(char *filename, char *buf, uint16_t len, char *body, si
 	}
 
 	int retval = -1;
-	PyObject *spool_dict = PyDict_New();
 	PyObject *pyargs = PyTuple_New(1);
 	PyObject *ret = NULL;
 
-	PyObject *value = PyString_FromString(filename);
-	PyDict_SetItemString(spool_dict, "spooler_task_name", value);
-	Py_DECREF(value);
-
-	if (uwsgi_hooked_parse(buf, len, uwsgi_python_add_item, spool_dict)) {
-		// malformed packet, destroy it
+	PyObject *spool_dict = uwsgi_python_dict_from_spooler_content(filename, buf, len, body, body_len);
+	if (!spool_dict) {
 		retval = -2;
 		goto clear;
 	}
 
-	if (body && body_len > 0) {
-		PyObject *value = PyString_FromStringAndSize(body, body_len);
-		PyDict_SetItemString(spool_dict, "body", value);
-		Py_DECREF(value);
-	}
 	// PyTuple_SetItem steals a reference !!!
 	Py_INCREF(spool_dict);
 	PyTuple_SetItem(pyargs, 0, spool_dict);

--- a/plugins/python/uwsgi_pymodule.c
+++ b/plugins/python/uwsgi_pymodule.c
@@ -2243,22 +2243,13 @@ PyObject *py_uwsgi_spooler_get_task(PyObject * self, PyObject * args) {
 		return Py_None;
 	}
 
-	PyObject *spool_dict = PyDict_New();
+	uwsgi_protected_close(spool_fd);
 
-	PyObject *value = PyString_FromString(task_path);
-	PyDict_SetItemString(spool_dict, "spooler_task_name", value);
-	Py_DECREF(value);
+	PyObject *spool_dict = uwsgi_python_dict_from_spooler_content(task_path, spool_buf, uh._pktsize, body, body_len);
 
-	if (uwsgi_hooked_parse(spool_buf, uh._pktsize, uwsgi_python_add_item, spool_dict)) {
-		Py_XDECREF(spool_dict);
+	if (!spool_dict) {
 		Py_INCREF(Py_None);
 		return Py_None;
-	}
-
-	if (body && body_len > 0) {
-		PyObject *value = PyString_FromStringAndSize(body, body_len);
-		PyDict_SetItemString(spool_dict, "body", value);
-		Py_DECREF(value);
 	}
 
 	return spool_dict;

--- a/plugins/python/uwsgi_pymodule.c
+++ b/plugins/python/uwsgi_pymodule.c
@@ -2203,6 +2203,105 @@ PyObject *py_uwsgi_spooler_pids(PyObject * self, PyObject * args) {
     return ret;
 }
 
+PyObject *py_uwsgi_spooler_get_task(PyObject * self, PyObject * args) {
+
+        char spool_buf[0xffff];
+        struct uwsgi_header uh;
+        char *body = NULL;
+        size_t body_len = 0;
+
+        int spool_fd;
+
+        char *task_path = NULL;
+
+        struct stat task_stat;
+
+        if (!PyArg_ParseTuple(args, "s:spooler_get_task", &task_path)) {
+                return NULL;
+        }
+
+        if (lstat(task_path, &task_stat)) {
+                Py_INCREF(Py_None);
+                return Py_None;
+        }
+
+        if (access(task_path, R_OK | W_OK)) {
+                Py_INCREF(Py_None);
+                return Py_None;
+        }
+
+        spool_fd = open(task_path, O_RDWR);
+
+        if (spool_fd < 0) {
+                Py_INCREF(Py_None);
+                return Py_None;
+        }
+
+        // check if the file is locked by another process
+        if (uwsgi_fcntl_is_locked(spool_fd)) {
+                uwsgi_protected_close(spool_fd);
+                Py_INCREF(Py_None);
+                return Py_None;
+        }
+
+        // unlink() can destroy the lock !!!
+        if (access(task_path, R_OK | W_OK)) {
+                uwsgi_protected_close(spool_fd);
+                Py_INCREF(Py_None);
+                return Py_None;
+        }
+
+        ssize_t rlen = uwsgi_protected_read(spool_fd, &uh, 4);
+
+        if (rlen != 4) {
+                uwsgi_protected_close(spool_fd);
+                Py_INCREF(Py_None);
+                return Py_None;
+        }
+
+#ifdef __BIG_ENDIAN__
+        uh._pktsize = uwsgi_swap16(uh._pktsize);
+#endif
+
+        if (uwsgi_protected_read(spool_fd, spool_buf, uh._pktsize) != uh._pktsize) {
+                uwsgi_protected_close(spool_fd);
+                Py_INCREF(Py_None);
+                return Py_None;
+        }
+
+        // body available ?
+        if (task_stat.st_size > (uh._pktsize + 4)) {
+                body_len = task_stat.st_size - (uh._pktsize + 4);
+                body = uwsgi_malloc(body_len);
+                if ((size_t) uwsgi_protected_read(spool_fd, body, body_len) != body_len) {
+                        uwsgi_protected_close(spool_fd);
+                        free(body);
+                        Py_INCREF(Py_None);
+                        return Py_None;
+                }
+        }
+
+        PyObject *spool_dict = PyDict_New();
+
+        PyObject *value = PyString_FromString(task_path);
+        PyDict_SetItemString(spool_dict, "spooler_task_name", value);
+        Py_DECREF(value);
+
+        if (uwsgi_hooked_parse(spool_buf, uh._pktsize, uwsgi_python_add_item, spool_dict)) {
+                Py_XDECREF(spool_dict);
+                Py_INCREF(Py_None);
+                return Py_None;
+        }
+
+        if (body && body_len > 0) {
+                PyObject *value = PyString_FromStringAndSize(body, body_len);
+                PyDict_SetItemString(spool_dict, "body", value);
+                Py_DECREF(value);
+        }
+
+        return spool_dict;
+}
+
 
 PyObject *py_uwsgi_connect(PyObject * self, PyObject * args) {
 
@@ -2636,6 +2735,8 @@ static PyMethodDef uwsgi_spooler_methods[] = {
 	{"spooler_jobs", py_uwsgi_spooler_jobs, METH_VARARGS, ""},
 	{"spooler_pid", py_uwsgi_spooler_pid, METH_VARARGS, ""},
 	{"spooler_pids", py_uwsgi_spooler_pids, METH_VARARGS, ""},
+
+        {"spooler_get_task", py_uwsgi_spooler_get_task, METH_VARARGS, ""},
 	{NULL, NULL},
 };
 

--- a/plugins/python/uwsgi_python.h
+++ b/plugins/python/uwsgi_python.h
@@ -319,6 +319,8 @@ int uwsgi_request_python_raw(struct wsgi_request *);
 
 void uwsgi_python_set_thread_name(int);
 
+void uwsgi_python_add_item(char *, uint16_t, char *, uint16_t, void *);
+
 #define py_current_wsgi_req() current_wsgi_req();\
 			if (!wsgi_req) {\
 				return PyErr_Format(PyExc_SystemError, "you can call uwsgi api function only from the main callable");\

--- a/plugins/python/uwsgi_python.h
+++ b/plugins/python/uwsgi_python.h
@@ -285,6 +285,8 @@ void init_uwsgi_module_cache(PyObject *);
 void init_uwsgi_module_queue(PyObject *);
 void init_uwsgi_module_snmp(PyObject *);
 
+PyObject *uwsgi_python_dict_from_spooler_content(char *, char *, uint16_t, char *, size_t);
+
 PyObject *uwsgi_pyimport_by_filename(char *, char *);
 
 void threaded_swap_ts(struct wsgi_request *, struct uwsgi_app *);

--- a/t/spooler/read.py
+++ b/t/spooler/read.py
@@ -1,0 +1,35 @@
+# uswgi
+
+from uwsgidecorators import spoolraw, muleloop
+
+import uwsgi
+import time
+import collections
+import random
+import os
+
+@muleloop(1)
+def reader():
+    c = collections.Counter()
+
+    for file in os.listdir("myspool"):
+        try:
+            c[uwsgi.spooler_get_task("myspool/" + file)["dest"]] += 1
+        except Exception:
+            pass
+
+    print(c)
+    time.sleep(5)
+
+projects = ["uwsgi", "python", "ruby", "nginx", "memcache"]
+
+@muleloop(2)
+def producer():
+    uwsgi.spool(ud_spool_func="consumer", dest=random.choice(projects))
+    time.sleep(2)
+
+@spoolraw
+def consumer(args):
+    print("project : " + args["dest"])
+    time.sleep(3)
+    return uwsgi.SPOOL_OK

--- a/uwsgi.h
+++ b/uwsgi.h
@@ -3122,6 +3122,9 @@ char *uwsgi_spool_request(struct wsgi_request *, char *, size_t, char *, size_t)
 void spooler(struct uwsgi_spooler *);
 pid_t spooler_start(struct uwsgi_spooler *);
 
+int uwsgi_spooler_read_header(char *, int, struct uwsgi_header *);
+int uwsgi_spooler_read_content(int, char *, char **, size_t *, struct uwsgi_header *, struct stat *);
+
 #if defined(_GNU_SOURCE) || defined(__UCLIBC__)
 #define uwsgi_versionsort versionsort
 #else


### PR DESCRIPTION
Hi,

I added this feature, but as it may benefit others, maybe you could merge it.

I can adjust the modifications if needs be. This code introduce redundancy with the core but I didn't want to change it. Another solution would be to break spooler_manage_task into multiple functions to use them in this feature.

cheers,
Shir0kamii