### PR TITLE
[fix] `event_queue_wait_multi' writes out-of-bounds

### DIFF
--- a/core/event.c
+++ b/core/event.c
@@ -173,6 +173,9 @@ int event_queue_wait_multi(int eq, int timeout, void *events, int nevents) {
                 int i;
                 for(i=0;i<upe->nevents;i++) {
                         if (upe->poll[i].revents) {
+				if (cnt >= nevents)
+					break;
+
 				struct pollfd *pevents = (struct pollfd *)events;	
 				struct pollfd *upoll = &pevents[cnt];
 				upoll->fd = upe->poll[i].fd;


### PR DESCRIPTION
In case uwsgi is compiled with UWSGI_EVENT_USE_POLL and `event_queue_wait_multi` is used, it is possible to get out-of-bound writes into `events` pointer in some circumstances.  Consider

    evq = event_queue_init()
    event_queue_add_fd_read(evq, fd1)
    event_queue_add_fd_read(evq, fd2)
    events = event_queue_alloc(1)
    event_queue_wait_multi(evq, 30, events, 1)

and in this moment both `fd1` and `fd2` triggers simultaneously, this will cause writing into `events[1]` which is out-of-bounds
