### PR TITLE
Logsocket plugin - fixed uninitialized var SIGSEGV

### DIFF
--- a/plugins/logsocket/logsocket_plugin.c
+++ b/plugins/logsocket/logsocket_plugin.c
@@ -43,6 +43,7 @@ ssize_t uwsgi_socket_logger(struct uwsgi_logger *ul, char *message, size_t len) 
 		else {
 			ul->msg.msg_iov = uwsgi_malloc(sizeof(struct iovec));
 			ul->msg.msg_iovlen = 1;
+			ul->count = 0;
 		}
 
 		if (comma) {


### PR DESCRIPTION
While playing with socket logger I've observed a lot of SIGSEGVs. 

It seems that initialization code is not setting `ul->count` in case when `ul->data` is null.
