### PR TITLE
Guard error_override against different APIs (particularly 2.2 to 2.4)

### DIFF
--- a/apache2/mod_proxy_uwsgi.c
+++ b/apache2/mod_proxy_uwsgi.c
@@ -374,7 +374,12 @@ static int uwsgi_response(request_rec *r, proxy_conn_rec *backend, proxy_server_
 	}
 
     // honor ProxyErrorOverride and ErrorDocument
+#if AP_MODULE_MAGIC_AT_LEAST(20101106,0)
+    proxy_dir_conf *dconf = ap_get_module_config(r->per_dir_config, &proxy_module);
+    if (dconf->error_override && ap_is_HTTP_ERROR(r->status)) {
+#else
     if (conf->error_override && ap_is_HTTP_ERROR(r->status)) {
+#endif
         int status = r->status;
         r->status = HTTP_OK;
         r->status_line = NULL;


### PR DESCRIPTION
The previous code in #1292 cannot compile with Apache httpd 2.4 API. The definition of error_override is moved from proxy_server_conf to proxy_dir_conf in commit 9eb0360e041928ca79a799c4d1cfa0a5377a6787.
