### PR TITLE
If worker is handling signal it's busy

### DIFF
--- a/core/master_checks.c
+++ b/core/master_checks.c
@@ -366,7 +366,7 @@ int uwsgi_master_check_daemons_death(int diedpid) {
 
 int uwsgi_worker_is_busy(int wid) {
 	int i;
-	if (uwsgi.workers[uwsgi.mywid].sig) return 1;
+	if (uwsgi.workers[wid].sig) return 1;
 	for(i=0;i<uwsgi.cores;i++) {
 		if (uwsgi.workers[wid].cores[i].in_request) {
 			return 1;


### PR DESCRIPTION
When checking if worker is busy, check that it's not handling a signal.

Until now, the function checked that mywid is not handling
signal instead of the worker in question.