### PR TITLE
plugins/alarm_speech: fix AppKit spelling to support case-sensitive HFS

### DIFF
--- a/plugins/alarm_speech/uwsgiplugin.py
+++ b/plugins/alarm_speech/uwsgiplugin.py
@@ -7,7 +7,7 @@ uwsgi_os = os.uname()[0]
 LDFLAGS = []
 if uwsgi_os == "Darwin":
     CFLAGS = []
-    LIBS = ['-framework appkit']
+    LIBS = ['-framework AppKit']
 else:
     CFLAGS = ['-I /usr/include/GNUstep']
     LIBS = []


### PR DESCRIPTION
Avoids a link error when building on a case-sensitive filesystem on OS X.

Fixes #1127