### PR TITLE
python: add uwsgi.accepting() for chain-reload + worker-override combo

### DIFF
--- a/plugins/python/uwsgi_pymodule.c
+++ b/plugins/python/uwsgi_pymodule.c
@@ -2426,6 +2426,15 @@ PyObject *py_uwsgi_ready_fd(PyObject * self, PyObject * args) {
 	return PyInt_FromLong(uwsgi_ready_fd(wsgi_req));
 }
 
+PyObject *py_uwsgi_accepting(PyObject * self, PyObject * args) {
+	int accepting = 1;
+	if (!PyArg_ParseTuple(args, "|i", &accepting)) {
+		return NULL;
+	}
+	uwsgi.workers[uwsgi.mywid].accepting = !!accepting;
+	return Py_None;
+}
+
 PyObject *py_uwsgi_parse_file(PyObject * self, PyObject * args) {
 
 	char *filename;
@@ -2590,6 +2599,7 @@ static PyMethodDef uwsgi_advanced_methods[] = {
 	{"is_locked", py_uwsgi_is_locked, METH_VARARGS, ""},
 	{"unlock", py_uwsgi_unlock, METH_VARARGS, ""},
 	{"cl", py_uwsgi_cl, METH_VARARGS, ""},
+	{"accepting", py_uwsgi_accepting, METH_VARARGS, ""},
 
 	{"setprocname", py_uwsgi_setprocname, METH_VARARGS, ""},
 


### PR DESCRIPTION
Previously it was not possible to use `touch-chain-reload` and `python-worker-override` at the same time since the worker-override script was not able to set the necessary `accepting` flag on the worker structure.

This patch adds a small `uwsgi` module API, `accepting([bool])` that does this.