### PR TITLE
core/routing: new condition ipin

### DIFF
--- a/core/routing.c
+++ b/core/routing.c
@@ -1711,12 +1711,11 @@ static int uwsgi_route_condition_ipin(struct wsgi_request *wsgi_req, struct uwsg
         }
 
 	memcpy(ipbuf, ub->buf, ub->pos);
-	if ((slash = memchr(ub2->buf, '/', ub2->pos)) != NULL) {
+	memcpy(maskbuf, ub2->buf, ub2->pos);
+
+	if ((slash = strchr(maskbuf, '/')) != NULL) {
 		*slash++ = 0;
 		pfxlen = atoi(slash);
-		strcpy(maskbuf, ub2->buf);
-	} else {
-		memcpy(maskbuf, ub2->buf, ub2->pos);
 	}
 
         uwsgi_buffer_destroy(ub);


### PR DESCRIPTION
Add a new router condition, "ipin": check if an IPv4 address is inside a given network.

Sample usage: 

```
./uwsgi --route-if 'ipin:${REMOTE_ADDR};127.0.0.0/8 return:200' --route-run return:404 --http :8080
```

All requests from localhost will return 200, while other requests will return 404.