### PR TITLE
'uwsgiconfig.py' now removes detected C compiler version number.

### DIFF
--- a/uwsgiconfig.py
+++ b/uwsgiconfig.py
@@ -30,8 +30,10 @@ except ImportError:
 
 PY3 = sys.version_info[0] == 3
 
-GCC = os.environ.get('CC', sysconfig.get_config_var('CC'))
-if not GCC:
+c_compiler = os.environ.get('CC', sysconfig.get_config_var('CC'))
+if c_compiler:
+    GCC = c_compiler.split('-')[0]
+else:
     GCC = 'gcc'
 
 def get_preprocessor():


### PR DESCRIPTION
My proposed fix for issue #1235, where the detected C compiler string can contain a version number causing errors in subsequent version detection code.