### PR TITLE
async proto_parser_status fail backport

### DIFF
--- a/core/async.c
+++ b/core/async.c
@@ -549,6 +549,8 @@ void async_loop() {
 					else if (proto_parser_status < 0) {
 						uwsgi.async_proto_fd_table[interesting_fd] = NULL;
 						close(interesting_fd);
+						uwsgi.async_queue_unused_ptr++;
++						uwsgi.async_queue_unused[uwsgi.async_queue_unused_ptr] = uwsgi.wsgi_req;
 						continue;
 					}
 					// re-add timer


### PR DESCRIPTION
looks like this is realy solves my problem with deadlock and 100% cpu load, when I 'attack' my server with 'ab' util