### PR TITLE
core: Add a --skip-atexit-teardown option to skip perl/python teardown

### DIFF
--- a/core/uwsgi.c
+++ b/core/uwsgi.c
@@ -95,6 +95,7 @@ static struct uwsgi_option uwsgi_base_options[] = {
 
 	{"skip-zero", no_argument, 0, "skip check of file descriptor 0", uwsgi_opt_true, &uwsgi.skip_zero, 0},
 	{"skip-atexit", no_argument, 0, "skip atexit hooks (ignored by the master)", uwsgi_opt_true, &uwsgi.skip_atexit, 0},
+	{"skip-atexit-teardown", no_argument, 0, "skip atexit teardown (ignored by the master)", uwsgi_opt_true, &uwsgi.skip_atexit_teardown, 0},
 
 	{"set", required_argument, 'S', "set a placeholder or an option", uwsgi_opt_set_placeholder, NULL, UWSGI_OPT_IMMEDIATE},
 	{"set-placeholder", required_argument, 0, "set a placeholder", uwsgi_opt_set_placeholder, (void *) 1, UWSGI_OPT_IMMEDIATE},

--- a/plugins/psgi/psgi_plugin.c
+++ b/plugins/psgi/psgi_plugin.c
@@ -854,6 +854,12 @@ realstuff:
 		uwsgi_perl_run_hook(uperl.atexit);
 	}
 
+	// For the reasons explained in
+	// https://github.com/unbit/uwsgi/issues/1384, tearing down
+	// the interpreter can be very expensive.
+	if (uwsgi.skip_atexit_teardown)
+		return;
+
 destroyperl:
 
         // We must free our perl context(s) so any DESTROY hooks

--- a/plugins/python/python_plugin.c
+++ b/plugins/python/python_plugin.c
@@ -406,6 +406,12 @@ realstuff:
 			PyErr_Clear();
 	}
 
+	// For the reasons explained in
+	// https://github.com/unbit/uwsgi/issues/1384, tearing down
+	// the interpreter can be very expensive.
+	if (uwsgi.skip_atexit_teardown)
+		return;
+
 	Py_Finalize();
 }
 

--- a/uwsgi.h
+++ b/uwsgi.h
@@ -2862,6 +2862,8 @@ struct uwsgi_server {
 	struct uwsgi_string_list *touch_mules_reload;
 	struct uwsgi_string_list *touch_spoolers_reload;
 	int spooler_reload_mercy;
+
+	int skip_atexit_teardown;
 };
 
 struct uwsgi_rpc {


### PR DESCRIPTION
This is a general option meant to be used for any number of embedded
languages, but which is currently just used by python & perl.

As detailed at length in my issue #1384[1] the full destruction I
added for perl in 1dcdb72[2] can be *very* expensive when a child
dies, and in particular when all children die at once when the server
goes down. This was first introduced in uWSGI 2.0.9.

This is not a perl-specific issue as the issue notes, but rather a
generic issue with embedding any number of programming language
interpreters & compilers. Fully tearing them down can be very
expensive, but just calling C's exit function is cheap, and often
people running uWSGI at scale are very willing to make that trade-off.

This issue also impacts python embedding since uWSGI 1.1 (f4f4d5a) as
noted in a follow-up comment of mine to that issue.

So to fix this add a --skip-atexit-teardown option to allow skipping
DESTROY during perl destruction, __del__ during python destruction
etc. This can then be used for other languages in the future as we add
uwsgi_*_atexit handlers for them.

This emulates the hack of calling POSIX::_exit() in perl or
os._exit(0) in python at the very end of the atexit handler, but
allows uWSGI to do any cleanup it wanted to do on its own after
calling atexit.

1. https://github.com/unbit/uwsgi/issues/1384
2. https://github.com/unbit/uwsgi/commit/1dcdb72