### PR TITLE
Add initialization of emperor_throttle (was uninitialized)

### DIFF
--- a/core/emperor.c
+++ b/core/emperor.c
@@ -2009,6 +2009,7 @@ void emperor_loop() {
 	uwsgi.max_fd = rl.rlim_cur;
 
 	emperor_throttle_level = uwsgi.emperor_throttle;
+	emperor_throttle = 0;
 
 	// the queue must be initialized before adding scanners
 	uwsgi.emperor_queue = event_queue_init();


### PR DESCRIPTION
Hi,

I've found an uninitialized value and fixed it. We talked about it on IRC with @xrmx so it should be fine.