### PR TITLE
Enable keepalive also for 1 second

### DIFF
--- a/plugins/http/http.c
+++ b/plugins/http/http.c
@@ -1009,7 +1009,7 @@ ssize_t hr_instance_read(struct corerouter_peer *peer) {
 			hr->can_gzip = 0;
 			hr->has_gzip = 0;
 #endif
-			if (uhttp.keepalive > 1) {
+			if (uhttp.keepalive > 0) {
 				http_set_timeout(peer->session->main_peer, uhttp.keepalive);
 			}
 		}


### PR DESCRIPTION
The current condition ignore http-keepalive == 1.
Since it is set in seconds, the timeout should be set also for a value of  1.