### PR TITLE
plugin/rados: add ability to configure rados namespace

### DIFF
--- a/plugins/rados/uwsgiplugin.py
+++ b/plugins/rados/uwsgiplugin.py
@@ -16,6 +16,17 @@ int main()
     return 0;
 }
 """, LIBS=['-lrados'])
+has_rados_ioctx_set_namespace = __main__.test_snippet("""
+#include <rados/librados.h>
+int main()
+{
+    rados_ioctx_t ctx = NULL;
+    rados_ioctx_set_namespace(ctx, NULL);
+    return 0;
+}
+""", LIBS=['-lrados'])
 
 if has_rados_ioctx_pool_requires_alignment2:
-    CFLAGS.append('-DHAS_RADOS_POOL_REQUIRES_ALIGNMENT2')
+    CFLAGS.append('-DHAS_RADOS_IOCTX_POOL_REQUIRES_ALIGNMENT2')
+if has_rados_ioctx_set_namespace:
+    CFLAGS.append('-DHAS_RADOS_IOCTX_SET_NAMESPACE')


### PR DESCRIPTION
Let user configure rados pool namespace.
If librados is too old, then non-empty namespace is error.