### PR TITLE
EPOLLEXCLUSIVE should be used only for server socket

### DIFF
--- a/core/socket.c
+++ b/core/socket.c
@@ -1374,10 +1374,10 @@ void uwsgi_add_sockets_to_queue(int queue, int async_id) {
 	struct uwsgi_socket *uwsgi_sock = uwsgi.sockets;
 	while (uwsgi_sock) {
 		if (uwsgi_sock->fd_threads && async_id > -1 && uwsgi_sock->fd_threads[async_id] > -1) {
-			event_queue_add_fd_read(queue, uwsgi_sock->fd_threads[async_id]);
+			event_queue_add_fd_accept(queue, uwsgi_sock->fd_threads[async_id]);
 		}
 		else if (uwsgi_sock->fd > -1) {
-			event_queue_add_fd_read(queue, uwsgi_sock->fd);
+			event_queue_add_fd_accept(queue, uwsgi_sock->fd);
 		}
 		uwsgi_sock = uwsgi_sock->next;
 	}

--- a/uwsgi.h
+++ b/uwsgi.h
@@ -3255,6 +3255,7 @@ void *uwsgi_calloc(size_t);
 int event_queue_init(void);
 void *event_queue_alloc(int);
 int event_queue_add_fd_read(int, int);
+int event_queue_add_fd_accept(int, int);
 int event_queue_add_fd_write(int, int);
 int event_queue_del_fd(int, int, int);
 int event_queue_wait(int, int, int *);


### PR DESCRIPTION
When EPOLLEXCLUSIVE is used for EPOLL_CTL_ADD, next EPOLL_CTL_MOD should
use EPOLLEXCLUSIVE, too.

Current events API have read_to_write and write_to_read.
But using EPOLLEXCLUSIVE with EPOLLOUT may break some plugins.
For example, sending logs from workers through shared socket.
In this case, all workers should be waken up.

We want to avoid thundering herd problem for server socket.
So add event_queue_add_fd_accept() API.  Only it uses EPOLLEXCLUSIVE.

fixes #1250 