### PR TITLE
plugin/rados: fix deprecation warning/error

### DIFF
--- a/plugins/rados/rados.c
+++ b/plugins/rados/rados.c
@@ -159,8 +159,16 @@ static int uwsgi_rados_put(struct wsgi_request *wsgi_req, rados_ioctx_t ctx, cha
 	int ret;
 	const char* method;
 	int truncate = remains == 0;
+#ifdef HAS_RADOS_POOL_REQUIRES_ALIGNMENT2
+	if (!truncate && !rados_ioctx_pool_requires_alignment2(ctx, &ret) && ret) {
+		uint64_t alignment;
+		if (rados_ioctx_pool_required_alignment2(ctx, &alignment)) {
+			/* ignore error here */
+		} else
+#else
 	if (!truncate && rados_ioctx_pool_requires_alignment(ctx)) {
 		uint64_t alignment = rados_ioctx_pool_required_alignment(ctx);
+#endif
 		if (buffer_size <= alignment) {
 			buffer_size = alignment;
 		} else if (buffer_size <= alignment * 2) {

--- a/plugins/rados/uwsgiplugin.py
+++ b/plugins/rados/uwsgiplugin.py
@@ -4,3 +4,18 @@ CFLAGS = []
 LDFLAGS = []
 LIBS = ['-lrados']
 GCC_LIST = ['rados']
+
+import __main__
+has_rados_ioctx_pool_requires_alignment2 = __main__.test_snippet("""
+#include <rados/librados.h>
+int main()
+{
+    rados_ioctx_t ctx = NULL;
+    rados_ioctx_pool_requires_alignment2(ctx, NULL);
+    rados_ioctx_pool_required_alignment2(ctx, NULL);
+    return 0;
+}
+""", LIBS=['-lrados'])
+
+if has_rados_ioctx_pool_requires_alignment2:
+    CFLAGS.append('-DHAS_RADOS_POOL_REQUIRES_ALIGNMENT2')

--- a/uwsgiconfig.py
+++ b/uwsgiconfig.py
@@ -176,17 +176,20 @@ def spcall2(cmd):
         return None
 
 
-def test_snippet(snippet):
+def test_snippet(snippet, CFLAGS=[], LDFLAGS=[], LIBS=[]):
     """Compile a C snippet to see if features are available at build / link time."""
+    cflags = " ".join(CFLAGS)
+    ldflags = " ".join(LDFLAGS)
+    libs = " ".join(LIBS)
     if sys.version_info[0] >= 3 or (sys.version_info[0] == 2 and sys.version_info[1] > 5):
         if not isinstance(snippet, bytes):
             if PY3:
                 snippet = bytes(snippet, sys.getdefaultencoding())
             else:
                 snippet = bytes(snippet)
-        cmd = "{0} -xc - -o /dev/null".format(GCC)
+        cmd = "{0} {1} -xc - {2} {3} -o /dev/null".format(GCC, cflags, ldflags, libs)
     else:
-        cmd = GCC + " -xc - -o /dev/null"
+        cmd = " ".join([GCC, cflags, "-xc -", ldflags, libs, "-o /dev/null"])
     p = subprocess.Popen(cmd, shell=True, stdin=subprocess.PIPE, stderr=subprocess.PIPE, stdout=subprocess.PIPE)
     p.communicate(snippet)
     return p.returncode == 0


### PR DESCRIPTION
- `rados_ioctx_pool_requires_alignment` is marked as deprecated in last
  versions of librados2. It causes warning which is converted to error.
- detect presence of `rados_ioctx_pool_requires_alignment2` and
  use it if present.