### PR TITLE
Complex improving plugin/rados

### DIFF
--- a/core/protocol.c
+++ b/core/protocol.c
@@ -228,7 +228,8 @@ static int uwsgi_proto_check_9(struct wsgi_request *wsgi_req, char *key, char *b
 	return 0;
 }
 
-static void uwsgi_parse_http_range(char *buf, uint16_t len, size_t *from, size_t *to) {
+static void uwsgi_parse_http_range(char *buf, uint16_t len, enum uwsgi_range *parsed, int64_t *from, int64_t *to) {
+	*parsed = UWSGI_RANGE_INVALID;
 	*from = 0;
 	*to = 0;
 	uint16_t rlen = 0;
@@ -248,18 +249,37 @@ static void uwsgi_parse_http_range(char *buf, uint16_t len, size_t *from, size_t
 	rlen -= 6;
 	char *dash = memchr(range, '-', rlen);
 	if (!dash) return;
-	*from = uwsgi_str_num(range, dash-range);
-	*to = uwsgi_str_num(dash+1, rlen - ((dash+1)-range));
-	if (*to > 0 && *from > *to) {
-		*from = 0;
-		*to = 0;
+	if (dash != range) {
+		*from = uwsgi_str_num(range, dash-range);
+		if (dash == range+(rlen-1)) {
+			/* RFC7233 prefix range
+			 * `bytes=start-` is a same as `byte=start-0x7ffffffffffffff`
+			 */
+			*to = INT64_MAX;
+		} else {
+			*to = uwsgi_str_num(dash+1, rlen - ((dash+1)-range));
+		}
+		if (*to >= *from) {
+			*parsed = UWSGI_RANGE_PARSED;
+		} else {
+			*from = 0;
+			*to = 0;
+		}
+	} else {
+		/* RFC7233 suffix-byte-range-spec: `bytes=-500` */
+		*from = -(int64_t)uwsgi_str_num(dash+1, rlen - ((dash+1)-range));
+		if (*from < 0) {
+			*to = INT64_MAX;
+			*parsed = UWSGI_RANGE_PARSED;
+		}
 	}
 }
 
 static int uwsgi_proto_check_10(struct wsgi_request *wsgi_req, char *key, char *buf, uint16_t len) {
 
 	if (uwsgi.honour_range && !uwsgi_proto_key("HTTP_RANGE", 10)) {
-		uwsgi_parse_http_range(buf, len, &wsgi_req->range_from, &wsgi_req->range_to);
+		uwsgi_parse_http_range(buf, len, &wsgi_req->range_parsed,
+				&wsgi_req->range_from, &wsgi_req->range_to);
 		return 0;
 	}
 

--- a/core/protocol.c
+++ b/core/protocol.c
@@ -280,6 +280,9 @@ static int uwsgi_proto_check_10(struct wsgi_request *wsgi_req, char *key, char *
 	if (uwsgi.honour_range && !uwsgi_proto_key("HTTP_RANGE", 10)) {
 		uwsgi_parse_http_range(buf, len, &wsgi_req->range_parsed,
 				&wsgi_req->range_from, &wsgi_req->range_to);
+		// set deprecated fields for binary compatibility
+		wsgi_req->__range_from = (size_t)wsgi_req->range_from;
+		wsgi_req->__range_to = (size_t)wsgi_req->range_to;
 		return 0;
 	}
 

--- a/core/utils.c
+++ b/core/utils.c
@@ -2045,10 +2045,10 @@ int uwsgi_str4_num(char *str) {
 	return num;
 }
 
-size_t uwsgi_str_num(char *str, int len) {
+uint64_t uwsgi_str_num(char *str, int len) {
 
 	int i;
-	size_t num = 0;
+	uint64_t num = 0;
 
 	uint64_t delta = pow(10, len);
 
@@ -4627,3 +4627,27 @@ int uwsgi_versionsort(const struct dirent **da, const struct dirent **db) {
         }
 }
 #endif
+
+void uwsgi_fix_range_for_size(enum uwsgi_range* parsed, int64_t* from, int64_t* to, int64_t size) {
+        if (*parsed != UWSGI_RANGE_PARSED) {
+                return;
+        }
+        if (*from < 0) {
+                *from = size + *from;
+        }
+        if (*to > size-1) {
+                *to = size-1;
+        }
+        if (*from == 0 && *to == size-1) {
+                /* we have a right to reset to 200 OK answer */
+                *parsed = UWSGI_RANGE_NOT_PARSED;
+        }
+        else if (*to >= *from) {
+                *parsed = UWSGI_RANGE_VALID;
+        }
+        else { /* case *from > size-1 is also handled here */
+                *parsed = UWSGI_RANGE_INVALID;
+                *from = 0;
+                *to = 0;
+        }
+}

--- a/plugins/rados/rados.c
+++ b/plugins/rados/rados.c
@@ -157,6 +157,16 @@ static int uwsgi_rados_put(struct wsgi_request *wsgi_req, rados_ioctx_t ctx, cha
 	uint64_t off = 0;
 	int ret;
 	const char* method;
+	if (rados_ioctx_pool_requires_alignment(ctx)) {
+		uint64_t alignment = rados_ioctx_pool_required_alignment(ctx);
+		if (buffer_size <= alignment) {
+			buffer_size = alignment;
+		} else if (buffer_size <= alignment * 2) {
+			buffer_size = alignment * 2;
+		} else if (alignment) {
+			buffer_size -= buffer_size % alignment;
+		}
+	}
         while(remains > 0) {
                 ssize_t body_len = 0;
                 char *body =  uwsgi_request_body_read(wsgi_req, UMIN(remains, buffer_size) , &body_len);

--- a/plugins/rados/rados.c
+++ b/plugins/rados/rados.c
@@ -160,7 +160,7 @@ static int uwsgi_rados_put(struct wsgi_request *wsgi_req, rados_ioctx_t ctx, cha
                 char *body =  uwsgi_request_body_read(wsgi_req, UMIN(remains, buffer_size) , &body_len);
                 if (!body || body == uwsgi.empty) goto error;
 		if (uwsgi.async < 1) {
-			if (rados_write_full(ctx, key, body, body_len) < 0) {
+			if (rados_write(ctx, key, body, body_len, off) < 0) {
 				return -1;
 			}
 		}
@@ -182,7 +182,7 @@ static int uwsgi_rados_put(struct wsgi_request *wsgi_req, rados_ioctx_t ctx, cha
                 		free(urcb);
                 		goto error;
         		}
-        		if (rados_aio_write_full(ctx, key, comp, body, body_len) < 0) {
+        		if (rados_aio_write(ctx, key, comp, body, body_len, off) < 0) {
                 		free(urcb);
                 		rados_aio_release(comp);
                 		goto error;

--- a/plugins/rados/rados.c
+++ b/plugins/rados/rados.c
@@ -486,7 +486,7 @@ static void uwsgi_rados_add_mountpoint(char *arg, size_t arg_len) {
 	uwsgi_log("connected to Ceph pool: %s on cluster %.*s\n", urmp->pool, 37, fsid);
 	
 	int id = uwsgi_apps_cnt;
-	struct uwsgi_app *ua = uwsgi_add_app(id, rados_plugin.modifier1, urmp->mountpoint, strlen(urmp->mountpoint), NULL, NULL);
+	struct uwsgi_app *ua = uwsgi_add_app(id, rados_plugin.modifier1, urmp->mountpoint, strlen(urmp->mountpoint), NULL, (void*)1);
 	if (!ua) {
 		uwsgi_log("[rados] unable to mount %s\n", urmp->mountpoint);
 		rados_shutdown(cluster);

--- a/uwsgi.h
+++ b/uwsgi.h
@@ -1522,9 +1522,9 @@ struct wsgi_request {
 	// when set, do not send warnings about bad behaviours
 	int post_warning;
 
-	enum uwsgi_range range_parsed;
-	int64_t range_from;
-	int64_t range_to;
+	// deprecated fields: size_t is 32bit on 32bit platform
+	size_t __range_from;
+	size_t __range_to;
 
 	// current socket mapped to request
 	struct uwsgi_socket *socket;
@@ -1618,6 +1618,12 @@ struct wsgi_request {
 
 	// uWSGI 2.1
 	uint64_t len;
+
+	// 64bit range, deprecates size_t __range_from, __range_to
+	enum uwsgi_range range_parsed;
+	int64_t range_from;
+	int64_t range_to;
+
 };
 
 

--- a/uwsgi.h
+++ b/uwsgi.h
@@ -1350,6 +1350,13 @@ struct uwsgi_transformation {
 	struct uwsgi_transformation *next;
 };
 
+enum uwsgi_range {
+	UWSGI_RANGE_NOT_PARSED,
+	UWSGI_RANGE_PARSED,
+	UWSGI_RANGE_VALID,
+	UWSGI_RANGE_INVALID,
+};
+
 struct wsgi_request {
 	int fd;
 	struct uwsgi_header *uh;
@@ -1515,8 +1522,9 @@ struct wsgi_request {
 	// when set, do not send warnings about bad behaviours
 	int post_warning;
 
-	size_t range_from;
-	size_t range_to;
+	enum uwsgi_range range_parsed;
+	int64_t range_from;
+	int64_t range_to;
 
 	// current socket mapped to request
 	struct uwsgi_socket *socket;
@@ -3515,7 +3523,7 @@ int uwsgi_static_want_gzip(struct wsgi_request *, char *, size_t *, struct stat 
 time_t timegm(struct tm *);
 #endif
 
-size_t uwsgi_str_num(char *, int);
+uint64_t uwsgi_str_num(char *, int);
 size_t uwsgi_str_occurence(char *, size_t, char);
 
 int uwsgi_proto_base_write(struct wsgi_request *, char *, size_t);
@@ -4577,7 +4585,9 @@ int uwsgi_proto_ssl_sendfile(struct wsgi_request *, int, size_t, size_t);
 ssize_t uwsgi_sendfile_do(int, int, size_t, size_t);
 int uwsgi_proto_base_fix_headers(struct wsgi_request *);
 int uwsgi_response_add_content_length(struct wsgi_request *, uint64_t);
-int uwsgi_response_add_content_range(struct wsgi_request *, uint64_t, uint64_t, uint64_t);
+void uwsgi_fix_range_for_size(enum uwsgi_range*, int64_t*, int64_t*, int64_t);
+void uwsgi_request_fix_range_for_size(struct wsgi_request *, int64_t);
+int uwsgi_response_add_content_range(struct wsgi_request *, int64_t, int64_t, int64_t);
 int uwsgi_response_add_expires(struct wsgi_request *, uint64_t);
 int uwsgi_response_add_last_modified(struct wsgi_request *, uint64_t);
 int uwsgi_response_add_date(struct wsgi_request *, char *, uint16_t, uint64_t);


### PR DESCRIPTION
- librados have ability to read part of object from a middle. HTTP has 'Range: bytes=' header.
  Lets join these abilities.
- rados plugin used very small buffersizes. Given that requests with librados are not pipelined, it leads to
  extremely poor performance.
  Lets increase default buffer size and make it configurable.
- fix PUT for objects larger than buffer size and add ability to PUT zero sized objects
- fix PUT large objects into Erasure coded pools
- small fix for handling mount point. It seems that it were not working with mountpoint different from '/'.