### PR TITLE
graceful shutdown resets pending responses resulting in 502 errors

### DIFF
--- a/core/loop.c
+++ b/core/loop.c
@@ -60,6 +60,8 @@ void *uwsgi_get_loop(char *name) {
 
 void simple_loop() {
 	uwsgi_loop_cores_run(simple_loop_run);
+	if (uwsgi.workers[uwsgi.mywid].close_sockets)
+		uwsgi_close_all_sockets();
 }
 
 void uwsgi_loop_cores_run(void *(*func) (void *)) {

--- a/core/socket.c
+++ b/core/socket.c
@@ -1259,8 +1259,10 @@ void uwsgi_close_all_sockets() {
         struct uwsgi_socket *uwsgi_sock = uwsgi.sockets;
 
         while (uwsgi_sock) {
-                if (uwsgi_sock->bound)
+                if (uwsgi_sock->bound) {
+                        shutdown(uwsgi_sock->fd, SHUT_RDWR);
                         close(uwsgi_sock->fd);
+                }
                 uwsgi_sock = uwsgi_sock->next;
         }
 }

--- a/core/uwsgi.c
+++ b/core/uwsgi.c
@@ -1288,6 +1288,7 @@ void gracefully_kill(int signum) {
 		struct wsgi_request *wsgi_req = current_wsgi_req();
 		wait_for_threads();
 		if (!uwsgi.workers[uwsgi.mywid].cores[wsgi_req->async_id].in_request) {
+			uwsgi_close_all_sockets();
 			exit(UWSGI_RELOAD_CODE);
 		}
 		return;
@@ -1296,10 +1297,12 @@ void gracefully_kill(int signum) {
 
 	// still not found a way to gracefully reload in async mode
 	if (uwsgi.async > 0) {
+		uwsgi_close_all_sockets();
 		exit(UWSGI_RELOAD_CODE);
 	}
 
 	if (!uwsgi.workers[uwsgi.mywid].cores[0].in_request) {
+		uwsgi_close_all_sockets();
 		exit(UWSGI_RELOAD_CODE);
 	}
 }

--- a/uwsgi.h
+++ b/uwsgi.h
@@ -3048,6 +3048,7 @@ struct uwsgi_worker {
 	int manage_next_request;
 
 	int destroy;
+	int close_sockets;
 
 	int apps_cnt;
 	struct uwsgi_app *apps;

--- a/uwsgi.h
+++ b/uwsgi.h
@@ -3048,7 +3048,6 @@ struct uwsgi_worker {
 	int manage_next_request;
 
 	int destroy;
-	int close_sockets;
 
 	int apps_cnt;
 	struct uwsgi_app *apps;
@@ -3077,6 +3076,8 @@ struct uwsgi_worker {
 	int accepting;
 
 	char name[0xff];
+
+	int close_sockets;
 };
 
 


### PR DESCRIPTION
We front uwsgi with nginx, and shutdown uwsgi by sending "q" to the master fifo. This causes uwsgi to finish processing any requests and then exit, which closes the sockets that nginx is reading.

If nginx has not yet finished reading a response, it gets an RST from uwsgi and fails the request with a 502 and logs the ECONNRESET (104):
```
2016/09/29 22:11:00 [error] 32643#0: *79 recv() failed (104: Connection reset by peer) while reading response header from upstream, client: 127.0.0.1, server: , request: "GET / HTTP/1.1", upstream: "uwsgi://unix:/tmp/uwsgi.sock:", host: "localhost:9091"
127.0.0.1 - - [29/Sep/2016:22:11:00 +0000] "GET / HTTP/1.1" 502 173 "-" "curl/7.35.0"
```

So when gracefully shutting down uwsgi, nginx is returning HTTP 502 errors to clients.

The socket needs to be shutdown() before closing so that we go through a normal `FIN -> ACK/FIN -> ACK -> closed` roundtrip and then can safely close the socket.

> close() with any pending readable data could lead to an immediate reset being sent

https://blog.netherlabs.nl/articles/2009/01/18/the-ultimate-so_linger-page-or-why-is-my-tcp-not-reliable

This PR attempts to fix this.

You can reproduce the issue using nginx and uwsgi with the config files and scripts in this gist
https://gist.github.com/rectalogic/0f7603be7d4c8e8520598d8b9e42c3e1#file-readme-md

Clone the gist, symlink nginx and uwsgi binaries into that directory and run `nginx.sh` and `uwsgi.sh` in separate terminals, and then `runquit.sh` and watch nginx stderr for the `recv() failed (104: Connection reset by peer)` error.