### PR TITLE
Only kill worker if it's not busy

### DIFF
--- a/core/master_utils.c
+++ b/core/master_utils.c
@@ -190,9 +190,11 @@ safe:
 		time_t oldest_worker_spawn = INT_MAX;
 		for (i = 1; i <= uwsgi.numproc; i++) {
 			if (uwsgi.workers[i].cheaped == 0 && uwsgi.workers[i].pid > 0) {
-				if (uwsgi.workers[i].last_spawn < oldest_worker_spawn) {
-					oldest_worker_spawn = uwsgi.workers[i].last_spawn;
-					oldest_worker = i;
+				if (uwsgi_worker_is_busy(i) == 0) {
+					if (uwsgi.workers[i].last_spawn < oldest_worker_spawn) {
+						oldest_worker_spawn = uwsgi.workers[i].last_spawn;
+						oldest_worker = i;
+					}
 				}
 			}
 		}


### PR DESCRIPTION
We had a bug where in busyness, if the load is too low, uwsgi would kill
a worker, without checking if it's busy - simply kills the oldest worker.

I've added a check that the worker is not busy handling
a request before killing it.

Solves #1288 