### PR TITLE
Resolve memory leaks in core/utils.c

### DIFF
--- a/core/utils.c
+++ b/core/utils.c
@@ -877,6 +877,7 @@ void uwsgi_as_root() {
 				uwsgi_error("setgroups()");
 				exit(1);
 			}
+			free(ags_list);
 		}
 		int additional_groups = getgroups(0, NULL);
 		if (additional_groups > 0) {
@@ -1627,6 +1628,7 @@ void parse_sys_envs(char **envs) {
 			eq_pos[0] = 0;
 
 			add_exported_option(earg, eq_pos + 1, 0);
+			free(earg);
 		}
 		uenvs++;
 	}


### PR DESCRIPTION
Found with `clang`'s static analyzer