### PR TITLE
Fix inet_ntop buffer size

### DIFF
--- a/plugins/corerouter/corerouter.c
+++ b/plugins/corerouter/corerouter.c
@@ -643,7 +643,7 @@ struct corerouter_session *corerouter_alloc_session(struct uwsgi_corerouter *ucr
 	memcpy(&cs->client_sockaddr, cr_addr, cr_addr_len);
 	switch(cr_addr->sa_family) {
 		case AF_INET:
-			if (inet_ntop(AF_INET, &cs->client_sockaddr.sa_in.sin_addr, cs->client_address, cr_addr_len) == NULL) {
+			if (inet_ntop(AF_INET, &cs->client_sockaddr.sa_in.sin_addr, cs->client_address, sizeof(cs->client_address)) == NULL) {
 				uwsgi_error("corerouter_alloc_session/inet_ntop()");
 				memcpy(cs->client_address, "0.0.0.0", 7);
 				cs->client_port[0] = '0';
@@ -653,7 +653,7 @@ struct corerouter_session *corerouter_alloc_session(struct uwsgi_corerouter *ucr
 			break;
 #ifdef AF_INET6
 		case AF_INET6:
-			if (inet_ntop(AF_INET6, &cs->client_sockaddr.sa_in6.sin6_addr, cs->client_address, cr_addr_len) == NULL) {
+			if (inet_ntop(AF_INET6, &cs->client_sockaddr.sa_in6.sin6_addr, cs->client_address, sizeof(cs->client_address)) == NULL) {
 				uwsgi_error("corerouter_alloc_session/inet_ntop()");
 				memcpy(cs->client_address, "0.0.0.0", 7);
 				cs->client_port[0] = '0';

--- a/plugins/corerouter/cr.h
+++ b/plugins/corerouter/cr.h
@@ -330,7 +330,7 @@ struct corerouter_session {
 #ifdef AF_INET6
 	char client_address[INET6_ADDRSTRLEN];
 #else
-	char client_address[INET_ADDRLEN];
+	char client_address[INET_ADDRSTRLEN];
 #endif
 
 	// use 11 bytes to be snprintf friendly


### PR DESCRIPTION
Buffer size specified in a call to `inet_ntop` did not reflect the size of the buffer, `cs->client_address` (46 bytes in case of AF_INET6).  IPv6 addresses whose string representation was longer than the specified size (28) were misrepresented as `0.0.0.0`.

No-AF_INET6 client_address buffer size also seems off, although I could not test the change, and I doubt that your Travis setup will test it.
