### PR TITLE
Add bindings to the Python API

### DIFF
--- a/plugins/python/uwsgi_pymodule.c
+++ b/plugins/python/uwsgi_pymodule.c
@@ -1488,6 +1488,27 @@ PyObject *py_uwsgi_mule_get_msg(PyObject * self, PyObject * args, PyObject *kwar
 	return msg;
 }
 
+PyObject *py_uwsgi_mule_file(PyObject * self, PyObject * args) {
+	
+	int mule_id = uwsgi.muleid;
+
+	if (PyArg_ParseTuple(args, "|i", &mule_id) && mule_id == 0) {
+		return NULL;
+	}
+
+	if (uwsgi.mules_cnt < mule_id && mule_id > 0) {
+		return PyErr_Format(PyExc_ValueError, "The id you provided doesn't correspond to any mule");
+	}
+
+	struct uwsgi_mule *mule = get_mule_by_id(mule_id);
+	if (!mule || !mule->patch) {
+		Py_INCREF(Py_None);
+		return Py_None;
+	}
+
+	return PyString_FromString(mule->patch);
+}
+
 PyObject *py_uwsgi_farm_get_msg(PyObject * self, PyObject * args) {
 
         ssize_t len = 0;
@@ -2814,6 +2835,8 @@ static PyMethodDef uwsgi_advanced_methods[] = {
 	{"add_var", py_uwsgi_add_var, METH_VARARGS, ""},
 
 	{"micros", py_uwsgi_micros, METH_VARARGS, ""},
+
+	{"mule_file", py_uwsgi_mule_file, METH_VARARGS, ""},
 
 	{NULL, NULL},
 };

--- a/plugins/python/uwsgi_pymodule.c
+++ b/plugins/python/uwsgi_pymodule.c
@@ -1489,7 +1489,7 @@ PyObject *py_uwsgi_mule_get_msg(PyObject * self, PyObject * args, PyObject *kwar
 }
 
 PyObject *py_uwsgi_mule_file(PyObject * self, PyObject * args) {
-	
+
 	int mule_id = uwsgi.muleid;
 
 	if (PyArg_ParseTuple(args, "|i", &mule_id) && mule_id == 0) {
@@ -1507,6 +1507,21 @@ PyObject *py_uwsgi_mule_file(PyObject * self, PyObject * args) {
 	}
 
 	return PyString_FromString(mule->patch);
+}
+
+PyObject *py_uwsgi_spooler_dir(PyObject * self, PyObject * args) {
+
+	struct uwsgi_spooler *spooler = uwsgi.spoolers;
+
+	for (;spooler;spooler=spooler->next) {
+		if (uwsgi.mypid == spooler->pid) {
+			if (spooler->dir) return PyString_FromString(spooler->dir);
+			Py_INCREF(Py_None);
+			return Py_None;
+		}
+	}
+
+	return PyErr_Format(PyExc_ValueError, "This process is not a spooler");
 }
 
 PyObject *py_uwsgi_farm_get_msg(PyObject * self, PyObject * args) {
@@ -2837,6 +2852,7 @@ static PyMethodDef uwsgi_advanced_methods[] = {
 	{"micros", py_uwsgi_micros, METH_VARARGS, ""},
 
 	{"mule_file", py_uwsgi_mule_file, METH_VARARGS, ""},
+	{"spooler_dir", py_uwsgi_spooler_dir, METH_VARARGS, ""},
 
 	{NULL, NULL},
 };

--- a/tests/mule_file.py
+++ b/tests/mule_file.py
@@ -1,0 +1,3 @@
+# uwsgi --master --plugins=python --mule=mule_file.py -s:0 
+import uwsgi
+print(uwsgi.mule_file())

--- a/tests/spooler_dir.py
+++ b/tests/spooler_dir.py
@@ -1,0 +1,10 @@
+# uwsgi --master --plugins=python27 --spooler=/var/spool/uwsgi/ --spooler-import spooler_dir.py
+import uwsgi
+
+
+def spooler_func(env):
+    print(uwsgi.spooler_dir())
+    return uwsgi.SPOOL_RETRY
+
+uwsgi.spooler = spooler_func
+uwsgi.spool({"foo": "bar"})


### PR DESCRIPTION
Hi,

First, I'm sorry for the inconvenience about closing a PR and opening another one. I now understand that it's only noise for you and won't do it again.

Then, the PR stuff. It adds two new functions to the Python API. Each one is about identifying a process. One for spoolers, and one for mules.

In a mule process, you can call `uwsgi.mule_file()` and get the patch applied to the mule (or None if there was no patch applied). If you give the id of a mule to the function, it will give you the patch applied to that mule, even if you're not in a mule process.

In a spooler process, you can call `uwsgi.spooler_dir()` and get the directory the spooler is monitoring. I didn't add the ability to retrieve spooler directory by id, since spooler doesn't have ids and I don't know if I should simulate an ID, by enumerating the spoolers. If you prefer me to implement it, just ask.

Again, I will add these entries to uwsgi-doc soon if it's merged. And I hope it will!

Cheers
