### PR TITLE
add wsgi_request info to stats output

### DIFF
--- a/core/master_utils.c
+++ b/core/master_utils.c
@@ -1272,6 +1272,20 @@ struct uwsgi_stats *uwsgi_master_generate_stats() {
 			if (uwsgi_stats_list_close(us))
 				goto end;
 
+			if (uwsgi_stats_comma(us)) goto end;
+
+			if (uwsgi_stats_key(us, "req_info"))
+				goto end;
+
+			uwsgi_stats_symbol(us, '\n');
+
+			if (uwsgi_stats_object_open(us))
+				goto end;
+
+			if (uwsgi_stats_dump_request(us, uc)) goto end;
+
+			if (uwsgi_stats_object_close(us))
+				goto end;
 
 			if (uwsgi_stats_object_close(us))
 				goto end;

--- a/core/stats.c
+++ b/core/stats.c
@@ -585,26 +585,10 @@ int uwsgi_stats_dump_vars(struct uwsgi_stats *us, struct uwsgi_core *uc) {
 	return 0;
 }
 
-#define Q(key) #key
-#define kvn_comma(key) uwsgi_stats_keyvaln_comma(us, Q(key), req.key, req.key ## _len)
-
 int uwsgi_stats_dump_request(struct uwsgi_stats *us, struct uwsgi_core *uc) {
 	if (!uc->in_request) return 0;
 	struct wsgi_request req = uc->req;
-	uwsgi_stats_keylong_comma(us, "request_start", req.start_of_request_in_sec);
-
-	kvn_comma(uri);
-	kvn_comma(remote_addr);
-	kvn_comma(remote_user);
-	kvn_comma(query_string);
-	kvn_comma(protocol);
-	kvn_comma(method);
-	kvn_comma(scheme);
-	kvn_comma(https);
-	kvn_comma(script_name);
-
-	// a trailing comma isn't valid json
-	uwsgi_stats_keyvaln(us, "host", req.host, req.host_len);
+	uwsgi_stats_keylong(us, "request_start", req.start_of_request_in_sec);
 
 	return 0;
 }

--- a/core/stats.c
+++ b/core/stats.c
@@ -584,3 +584,27 @@ int uwsgi_stats_dump_vars(struct uwsgi_stats *us, struct uwsgi_core *uc) {
 	if (uwsgi_stats_str(us, "")) return -1;
 	return 0;
 }
+
+#define Q(key) #key
+#define kvn_comma(key) uwsgi_stats_keyvaln_comma(us, Q(key), req.key, req.key ## _len)
+
+int uwsgi_stats_dump_request(struct uwsgi_stats *us, struct uwsgi_core *uc) {
+	if (!uc->in_request) return 0;
+	struct wsgi_request req = uc->req;
+	uwsgi_stats_keylong_comma(us, "request_start", req.start_of_request_in_sec);
+
+	kvn_comma(uri);
+	kvn_comma(remote_addr);
+	kvn_comma(remote_user);
+	kvn_comma(query_string);
+	kvn_comma(protocol);
+	kvn_comma(method);
+	kvn_comma(scheme);
+	kvn_comma(https);
+	kvn_comma(script_name);
+
+	// a trailing comma isn't valid json
+	uwsgi_stats_keyvaln(us, "host", req.host, req.host_len);
+
+	return 0;
+}

--- a/uwsgi.h
+++ b/uwsgi.h
@@ -4600,6 +4600,7 @@ int uwsgi_response_add_date(struct wsgi_request *, char *, uint16_t, uint64_t);
 
 const char *uwsgi_http_status_msg(char *, uint16_t *);
 int uwsgi_stats_dump_vars(struct uwsgi_stats *, struct uwsgi_core *);
+int uwsgi_stats_dump_request(struct uwsgi_stats *, struct uwsgi_core *);
 
 int uwsgi_contains_n(char *, size_t, char *, size_t);
 


### PR DESCRIPTION
As I mentioned in #1316, we don't have much in the way of per-request information in the stats server. Some of this information is available in the logs and some might be available in the "vars" field, but it is helpful to get this from stats (as in the apache server_status).