### PR TITLE
BUG: When a process receives a signal, poll is interrupted and returns with errno=EINTR

### DIFF
--- a/core/reader.c
+++ b/core/reader.c
@@ -5,11 +5,20 @@ extern struct uwsgi_server uwsgi;
 int uwsgi_simple_wait_read_hook(int fd, int timeout) {
 	struct pollfd upoll;
 	timeout = timeout * 1000;
+        int ret = 0;
 
         upoll.fd = fd;
         upoll.events = POLLIN;
         upoll.revents = 0;
-        int ret = poll(&upoll, 1, timeout);
+        for(;;) {
+            ret = poll(&upoll, 1, timeout);
+            if ((ret < 0) && (errno == EINTR)){
+                continue;
+            }
+            else {
+                break;
+            }
+        }
 
         if (ret > 0) {
                 if (upoll.revents & POLLIN) {


### PR DESCRIPTION
Adding a retry on EINTR