### PR TITLE
Add reload-on-{pss,uss}

### DIFF
--- a/core/init.c
+++ b/core/init.c
@@ -499,7 +499,7 @@ void sanitize_args() {
 		exit(1);
 	}
 
-	if (uwsgi.cheaper_rss_limit_soft && uwsgi.logging_options.memory_report != 1 && uwsgi.force_get_memusage != 1) {
+	if (uwsgi.cheaper_rss_limit_soft && !uwsgi.logging_options.memory_report && uwsgi.force_get_memusage != 1) {
 		uwsgi_log("enabling cheaper-rss-limit-soft requires enabling also memory-report\n");
 		exit(1);
 	}

--- a/core/logging.c
+++ b/core/logging.c
@@ -864,6 +864,27 @@ void get_memusage(uint64_t * rss, uint64_t * vsz) {
 
 }
 
+//TODO: add non-linux uss and pss metrics
+void get_smaps_memusage(uint64_t * uss, uint64_t * pss) {
+#ifdef __linux__
+  FILE *file = fopen("/proc/self/smaps", "r");
+
+  char line [BUFSIZ];
+  while (fgets(line, sizeof line, file))
+    {
+      char substr[32];
+      int n;
+      if (sscanf(line, "%31[^:]: %d", substr, &n) == 2)
+        {
+	  if (strcmp(substr, "Private_Clean") == 0)  { *uss += n * 1024; }
+	  else if (strcmp(substr, "Private_Dirty") == 0)  { *uss += n * 1024; }
+	  else if (strcmp(substr, "Pss") == 0)            { *pss += n * 1024; }
+        }
+    }
+  fclose(file);
+#endif
+}
+
 void uwsgi_register_logger(char *name, ssize_t(*func) (struct uwsgi_logger *, char *, size_t)) {
 
 	struct uwsgi_logger *ul = uwsgi.loggers, *old_ul;

--- a/core/logging.c
+++ b/core/logging.c
@@ -866,21 +866,23 @@ void get_memusage(uint64_t * rss, uint64_t * vsz) {
 
 #ifdef __linux__
 void get_memusage_extra(uint64_t * uss, uint64_t * pss) {
-  FILE *file = fopen("/proc/self/smaps", "r");
+	FILE *file = fopen("/proc/self/smaps", "r");
 
-  char line [BUFSIZ];
-  while (fgets(line, sizeof line, file))
-    {
-      char substr[32];
-      int n;
-      if (sscanf(line, "%31[^:]: %d", substr, &n) == 2)
-        {
-	  if (strcmp(substr, "Private_Clean") == 0)  { *uss += n * 1024; }
-	  else if (strcmp(substr, "Private_Dirty") == 0)  { *uss += n * 1024; }
-	  else if (strcmp(substr, "Pss") == 0)            { *pss += n * 1024; }
-        }
-    }
-  fclose(file);
+	char line [BUFSIZ];
+	while (fgets(line, sizeof line, file)) {
+		char substr[32];
+		int n;
+		if (sscanf(line, "%31[^:]: %d", substr, &n) == 2)
+		{
+			if (strcmp(substr, "Private_Clean") == 0)
+				*uss += n * 1024;
+			else if (strcmp(substr, "Private_Dirty") == 0)
+				*uss += n * 1024;
+			else if (strcmp(substr, "Pss") == 0)
+				*pss += n * 1024;
+		}
+	}
+	fclose(file);
 }
 #endif
 

--- a/core/logging.c
+++ b/core/logging.c
@@ -864,9 +864,8 @@ void get_memusage(uint64_t * rss, uint64_t * vsz) {
 
 }
 
-//TODO: add non-linux uss and pss metrics
-void get_memusage_extra(uint64_t * uss, uint64_t * pss) {
 #ifdef __linux__
+void get_memusage_extra(uint64_t * uss, uint64_t * pss) {
   FILE *file = fopen("/proc/self/smaps", "r");
 
   char line [BUFSIZ];
@@ -882,8 +881,8 @@ void get_memusage_extra(uint64_t * uss, uint64_t * pss) {
         }
     }
   fclose(file);
-#endif
 }
+#endif
 
 void uwsgi_register_logger(char *name, ssize_t(*func) (struct uwsgi_logger *, char *, size_t)) {
 

--- a/core/logging.c
+++ b/core/logging.c
@@ -865,7 +865,7 @@ void get_memusage(uint64_t * rss, uint64_t * vsz) {
 }
 
 //TODO: add non-linux uss and pss metrics
-void get_smaps_memusage(uint64_t * uss, uint64_t * pss) {
+void get_memusage_extra(uint64_t * uss, uint64_t * pss) {
 #ifdef __linux__
   FILE *file = fopen("/proc/self/smaps", "r");
 

--- a/core/logging.c
+++ b/core/logging.c
@@ -716,17 +716,19 @@ void uwsgi_logit_simple(struct wsgi_request *wsgi_req) {
 		logvecpos++;
 	}
 
-	if (uwsgi.logging_options.memory_report == 1) {
-		rlen = snprintf(mempkt, 4096, "{address space usage: %lld bytes/%lluMB} {rss usage: %llu bytes/%lluMB} {uss usage: %llu bytes/%lluMB} {pss usage: %llu bytes/%lluMB} ",
+	if (uwsgi.logging_options.memory_report) {
+		rlen = snprintf(mempkt, 4096, "{address space usage: %lld bytes/%lluMB} {rss usage: %llu bytes/%lluMB} ",
 						(unsigned long long) uwsgi.workers[uwsgi.mywid].vsz_size,
 						(unsigned long long) uwsgi.workers[uwsgi.mywid].vsz_size / 1024 / 1024,
 						(unsigned long long) uwsgi.workers[uwsgi.mywid].rss_size,
-						(unsigned long long) uwsgi.workers[uwsgi.mywid].rss_size / 1024 / 1024,
-						(unsigned long long) uwsgi.workers[uwsgi.mywid].uss_size,
-						(unsigned long long) uwsgi.workers[uwsgi.mywid].uss_size / 1024 / 1024,
-						(unsigned long long) uwsgi.workers[uwsgi.mywid].pss_size,
-						(unsigned long long) uwsgi.workers[uwsgi.mywid].pss_size / 1024 / 1024);
-
+						(unsigned long long) uwsgi.workers[uwsgi.mywid].rss_size / 1024 / 1024);
+		if (uwsgi.logging_options.memory_report == 2) {
+			rlen += snprintf(mempkt + rlen, 4096 - rlen, "{uss usage: %llu bytes/%lluMB} {pss usage: %llu bytes/%lluMB} ",
+							(unsigned long long) uwsgi.workers[uwsgi.mywid].uss_size,
+							(unsigned long long) uwsgi.workers[uwsgi.mywid].uss_size / 1024 / 1024,
+							(unsigned long long) uwsgi.workers[uwsgi.mywid].pss_size,
+							(unsigned long long) uwsgi.workers[uwsgi.mywid].pss_size / 1024 / 1024);
+		}
 		logvec[logvecpos].iov_base = mempkt;
 		logvec[logvecpos].iov_len = rlen;
 		logvecpos++;

--- a/core/logging.c
+++ b/core/logging.c
@@ -717,8 +717,16 @@ void uwsgi_logit_simple(struct wsgi_request *wsgi_req) {
 	}
 
 	if (uwsgi.logging_options.memory_report == 1) {
-		rlen = snprintf(mempkt, 4096, "{address space usage: %lld bytes/%lluMB} {rss usage: %llu bytes/%lluMB} ", (unsigned long long) uwsgi.workers[uwsgi.mywid].vsz_size, (unsigned long long) uwsgi.workers[uwsgi.mywid].vsz_size / 1024 / 1024,
-			(unsigned long long) uwsgi.workers[uwsgi.mywid].rss_size, (unsigned long long) uwsgi.workers[uwsgi.mywid].rss_size / 1024 / 1024);
+		rlen = snprintf(mempkt, 4096, "{address space usage: %lld bytes/%lluMB} {rss usage: %llu bytes/%lluMB} {uss usage: %llu bytes/%lluMB} {pss usage: %llu bytes/%lluMB} ",
+						(unsigned long long) uwsgi.workers[uwsgi.mywid].vsz_size,
+						(unsigned long long) uwsgi.workers[uwsgi.mywid].vsz_size / 1024 / 1024,
+						(unsigned long long) uwsgi.workers[uwsgi.mywid].rss_size,
+						(unsigned long long) uwsgi.workers[uwsgi.mywid].rss_size / 1024 / 1024,
+						(unsigned long long) uwsgi.workers[uwsgi.mywid].uss_size,
+						(unsigned long long) uwsgi.workers[uwsgi.mywid].uss_size / 1024 / 1024,
+						(unsigned long long) uwsgi.workers[uwsgi.mywid].pss_size,
+						(unsigned long long) uwsgi.workers[uwsgi.mywid].pss_size / 1024 / 1024);
+
 		logvec[logvecpos].iov_base = mempkt;
 		logvec[logvecpos].iov_len = rlen;
 		logvecpos++;

--- a/core/master_utils.c
+++ b/core/master_utils.c
@@ -718,6 +718,8 @@ int uwsgi_respawn_worker(int wid) {
 	uwsgi.workers[wid].pending_harakiri = 0;
 	uwsgi.workers[wid].rss_size = 0;
 	uwsgi.workers[wid].vsz_size = 0;
+	uwsgi.workers[wid].uss_size = 0;
+	uwsgi.workers[wid].pss_size = 0;
 	// ... reset stopped_at
 	uwsgi.workers[wid].cursed_at = 0;
 	uwsgi.workers[wid].no_mercy_at = 0;
@@ -1158,6 +1160,10 @@ struct uwsgi_stats *uwsgi_master_generate_stats() {
 		if (uwsgi_stats_keylong_comma(us, "rss", (unsigned long long) uwsgi.workers[i + 1].rss_size))
 			goto end;
 		if (uwsgi_stats_keylong_comma(us, "vsz", (unsigned long long) uwsgi.workers[i + 1].vsz_size))
+			goto end;
+		if (uwsgi_stats_keylong_comma(us, "uss", (unsigned long long) uwsgi.workers[i + 1].uss_size))
+			goto end;
+		if (uwsgi_stats_keylong_comma(us, "pss", (unsigned long long) uwsgi.workers[i + 1].pss_size))
 			goto end;
 
 		if (uwsgi_stats_keylong_comma(us, "running_time", (unsigned long long) uwsgi.workers[i + 1].running_time))

--- a/core/utils.c
+++ b/core/utils.c
@@ -1092,11 +1092,13 @@ void uwsgi_close_request(struct wsgi_request *wsgi_req) {
 		uwsgi.workers[uwsgi.mywid].rss_size = rss;
 	}
 
-	if (uwsgi.reload_on_uss) {
+#ifdef __linux__
+	if (uwsgi.reload_on_uss || uwsgi.reload_on_pss) {
 		get_memusage_extra(&uss, &pss);
 		uwsgi.workers[uwsgi.mywid].uss_size = uss;
 		uwsgi.workers[uwsgi.mywid].pss_size = pss;
 	}
+#endif
 
 	if (!wsgi_req->do_not_account) {
 		uwsgi.workers[0].requests++;
@@ -1227,6 +1229,7 @@ void uwsgi_close_request(struct wsgi_request *wsgi_req) {
 		);
 	}
 
+#ifdef __linux__
 	if (uwsgi.reload_on_uss && (rlim_t) uss >= uwsgi.reload_on_uss && (end_of_request - (uwsgi.workers[uwsgi.mywid].last_spawn * 1000000) >= uwsgi.min_worker_lifetime * 1000000)) {
 		goodbye_cruel_world("reload-on-uss limit reached (%llu >= %llu)",
 			(unsigned long long) (rlim_t) uss,
@@ -1240,6 +1243,7 @@ void uwsgi_close_request(struct wsgi_request *wsgi_req) {
 			(unsigned long long) uwsgi.reload_on_pss
 		);
 	}
+#endif
 
 	// after the first request, if i am a vassal, signal Emperor about my loyalty
 	if (uwsgi.has_emperor && !uwsgi.loyal) {

--- a/core/utils.c
+++ b/core/utils.c
@@ -1056,7 +1056,10 @@ void uwsgi_close_request(struct wsgi_request *wsgi_req) {
 
 	int waitpid_status;
 	int tmp_id;
-	uint64_t tmp_rt, rss = 0, vsz = 0, uss = 0, pss = 0;
+	uint64_t tmp_rt, rss = 0, vsz = 0;
+#ifdef __linux__
+	uint64_t uss = 0, pss = 0;
+#endif
 
 	// apply transformations
 	if (wsgi_req->transformations) {

--- a/core/utils.c
+++ b/core/utils.c
@@ -1093,7 +1093,7 @@ void uwsgi_close_request(struct wsgi_request *wsgi_req) {
 	}
 
 	if (uwsgi.reload_on_uss) {
-		get_smaps_memusage(&uss, &pss);
+		get_memusage_extra(&uss, &pss);
 		uwsgi.workers[uwsgi.mywid].uss_size = uss;
 		uwsgi.workers[uwsgi.mywid].pss_size = pss;
 	}

--- a/core/utils.c
+++ b/core/utils.c
@@ -1089,14 +1089,14 @@ void uwsgi_close_request(struct wsgi_request *wsgi_req) {
 	}
 
 	// get memory usage
-	if (uwsgi.logging_options.memory_report == 1 || uwsgi.force_get_memusage) {
+	if (uwsgi.logging_options.memory_report || uwsgi.force_get_memusage) {
 		get_memusage(&rss, &vsz);
 		uwsgi.workers[uwsgi.mywid].vsz_size = vsz;
 		uwsgi.workers[uwsgi.mywid].rss_size = rss;
 	}
 
 #ifdef __linux__
-	if (uwsgi.reload_on_uss || uwsgi.reload_on_pss) {
+	if (uwsgi.logging_options.memory_report || uwsgi.reload_on_uss || uwsgi.reload_on_pss) {
 		get_memusage_extra(&uss, &pss);
 		uwsgi.workers[uwsgi.mywid].uss_size = uss;
 		uwsgi.workers[uwsgi.mywid].pss_size = pss;

--- a/core/uwsgi.c
+++ b/core/uwsgi.c
@@ -181,7 +181,7 @@ static struct uwsgi_option uwsgi_base_options[] = {
 	{"max-vars", required_argument, 'v', "set the amount of internal iovec/vars structures", uwsgi_opt_max_vars, NULL, 0},
 	{"max-apps", required_argument, 0, "set the maximum number of per-worker applications", uwsgi_opt_set_int, &uwsgi.max_apps, 0},
 	{"buffer-size", required_argument, 'b', "set internal buffer size", uwsgi_opt_set_64bit, &uwsgi.buffer_size, 0},
-	{"memory-report", no_argument, 'm', "enable memory report", uwsgi_opt_true, &uwsgi.logging_options.memory_report, 0},
+	{"memory-report", optional_argument, 'm', "enable memory report. 1 for basic (default), 2 for uss/pss (Linux only)", uwsgi_opt_set_int, &uwsgi.logging_options.memory_report, 0},
 	{"profiler", required_argument, 0, "enable the specified profiler", uwsgi_opt_set_str, &uwsgi.profiler, 0},
 	{"cgi-mode", no_argument, 'c', "force CGI-mode for plugins supporting it", uwsgi_opt_true, &uwsgi.cgi_mode, 0},
 	{"abstract-socket", no_argument, 'a', "force UNIX socket in abstract mode (Linux only)", uwsgi_opt_true, &uwsgi.abstract_socket, 0},

--- a/core/uwsgi.c
+++ b/core/uwsgi.c
@@ -560,8 +560,10 @@ static struct uwsgi_option uwsgi_base_options[] = {
 	{"limit-nproc", required_argument, 0, "limit the number of spawnable processes", uwsgi_opt_set_int, &uwsgi.rl_nproc.rlim_max, 0},
 	{"reload-on-as", required_argument, 0, "reload if address space is higher than specified megabytes", uwsgi_opt_set_megabytes, &uwsgi.reload_on_as, UWSGI_OPT_MEMORY},
 	{"reload-on-rss", required_argument, 0, "reload if rss memory is higher than specified megabytes", uwsgi_opt_set_megabytes, &uwsgi.reload_on_rss, UWSGI_OPT_MEMORY},
+#ifdef __linux__
 	{"reload-on-uss", required_argument, 0, "reload if uss memory is higher than specified megabytes", uwsgi_opt_set_megabytes, &uwsgi.reload_on_uss, UWSGI_OPT_MEMORY},
 	{"reload-on-pss", required_argument, 0, "reload if pss memory is higher than specified megabytes", uwsgi_opt_set_megabytes, &uwsgi.reload_on_pss, UWSGI_OPT_MEMORY},
+#endif
 	{"evil-reload-on-as", required_argument, 0, "force the master to reload a worker if its address space is higher than specified megabytes", uwsgi_opt_set_megabytes, &uwsgi.evil_reload_on_as, UWSGI_OPT_MASTER | UWSGI_OPT_MEMORY},
 	{"evil-reload-on-rss", required_argument, 0, "force the master to reload a worker if its rss memory is higher than specified megabytes", uwsgi_opt_set_megabytes, &uwsgi.evil_reload_on_rss, UWSGI_OPT_MASTER | UWSGI_OPT_MEMORY},
 	{"mem-collector-freq", required_argument, 0, "set the memory collector frequency when evil reloads are in place", uwsgi_opt_set_int, &uwsgi.mem_collector_freq, 0},

--- a/core/uwsgi.c
+++ b/core/uwsgi.c
@@ -560,6 +560,8 @@ static struct uwsgi_option uwsgi_base_options[] = {
 	{"limit-nproc", required_argument, 0, "limit the number of spawnable processes", uwsgi_opt_set_int, &uwsgi.rl_nproc.rlim_max, 0},
 	{"reload-on-as", required_argument, 0, "reload if address space is higher than specified megabytes", uwsgi_opt_set_megabytes, &uwsgi.reload_on_as, UWSGI_OPT_MEMORY},
 	{"reload-on-rss", required_argument, 0, "reload if rss memory is higher than specified megabytes", uwsgi_opt_set_megabytes, &uwsgi.reload_on_rss, UWSGI_OPT_MEMORY},
+	{"reload-on-uss", required_argument, 0, "reload if uss memory is higher than specified megabytes", uwsgi_opt_set_megabytes, &uwsgi.reload_on_uss, UWSGI_OPT_MEMORY},
+	{"reload-on-pss", required_argument, 0, "reload if pss memory is higher than specified megabytes", uwsgi_opt_set_megabytes, &uwsgi.reload_on_pss, UWSGI_OPT_MEMORY},
 	{"evil-reload-on-as", required_argument, 0, "force the master to reload a worker if its address space is higher than specified megabytes", uwsgi_opt_set_megabytes, &uwsgi.evil_reload_on_as, UWSGI_OPT_MASTER | UWSGI_OPT_MEMORY},
 	{"evil-reload-on-rss", required_argument, 0, "force the master to reload a worker if its rss memory is higher than specified megabytes", uwsgi_opt_set_megabytes, &uwsgi.evil_reload_on_rss, UWSGI_OPT_MASTER | UWSGI_OPT_MEMORY},
 	{"mem-collector-freq", required_argument, 0, "set the memory collector frequency when evil reloads are in place", uwsgi_opt_set_int, &uwsgi.mem_collector_freq, 0},

--- a/plugins/carbon/carbon.c
+++ b/plugins/carbon/carbon.c
@@ -293,7 +293,7 @@ static int carbon_push_stats(int retry_cycle, time_t now) {
 				total_busyness += worker_busyness;
 				u_carbon.was_busy[i-1] = 0;
 
-				if (uwsgi.logging_options.memory_report == 1 || uwsgi.force_get_memusage) {
+				if (uwsgi.logging_options.memory_report || uwsgi.force_get_memusage) {
 					// only running workers are counted in total memory stats and if memory-report option is enabled
 					total_rss += uwsgi.workers[i].rss_size;
 					total_vsz += uwsgi.workers[i].vsz_size;
@@ -306,7 +306,7 @@ static int carbon_push_stats(int retry_cycle, time_t now) {
 			wok = carbon_write(fd, "%s%s.%s.worker%d.requests %llu %llu\n", u_carbon.root_node, u_carbon.hostname, u_carbon.id, i, (unsigned long long) uwsgi.workers[i].requests, (unsigned long long) now);
 			if (!wok) goto clear;
 
-			if (uwsgi.logging_options.memory_report == 1 || uwsgi.force_get_memusage) {
+			if (uwsgi.logging_options.memory_report || uwsgi.force_get_memusage) {
 				wok = carbon_write(fd, "%s%s.%s.worker%d.rss_size %llu %llu\n", u_carbon.root_node, u_carbon.hostname, u_carbon.id, i, (unsigned long long) uwsgi.workers[i].rss_size, (unsigned long long) now);
 				if (!wok) goto clear;
 
@@ -345,7 +345,7 @@ static int carbon_push_stats(int retry_cycle, time_t now) {
 
 		}
 
-		if (uwsgi.logging_options.memory_report == 1 || uwsgi.force_get_memusage) {
+		if (uwsgi.logging_options.memory_report || uwsgi.force_get_memusage) {
 			wok = carbon_write(fd, "%s%s.%s.rss_size %llu %llu\n", u_carbon.root_node, u_carbon.hostname, u_carbon.id, (unsigned long long) total_rss, (unsigned long long) now);
 			if (!wok) goto clear;
 

--- a/uwsgi.h
+++ b/uwsgi.h
@@ -3160,7 +3160,7 @@ void logto(char *);
 
 void log_request(struct wsgi_request *);
 void get_memusage(uint64_t *, uint64_t *);
-void get_smaps_memusage(uint64_t *, uint64_t *);
+void get_memusage_extra(uint64_t *, uint64_t *);
 void harakiri(void);
 
 void stats(int);

--- a/uwsgi.h
+++ b/uwsgi.h
@@ -3053,8 +3053,10 @@ struct uwsgi_worker {
 
 	uint64_t vsz_size;
 	uint64_t rss_size;
+#ifdef __linux__
 	uint64_t uss_size;
 	uint64_t pss_size;
+#endif
 
 	uint64_t running_time;
 

--- a/uwsgi.h
+++ b/uwsgi.h
@@ -2361,10 +2361,6 @@ struct uwsgi_server {
 	int force_get_memusage;
 	rlim_t reload_on_as;
 	rlim_t reload_on_rss;
-#ifdef __linux__
-	rlim_t reload_on_uss;
-	rlim_t reload_on_pss;
-#endif
 	rlim_t evil_reload_on_as;
 	rlim_t evil_reload_on_rss;
 
@@ -2873,6 +2869,11 @@ struct uwsgi_server {
 	int spooler_reload_mercy;
 
 	int skip_atexit_teardown;
+
+#ifdef __linux__
+	rlim_t reload_on_uss;
+	rlim_t reload_on_pss;
+#endif
 };
 
 struct uwsgi_rpc {
@@ -3053,10 +3054,6 @@ struct uwsgi_worker {
 
 	uint64_t vsz_size;
 	uint64_t rss_size;
-#ifdef __linux__
-	uint64_t uss_size;
-	uint64_t pss_size;
-#endif
 
 	uint64_t running_time;
 
@@ -3093,6 +3090,11 @@ struct uwsgi_worker {
 	char name[0xff];
 
 	int shutdown_sockets;
+
+#ifdef __linux__
+	uint64_t uss_size;
+	uint64_t pss_size;
+#endif
 };
 
 

--- a/uwsgi.h
+++ b/uwsgi.h
@@ -2361,8 +2361,10 @@ struct uwsgi_server {
 	int force_get_memusage;
 	rlim_t reload_on_as;
 	rlim_t reload_on_rss;
+#ifdef __linux__
 	rlim_t reload_on_uss;
 	rlim_t reload_on_pss;
+#endif
 	rlim_t evil_reload_on_as;
 	rlim_t evil_reload_on_rss;
 
@@ -3160,7 +3162,9 @@ void logto(char *);
 
 void log_request(struct wsgi_request *);
 void get_memusage(uint64_t *, uint64_t *);
+#ifdef __linux__
 void get_memusage_extra(uint64_t *, uint64_t *);
+#endif
 void harakiri(void);
 
 void stats(int);

--- a/uwsgi.h
+++ b/uwsgi.h
@@ -3091,10 +3091,8 @@ struct uwsgi_worker {
 
 	int shutdown_sockets;
 
-#ifdef __linux__
 	uint64_t uss_size;
 	uint64_t pss_size;
-#endif
 };
 
 

--- a/uwsgi.h
+++ b/uwsgi.h
@@ -2361,6 +2361,8 @@ struct uwsgi_server {
 	int force_get_memusage;
 	rlim_t reload_on_as;
 	rlim_t reload_on_rss;
+	rlim_t reload_on_uss;
+	rlim_t reload_on_pss;
 	rlim_t evil_reload_on_as;
 	rlim_t evil_reload_on_rss;
 
@@ -3049,6 +3051,8 @@ struct uwsgi_worker {
 
 	uint64_t vsz_size;
 	uint64_t rss_size;
+	uint64_t uss_size;
+	uint64_t pss_size;
 
 	uint64_t running_time;
 
@@ -3156,6 +3160,7 @@ void logto(char *);
 
 void log_request(struct wsgi_request *);
 void get_memusage(uint64_t *, uint64_t *);
+void get_smaps_memusage(uint64_t *, uint64_t *);
 void harakiri(void);
 
 void stats(int);


### PR DESCRIPTION
This pull request adds `reload-on-pss` and `reload-on-uss` options for linux only. It parses `/proc/self/smaps` to determine these values. See [this](https://lwn.net/Articles/230975/) article for explanation of these values.

I have not yet added support for other operating systems, since my development environment is linux only right now. If we want to add more OS support, [psutil](https://github.com/giampaolo/psutil) is a good reference for multiple OS implementations.
