### PR TITLE
Convert readthedocs link for their .org -> .io migration for hosted projects

### DIFF
--- a/README
+++ b/README
@@ -1,6 +1,6 @@
 The uWSGI project
 
-For official documentation check: https://uwsgi-docs.readthedocs.org/en/latest/
+For official documentation check: https://uwsgi-docs.readthedocs.io/en/latest/
 
 For commercial support check: http://unbit.com/
 

--- a/apache2/mod_proxy_uwsgi.c
+++ b/apache2/mod_proxy_uwsgi.c
@@ -30,7 +30,7 @@ ProxyPass / uwsgi://127.0.0.1:3031/
 
 Docs:
 
-http://uwsgi-docs.readthedocs.org/en/latest/Apache.html#mod-proxy-uwsgi
+https://uwsgi-docs.readthedocs.io/en/latest/Apache.html#mod-proxy-uwsgi
 
 */
 #define APR_WANT_MEMFUNC


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.