### PR TITLE
Fix reading inconsisntent data from spooler

### DIFF
--- a/core/spooler.c
+++ b/core/spooler.c
@@ -650,6 +650,12 @@ void spooler_manage_task(struct uwsgi_spooler *uspool, char *dir, char *task) {
 			if (uwsgi_spooler_read_header(task, spool_fd, &uh))
 				return;
 
+			// access lstat second time after getting a lock
+			// first-time lstat could be dirty (for example between writes in master)
+			if (lstat(task, &sf_lstat)) {
+				return;
+			}
+
 			if (uwsgi_spooler_read_content(spool_fd, spool_buf, &body, &body_len, &uh, &sf_lstat)) {
 				destroy_spool(dir, task);
 				return;


### PR DESCRIPTION
Hello! I got a strange behavior of uwsgi spooler on high load (try with 2.0.12 and current master). Spooler process periodically got an inconsistent data (that data we could not unpickle).

My environment

    [vagrant@hostname ~]$ uname -a
    Linux hostname 2.6.32-431.el6.x86_64 #1 SMP Fri Nov 22 03:15:09 UTC 2013 x86_64 x86_64 x86_64 GNU/Linux
    [vagrant@hostname ~]$ cat /etc/*release*
    CentOS release 6.5 (Final)

There is a test that checks for a problem. Run it in different consoles
    
First console

    uwsgi --master --http 127.0.0.1:8888 --processes 1 --wsgi-file ~/test.py --spooler ~/spool/ --spooler-processes 1

Second console

    siege -c 30 http://127.0.0.1:8888/ -b

File test.py

    import uwsgi
    import hashlib
    import subprocess
    
    string = '1' * 10000
    md5 = hashlib.md5(string).hexdigest()
    
    def application(env, start_response):
        uwsgi.spool(body=string, md5=md5)
    
        start_response('200 OK', [('Content-Type','text/html')])
        return ["Hello World"]
    
    
    def spooler(env):
        if 'md5' not in env:
            subprocess.call('echo "Md5 not in env!" | wall', shell=True)
        if env['md5'] != md5:
            subprocess.call('echo "Md5 wrong!" | wall', shell=True)
        if 'body' not in env:
            subprocess.call('echo "Body not in env!" | wall', shell=True)
        if hashlib.md5(env['body']).hexdigest() != env['md5']:
            subprocess.call('echo "Body wrong md5!" | wall', shell=True)
    
        return uwsgi.SPOOL_OK
    
    uwsgi.spooler = spooler


Also i never got a "Md5 not in env!" or "Md5 wrong!" message...