### PR TITLE
Add variable plugin_build_dir to uwsgiconfig

### DIFF
--- a/uwsgiconfig.py
+++ b/uwsgiconfig.py
@@ -1424,7 +1424,7 @@ def build_plugin(path, uc, cflags, ldflags, libs, name=None):
         pass
 
     if uc:
-        plugin_dest = uc.get('plugin_dir') + '/' + name + '_plugin'
+        plugin_dest = uc.get('plugin_build_dir', uc.get('plugin_dir')) + '/' + name + '_plugin'
     else:
         plugin_dest = name + '_plugin'
 


### PR DESCRIPTION
Package managers for Alpine Linux (APK) and Gentoo (Portage) builds packages in different directory than where are eventually installed. Therefore we need to set different `plugin_dir` for build and runtime.

Gentoo ebuild for uWSGI solved this problem using simple workaround that involves patching `uwsgiconfig.py` (see [here](https://github.com/gentoo/gentoo/blob/master/www-servers/uwsgi/uwsgi-2.0.11.2-r1.ebuild#L149)). This patch do the same thing; it adds build variable `plugin_build_dir`, but with fallback to `plugin_dir` for backward compatibility.

/cc @ncopa, https://github.com/alpinelinux/aports/pull/38