### PR TITLE
add pex builder for uwsgi

### DIFF
--- a/buildconf/pex.ini
+++ b/buildconf/pex.ini
@@ -1,0 +1,6 @@
+[uwsgi]
+main_plugin = python
+inherit = base
+bin_name = pex_uwsgi
+embed_files = pexbootstrap.py
+embed_config = uwsgipex.ini

--- a/pexbootstrap.py
+++ b/pexbootstrap.py
@@ -1,0 +1,23 @@
+import os
+import sys
+import pex.pex_bootstrapper
+
+def activate_pex():
+    entry_point = os.environ.get('UWSGI_PEX')
+    if not entry_point:
+        sys.stderr.write('couldnt determine pex from UWSGI_PEX environment variable, bailing!\n')
+        sys.exit(1)
+
+    sys.stderr.write('entry_point=%s\n' % entry_point)
+
+    sys.path[0] = os.path.abspath(sys.path[0])
+    sys.path.insert(0, entry_point)
+    sys.path.insert(0, os.path.abspath(os.path.join(entry_point, '.bootstrap')))
+
+    pex.pex_bootstrapper.bootstrap_pex_env(entry_point)
+
+    sys.stderr.write('sys.path=%s\n\n' % sys.path)
+
+    return entry_point
+
+activate_pex()

--- a/uwsgipex.ini
+++ b/uwsgipex.ini
@@ -1,0 +1,2 @@
+[uwsgi]
+import = sym://pexbootstrap_py


### PR DESCRIPTION
It is not straightforward how to integrate pex (distribution library) with uwsgi. I'm creating this PR but it needs a review from someone with more experience.
Usage:

* build uwsgi with: ` python uwsgiconfig.py --build pex`
* Build your pex file `pex -r requirements.txt . -o app.pex`
* Run uwsgi with `./pex_uwsgi --env UWSGI_PEX=/tmp/app.pex --module 'app.wsgi'`

- [ ] Where to put pexbootstrap.py?
- [ ] How to fail if build happens on non-linux os? Running pex on MacOS will fail silently.