### PR TITLE
Create the spooler directory if it doesn't exist

### DIFF
--- a/core/spooler.c
+++ b/core/spooler.c
@@ -23,7 +23,8 @@ void uwsgi_opt_add_spooler(char *opt, char *directory, void *mode) {
 	int i;
 	struct uwsgi_spooler *us;
 
-	if (access(directory, R_OK | W_OK | X_OK)) {
+	if (access(directory, R_OK | W_OK | X_OK) &&
+	    mkdir(directory, S_IRWXU | S_IXGRP | S_IRGRP)) {
 		uwsgi_error("[spooler directory] access()");
 		exit(1);
 	}


### PR DESCRIPTION
Hi !

As discussed in #1191, it would be a good idea to let uwsgi create the spooler if it can rather than die without trying.

Here is the PR proposing this modification. With it, uwsgi dies only if there is no directory and if it can't create it either.

Cheers