### PR TITLE
ensure stdin snippet is bytes for test_snippet() in uwsgiconfig.py

### DIFF
--- a/uwsgiconfig.py
+++ b/uwsgiconfig.py
@@ -174,6 +174,11 @@ def test_snippet(snippet):
     """Compile a C snippet to see if features are available at build / link time."""
     cmd = "{} -xc - -o /dev/null".format(GCC)
     p = subprocess.Popen(cmd, shell=True, stdin=subprocess.PIPE, stderr=subprocess.PIPE, stdout=subprocess.PIPE)
+    if not isinstance(snippet, bytes):
+        if sys.version_info[0] >= 3:
+            snippet = bytes(snippet, sys.getdefaultencoding())
+        else:
+            snippet = bytes(snippet)
     p.communicate(snippet)
     return p.returncode == 0
 


### PR DESCRIPTION
The signature of bytes() differs slightly between
python 2/3, so check the version before using it
to casting as bytes.

The python docs are a bit unclear, but [`bytes()` has been around since 2.6](http://stackoverflow.com/a/7320974/1547030).

Fixes the error raised by @bodgit here: https://github.com/unbit/uwsgi/issues/1211#issuecomment-199209935

---------

Alternatively, we could assume `snippet` is a string and use `.encode()`, or just explicitly prefix the problematic string with `b` [here](https://github.com/unbit/uwsgi/blob/cffbdfe54b6d2654c2beb0c809c47802351e402f/uwsgiconfig.py#L191-L197)...