### PR TITLE
add subscription-tolerance-inactive

### DIFF
--- a/core/init.c
+++ b/core/init.c
@@ -90,6 +90,7 @@ void uwsgi_init_default() {
 
 	uwsgi.subscribe_freq = 10;
 	uwsgi.subscription_tolerance = 17;
+	uwsgi.subscription_tolerance_inactive = 17;
 
 	uwsgi.cores = 1;
 	uwsgi.threads = 1;

--- a/core/subscription.c
+++ b/core/subscription.c
@@ -164,15 +164,18 @@ struct uwsgi_subscribe_node *uwsgi_get_subscribe_node(struct uwsgi_subscribe_slo
 	current_slot->hits++;
 	time_t now = uwsgi_now();
 	struct uwsgi_subscribe_node *node = current_slot->nodes;
+	int subscription_age;
+
 	while (node) {
+		subscription_age = now - node->last_check;
 		// is the node alive ?
-		if (now - node->last_check > uwsgi.subscription_tolerance) {
+		if ((node->len == 0 && (subscription_age > uwsgi.subscription_tolerance_inactive)) || (node->len > 0 && (subscription_age > uwsgi.subscription_tolerance))) {
 			if (node->death_mark == 0) {
 				if (node->len > 0) {
 					uwsgi_log("[uwsgi-subscription for pid %d] %.*s => marking %.*s as failed (no announce received in %d seconds)\n", (int) uwsgi.mypid, (int) keylen, key, (int) node->len, node->name, uwsgi.subscription_tolerance);
 				}
 				else if (node->vassal_len > 0) {
-					uwsgi_log("[uwsgi-subscription for pid %d] %.*s => marking vassal %.*s as failed (no announce received in %d seconds)\n", (int) uwsgi.mypid, (int) keylen, key, (int) node->vassal_len, node->vassal, uwsgi.subscription_tolerance);
+					uwsgi_log("[uwsgi-subscription for pid %d] %.*s => marking vassal %.*s as failed (no announce received in %d seconds)\n", (int) uwsgi.mypid, (int) keylen, key, (int) node->vassal_len, node->vassal, uwsgi.subscription_tolerance_inactive);
 				}
 			}
 			node->failcnt++;

--- a/core/uwsgi.c
+++ b/core/uwsgi.c
@@ -679,6 +679,7 @@ static struct uwsgi_option uwsgi_base_options[] = {
 	{"subscribe2", required_argument, 0, "subscribe to the specified subscription server using advanced keyval syntax", uwsgi_opt_add_string_list, &uwsgi.subscriptions2, UWSGI_OPT_MASTER},
 	{"subscribe-freq", required_argument, 0, "send subscription announce at the specified interval", uwsgi_opt_set_int, &uwsgi.subscribe_freq, 0},
 	{"subscription-tolerance", required_argument, 0, "set tolerance for subscription servers", uwsgi_opt_set_int, &uwsgi.subscription_tolerance, 0},
+	{"subscription-tolerance-inactive", required_argument, 0, "set tolerance for subscription servers for inactive vassals", uwsgi_opt_set_int, &uwsgi.subscription_tolerance_inactive, 0},
 	{"unsubscribe-on-graceful-reload", no_argument, 0, "force unsubscribe request even during graceful reload", uwsgi_opt_true, &uwsgi.unsubscribe_on_graceful_reload, 0},
 	{"start-unsubscribed", no_argument, 0, "configure subscriptions but do not send them (useful with master fifo)", uwsgi_opt_true, &uwsgi.subscriptions_blocked, 0},
 	{"subscription-clear-on-shutdown", no_argument, 0, "force clear instead of unsubscribe during shutdown", uwsgi_opt_true, &uwsgi.subscription_clear_on_shutdown, 0},

--- a/uwsgi.h
+++ b/uwsgi.h
@@ -2834,6 +2834,8 @@ struct uwsgi_server {
 	struct uwsgi_string_list *emperor_wait_for_command_ignore;
 	int subscription_vassal_required;
 	int subscription_clear_on_shutdown;
+
+	int subscription_tolerance_inactive;
 };
 
 struct uwsgi_rpc {


### PR DESCRIPTION
When nodes subscribe to a fastrouter, they can be easily configured to send subscription packets using the "subscribe" and "subscribe2" config options. This works well for active nodes. However, the fastrouter also has the option to have inactive subscriptions, and then contact an emperor to start those nodes when a request is received for them. These inactive nodes are of course not running, so they can't send subscription packets. Therefore an external process has to send their subscription packets.

It is often not convenient to send those inactive subscription packets very often, and if the process that subscribes inactive nodes fails or is slow, it can cause downtime. Therefore this pull request adds an "subscription-tolerance-inactive" config option. This can be set to a longer value than subscription-tolerance, and then the inactive nodes don't have to expire so quickly as the active ones.