### PR TITLE
Reload mules and spoolers

### DIFF
--- a/core/master.c
+++ b/core/master.c
@@ -861,6 +861,12 @@ int master_loop(char **argv, char **environ) {
 					uwsgi_reload_workers();
 					continue;
 				}
+				touched = uwsgi_check_touches(uwsgi.touch_mules_reload);
+				if (touched) {
+					uwsgi_log_verbose("*** %s has been touched... mules reload !!! ***\n", touched);
+					uwsgi_reload_mules();
+					continue;
+				}
 				touched = uwsgi_check_touches(uwsgi.touch_chain_reload);
 				if (touched) {
 					if (uwsgi.status.chain_reloading == 0) {
@@ -1103,6 +1109,18 @@ void uwsgi_reload_workers() {
 	for (i = 1; i <= uwsgi.numproc; i++) {
 		if (uwsgi.workers[i].pid > 0) {
 			uwsgi_curse(i, SIGHUP);
+		}
+	}
+	uwsgi_unblock_signal(SIGHUP);
+}
+
+void uwsgi_reload_mules() {
+	int i;
+
+	uwsgi_block_signal(SIGHUP);
+	for (i = 0; i <= uwsgi.mules_cnt; i++) {
+		if (uwsgi.mules[i].pid > 0) {
+			uwsgi_curse_mule(i, SIGHUP);
 		}
 	}
 	uwsgi_unblock_signal(SIGHUP);

--- a/core/master_checks.c
+++ b/core/master_checks.c
@@ -311,8 +311,14 @@ int uwsgi_master_check_spoolers_deadline() {
 int uwsgi_master_check_spoolers_death(int diedpid) {
 
 	struct uwsgi_spooler *uspool = uwsgi.spoolers;
+
 	while (uspool) {
 		if (uspool->pid > 0 && diedpid == uspool->pid) {
+			if (uspool->cursed_at) {
+				uspool->pid = 0;
+				uspool->cursed_at = 0;
+				uspool->no_mercy_at = 0;
+			}
 			if (uwsgi.spooler_cheap) {
 				uwsgi_log_verbose("spooler %s ended\n", uspool->dir);
 				uspool->pid = 0;

--- a/core/master_checks.c
+++ b/core/master_checks.c
@@ -341,11 +341,14 @@ int uwsgi_master_check_emperor_death(int diedpid) {
 int uwsgi_master_check_mules_death(int diedpid) {
 	int i;
 	for (i = 0; i < uwsgi.mules_cnt; i++) {
-		if (uwsgi.mules[i].pid == diedpid) {
+		if (!(uwsgi.mules[i].pid == diedpid)) continue;
+		if (!uwsgi.mules[i].cursed_at) {
 			uwsgi_log("OOOPS mule %d (pid: %d) crippled...trying respawn...\n", i + 1, uwsgi.mules[i].pid);
-			uwsgi_mule(i + 1);
-			return -1;
 		}
+		uwsgi.mules[i].no_mercy_at = 0;
+		uwsgi.mules[i].cursed_at = 0;
+		uwsgi_mule(i + 1);
+		return -1;
 	}
 	return 0;
 }

--- a/core/uwsgi.c
+++ b/core/uwsgi.c
@@ -577,6 +577,7 @@ static struct uwsgi_option uwsgi_base_options[] = {
 	{"never-swap", no_argument, 0, "lock all memory pages avoiding swapping", uwsgi_opt_true, &uwsgi.never_swap, 0},
 	{"touch-reload", required_argument, 0, "reload uWSGI if the specified file is modified/touched", uwsgi_opt_add_string_list, &uwsgi.touch_reload, UWSGI_OPT_MASTER},
 	{"touch-workers-reload", required_argument, 0, "trigger reload of (only) workers if the specified file is modified/touched", uwsgi_opt_add_string_list, &uwsgi.touch_workers_reload, UWSGI_OPT_MASTER},
+	{"touch-mules-reload", required_argument, 0, "reload mules if the specified file is modified/touched", uwsgi_opt_add_string_list, &uwsgi.touch_mules_reload, UWSGI_OPT_MASTER},
 	{"touch-chain-reload", required_argument, 0, "trigger chain reload if the specified file is modified/touched", uwsgi_opt_add_string_list, &uwsgi.touch_chain_reload, UWSGI_OPT_MASTER},
 	{"touch-logrotate", required_argument, 0, "trigger logrotation if the specified file is modified/touched", uwsgi_opt_add_string_list, &uwsgi.touch_logrotate, UWSGI_OPT_MASTER | UWSGI_OPT_LOG_MASTER},
 	{"touch-logreopen", required_argument, 0, "trigger log reopen if the specified file is modified/touched", uwsgi_opt_add_string_list, &uwsgi.touch_logreopen, UWSGI_OPT_MASTER | UWSGI_OPT_LOG_MASTER},

--- a/core/uwsgi.c
+++ b/core/uwsgi.c
@@ -578,6 +578,7 @@ static struct uwsgi_option uwsgi_base_options[] = {
 	{"touch-reload", required_argument, 0, "reload uWSGI if the specified file is modified/touched", uwsgi_opt_add_string_list, &uwsgi.touch_reload, UWSGI_OPT_MASTER},
 	{"touch-workers-reload", required_argument, 0, "trigger reload of (only) workers if the specified file is modified/touched", uwsgi_opt_add_string_list, &uwsgi.touch_workers_reload, UWSGI_OPT_MASTER},
 	{"touch-mules-reload", required_argument, 0, "reload mules if the specified file is modified/touched", uwsgi_opt_add_string_list, &uwsgi.touch_mules_reload, UWSGI_OPT_MASTER},
+	{"touch-spoolers-reload", required_argument, 0, "reload spoolers if the specified file is modified/touched", uwsgi_opt_add_string_list, &uwsgi.touch_spoolers_reload, UWSGI_OPT_MASTER},
 	{"touch-chain-reload", required_argument, 0, "trigger chain reload if the specified file is modified/touched", uwsgi_opt_add_string_list, &uwsgi.touch_chain_reload, UWSGI_OPT_MASTER},
 	{"touch-logrotate", required_argument, 0, "trigger logrotation if the specified file is modified/touched", uwsgi_opt_add_string_list, &uwsgi.touch_logrotate, UWSGI_OPT_MASTER | UWSGI_OPT_LOG_MASTER},
 	{"touch-logreopen", required_argument, 0, "trigger log reopen if the specified file is modified/touched", uwsgi_opt_add_string_list, &uwsgi.touch_logreopen, UWSGI_OPT_MASTER | UWSGI_OPT_LOG_MASTER},

--- a/t/mules/reload.py
+++ b/t/mules/reload.py
@@ -1,0 +1,37 @@
+import os
+import unittest
+import time
+from subprocess import Popen, PIPE
+
+
+def touch(fname):
+    with open(fname, 'a'):
+        os.utime(fname, None)
+    return
+
+
+def pgrep_mules():
+    cmd = ["pgrep", "-f", "uWSGI mule"]
+    proc = Popen(cmd, stdout=PIPE)
+    rv = set(map(int, proc.stdout.readlines()))
+    proc.terminate()
+    return rv
+
+
+class MuleReloadingTest(unittest.TestCase):
+
+    def test_reloading(self):
+        try:
+            uwsgi = Popen(["./uwsgi", "--master", "--mule", "--touch-mules-reload=/tmp/reload", "--socket=:0", "--auto-procname"])
+            subprocesses = pgrep_mules()
+            touch("/tmp/reload")
+            time.sleep(1)
+            new_subprocesses = pgrep_mules()
+            proc_intersect = subprocesses.intersection(new_subprocesses)
+            self.assertFalse(proc_intersect)
+        finally:
+            uwsgi.terminate()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/t/spooler/reload.py
+++ b/t/spooler/reload.py
@@ -1,0 +1,37 @@
+import os
+import unittest
+import time
+from subprocess import Popen, PIPE
+
+
+def touch(fname):
+    with open(fname, 'a'):
+        os.utime(fname, None)
+    return
+
+
+def pgrep_spoolers():
+    cmd = ["pgrep", "-f", "uWSGI spooler"]
+    proc = Popen(cmd, stdout=PIPE)
+    rv = set(map(int, proc.stdout.readlines()))
+    proc.terminate()
+    return rv
+
+
+class MuleReloadingTest(unittest.TestCase):
+
+    def test_reloading(self):
+        try:
+            uwsgi = Popen(["./uwsgi", "--master", "--spooler=directory", "--touch-spoolers-reload=/tmp/reload", "--socket=:0", "--auto-procname"])
+            subprocesses = pgrep_spoolers()
+            touch("/tmp/reload")
+            time.sleep(1)
+            new_subprocesses = pgrep_spoolers()
+            proc_intersect = subprocesses.intersection(new_subprocesses)
+            self.assertFalse(proc_intersect)
+        finally:
+            uwsgi.terminate()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/uwsgi.h
+++ b/uwsgi.h
@@ -2364,8 +2364,6 @@ struct uwsgi_server {
 
 	struct uwsgi_string_list *touch_reload;
 	struct uwsgi_string_list *touch_chain_reload;
-	struct uwsgi_string_list *touch_mules_reload;
-	struct uwsgi_string_list *touch_spoolers_reload;
 	struct uwsgi_string_list *touch_workers_reload;
 	struct uwsgi_string_list *touch_gracefully_stop;
 	struct uwsgi_string_list *touch_logrotate;
@@ -2861,6 +2859,8 @@ struct uwsgi_server {
 
 	int subscription_tolerance_inactive;
 
+	struct uwsgi_string_list *touch_mules_reload;
+	struct uwsgi_string_list *touch_spoolers_reload;
 	int spooler_reload_mercy;
 };
 

--- a/uwsgi.h
+++ b/uwsgi.h
@@ -1166,6 +1166,9 @@ struct uwsgi_spooler {
 	struct uwsgi_spooler *next;
 
 	time_t last_task_managed;
+
+	time_t cursed_at;
+	time_t no_mercy_at;
 };
 
 #ifdef UWSGI_ROUTING
@@ -2362,6 +2365,7 @@ struct uwsgi_server {
 	struct uwsgi_string_list *touch_reload;
 	struct uwsgi_string_list *touch_chain_reload;
 	struct uwsgi_string_list *touch_mules_reload;
+	struct uwsgi_string_list *touch_spoolers_reload;
 	struct uwsgi_string_list *touch_workers_reload;
 	struct uwsgi_string_list *touch_gracefully_stop;
 	struct uwsgi_string_list *touch_logrotate;
@@ -2856,6 +2860,8 @@ struct uwsgi_server {
 	int subscription_clear_on_shutdown;
 
 	int subscription_tolerance_inactive;
+
+	int spooler_reload_mercy;
 };
 
 struct uwsgi_rpc {
@@ -4814,6 +4820,7 @@ void uwsgi_log_rotate();
 void uwsgi_log_reopen();
 void uwsgi_reload_workers();
 void uwsgi_reload_mules();
+void uwsgi_reload_spoolers();
 void uwsgi_chain_reload();
 void uwsgi_refork_master();
 void uwsgi_update_pidfiles();

--- a/uwsgi.h
+++ b/uwsgi.h
@@ -2361,6 +2361,7 @@ struct uwsgi_server {
 
 	struct uwsgi_string_list *touch_reload;
 	struct uwsgi_string_list *touch_chain_reload;
+	struct uwsgi_string_list *touch_mules_reload;
 	struct uwsgi_string_list *touch_workers_reload;
 	struct uwsgi_string_list *touch_gracefully_stop;
 	struct uwsgi_string_list *touch_logrotate;
@@ -4812,6 +4813,7 @@ void uwsgi_log_do_rotate(char *, char *, off_t, int);
 void uwsgi_log_rotate();
 void uwsgi_log_reopen();
 void uwsgi_reload_workers();
+void uwsgi_reload_mules();
 void uwsgi_chain_reload();
 void uwsgi_refork_master();
 void uwsgi_update_pidfiles();


### PR DESCRIPTION
Hello,

This PR relates to issue #915.

We didn't really need the mules and spooler to be chain reloaded, so I thought a general option would be better for other users of uwsgi.

I added two new options to enable the reloading of the mules and the spoolers upon the modification of a file. It's independent from the reloading of the workers.

What do you think ? Is it good for you ?