### PR TITLE
fix emperor SIGURG feature (cleanup blacklist)

### DIFF
--- a/core/emperor.c
+++ b/core/emperor.c
@@ -1941,11 +1941,12 @@ static void emperor_wakeup(int sn) {
 }
 
 static void emperor_cleanup(int signum) {
-	uwsgi_log_verbose("[uwsgi-emperor] cleaning up blacklist ...\n");
-	struct uwsgi_instance *ui_current = ui;
-	while (ui_current->ui_next) {
-		uwsgi_emperor_blacklist_remove(ui_current->name);
-		ui_current = ui_current->ui_next;
+	uwsgi_log_verbose("[emperor] cleaning up blacklist ...\n");
+	struct uwsgi_emperor_blacklist_item *uebi = emperor_blacklist;
+	while (uebi) {
+		struct uwsgi_emperor_blacklist_item *next = uebi->next;
+		free(uebi);
+		uebi = next;
 	}
 }
 

--- a/core/emperor.c
+++ b/core/emperor.c
@@ -1948,6 +1948,7 @@ static void emperor_cleanup(int signum) {
 		free(uebi);
 		uebi = next;
 	}
+	emperor_blacklist = NULL;
 }
 
 void emperor_loop() {


### PR DESCRIPTION
Hi,

@unbit told me about a SIGURG feature for emperor to clean its blacklist but it didn't work. Here is the fix I writed.

If i understand clearly, the previous code was taking the vassal list which does not contains blacklisted vassals. Now I simply take the blacklist and free all of its items.

I will also make a PR for the documentation.