### PR TITLE
Don't kill yourself when killing all

### DIFF
--- a/core/uwsgi.c
+++ b/core/uwsgi.c
@@ -1363,7 +1363,7 @@ void gracefully_kill_them_all(int signum) {
 
         int i;
         for (i = 1; i <= uwsgi.numproc; i++) {
-                if (uwsgi.workers[i].pid > 0) {
+                if (uwsgi.workers[i].pid > 0 && uwsgi.mypid != uwsgi.workers[i].pid) {
                         uwsgi_curse(i, SIGHUP);
                 }
         }


### PR DESCRIPTION
gracefully_kill_them_all() may be called on worker id 1.
When that happens, the worker may try to kill itself by mistake.

Added a check for the worker not to kill itself.

Solves #1339 