### PR TITLE
correctly handle IPv6 sources in proto/http

### DIFF
--- a/proto/base.c
+++ b/proto/base.c
@@ -98,15 +98,15 @@ int uwsgi_proto_base_accept(struct wsgi_request *wsgi_req, int fd) {
 
 	wsgi_req->c_len = sizeof(struct sockaddr_un);
 #if defined(__linux__) && defined(SOCK_NONBLOCK) && !defined(OBSOLETE_LINUX_KERNEL)
-        return accept4(fd, (struct sockaddr *) &wsgi_req->c_addr, (socklen_t *) & wsgi_req->c_len, SOCK_NONBLOCK);
+        return accept4(fd, (struct sockaddr *) &wsgi_req->client_addr, (socklen_t *) & wsgi_req->c_len, SOCK_NONBLOCK);
 #elif defined(__linux__)
-	int client_fd = accept(fd, (struct sockaddr *) &wsgi_req->c_addr, (socklen_t *) & wsgi_req->c_len);
+	int client_fd = accept(fd, (struct sockaddr *) &wsgi_req->client_addr, (socklen_t *) & wsgi_req->c_len);
 	if (client_fd >= 0) {
 		uwsgi_socket_nb(client_fd);
 	}
 	return client_fd;
 #else
-	return accept(fd, (struct sockaddr *) &wsgi_req->c_addr, (socklen_t *) & wsgi_req->c_len);
+	return accept(fd, (struct sockaddr *) &wsgi_req->client_addr, (socklen_t *) & wsgi_req->c_len);
 #endif
 }
 

--- a/proto/http.c
+++ b/proto/http.c
@@ -822,17 +822,17 @@ void uwsgi_proto_http11_close(struct wsgi_request *wsgi_req) {
 }
 
 int uwsgi_proto_http11_accept(struct wsgi_request *wsgi_req, int fd) {
-        if (wsgi_req->socket->retry[wsgi_req->async_id]) {
-                wsgi_req->fd = wsgi_req->socket->fd_threads[wsgi_req->async_id];
+	if (wsgi_req->socket->retry[wsgi_req->async_id]) {
+		wsgi_req->fd = wsgi_req->socket->fd_threads[wsgi_req->async_id];
 		wsgi_req->c_len = sizeof(struct sockaddr_un);
 		int ret = getsockname(wsgi_req->fd, (struct sockaddr *) &wsgi_req->client_addr, (socklen_t *) &wsgi_req->c_len);
-                if (ret < 0)
+		if (ret < 0)
 			goto error;
-                ret = uwsgi_wait_read_req(wsgi_req);
-                if (ret <= 0)
+		ret = uwsgi_wait_read_req(wsgi_req);
+		if (ret <= 0)
 			goto error;
-                return wsgi_req->socket->fd_threads[wsgi_req->async_id];
-        }
+		return wsgi_req->socket->fd_threads[wsgi_req->async_id];
+	}
 	return uwsgi_proto_base_accept(wsgi_req, fd);
 
 error:

--- a/proto/http.c
+++ b/proto/http.c
@@ -337,14 +337,12 @@ static int http_parse(struct wsgi_request *wsgi_req, char *watermark) {
 					/* check if it's an IPv6-mapped-IPv4 address and, if so,
 					 * represent it as an IPv4 address
 					 *
-					 * Note: This macro isn't in any version of the POSIX
-					 * spec that I've found, but it's implemented on BSD,
-					 * Linux, and OS X.
+					 * these IPv6 macros are defined in POSIX.1-2001.
 					 */
 					if (IN6_IS_ADDR_V4MAPPED(&http_sin->sin6_addr)) {
 						/* just grab the last 4 bytes and pretend they're
-						 * IPv4. Linux has a convenience wrapped to get the
-						 * componenets word-wise, but OS X/BSD do not.
+						 * IPv4. None of the word/half-word convenience
+						 * functions are in POSIX, so just stick to .s6_addr
 						 */
 						uint32_t in4_addr = ((uint32_t*)http_sin->sin6_addr.s6_addr)[3];
 						if (inet_ntop(AF_INET, (void*)&in4_addr, ip, INET_ADDRSTRLEN)) {

--- a/proto/http.c
+++ b/proto/http.c
@@ -332,7 +332,7 @@ static int http_parse(struct wsgi_request *wsgi_req, char *watermark) {
 		switch (http_sa->sa_family) {
 			case AF_INET6:
 				{
-					memset(ip, 0, INET6_ADDRSTRLEN+1);
+					memset(ip, 0, sizeof(ip));
 					struct sockaddr_in6* http_sin = (struct sockaddr_in6*)http_sa;
 					/* check if it's an IPv6-mapped-IPv4 address and, if so,
 					 * represent it as an IPv4 address
@@ -367,7 +367,7 @@ static int http_parse(struct wsgi_request *wsgi_req, char *watermark) {
 			default:
 				{
 					struct sockaddr_in* http_sin = (struct sockaddr_in*)http_sa;
-					memset(ip, 0, INET_ADDRSTRLEN+1);
+					memset(ip, 0, sizeof(ip));
 					if (inet_ntop(AF_INET, (void *) &http_sin->sin_addr, ip, INET_ADDRSTRLEN)) {
 						wsgi_req->len += proto_base_add_uwsgi_var(wsgi_req, "REMOTE_ADDR", 11, ip, strlen(ip));
 					}

--- a/proto/http.c
+++ b/proto/http.c
@@ -344,7 +344,15 @@ static int http_parse(struct wsgi_request *wsgi_req, char *watermark) {
 						 * IPv4. None of the word/half-word convenience
 						 * functions are in POSIX, so just stick to .s6_addr
 						 */
-						uint32_t in4_addr = ((uint32_t*)http_sin->sin6_addr.s6_addr)[3];
+						union {
+							unsigned char s6[4];
+							uint32_t s4;
+						} addr_parts;
+						addr_parts.s6[0] = http_sin->sin6_addr.s6_addr[12];
+						addr_parts.s6[1] = http_sin->sin6_addr.s6_addr[13];
+						addr_parts.s6[2] = http_sin->sin6_addr.s6_addr[14];
+						addr_parts.s6[3] = http_sin->sin6_addr.s6_addr[15];
+						uint32_t in4_addr = addr_parts.s4;
 						if (inet_ntop(AF_INET, (void*)&in4_addr, ip, INET_ADDRSTRLEN)) {
 							wsgi_req->len += proto_base_add_uwsgi_var(wsgi_req, "REMOTE_ADDR", 11, ip, strlen(ip));
 						} else {

--- a/uwsgi.h
+++ b/uwsgi.h
@@ -1375,11 +1375,9 @@ struct wsgi_request {
 	char *appid;
 	uint16_t appid_len;
 
-	union address {
-		struct sockaddr_in sin;
-		struct sockaddr_in6 sin6;
-		struct sockaddr_un sun;
-	} c_addr;
+	// This structure should not be used any more
+	// in favor of the union client_addr at the end
+	struct sockaddr_un c_addr;
 	int c_len;
 
 	//iovec
@@ -1633,6 +1631,13 @@ struct wsgi_request {
 	enum uwsgi_range range_parsed;
 	int64_t range_from;
 	int64_t range_to;
+
+	// source address union, deprecates c_addr
+	union address {
+		struct sockaddr_in sin;
+		struct sockaddr_in6 sin6;
+		struct sockaddr_un sun;
+	} client_addr;
 
 };
 

--- a/uwsgi.h
+++ b/uwsgi.h
@@ -1375,8 +1375,11 @@ struct wsgi_request {
 	char *appid;
 	uint16_t appid_len;
 
-	//this is big enough to contain sockaddr_in
-	struct sockaddr_un c_addr;
+	union address {
+		struct sockaddr_in sin;
+		struct sockaddr_in6 sin6;
+		struct sockaddr_un sun;
+	} c_addr;
 	int c_len;
 
 	//iovec


### PR DESCRIPTION
I'd like to be able to bind HTTP sockets to IPv6 addresses and get a `REMOTE_ADDR` other than 0.0.0.0. As far as I can tell, this patch will implement that.

Not sure about the change to `uwsgi.h`; I think it's more correct (especially for any platform where `UNIX_PATH_MAX` isn't Linux's/Solaris's 108 bytes), but I would understand if folk wanted to avoid changing this structure and keep relying on the implementation detail of `sockaddr_in` and `sockaddr_in6` fitting in a `sockaddr_un`.
