### PR TITLE
Fix SystemError exception when async_args PyTuple is reused. #1408

### DIFF
--- a/plugins/python/pump_subhandler.c
+++ b/plugins/python/pump_subhandler.c
@@ -142,7 +142,12 @@ void *uwsgi_request_subhandler_pump(struct wsgi_request *wsgi_req, struct uwsgi_
 
 	// call
 
-	PyTuple_SetItem(wsgi_req->async_args, 0, wsgi_req->async_environ);
+	if (PyTuple_GetItem(wsgi_req->async_args, 0) != wsgi_req->async_environ) {
+	    if (PyTuple_SetItem(wsgi_req->async_args, 0, wsgi_req->async_environ)) {
+	        uwsgi_log_verbose("unable to set environ to the python application callable, consider using the holy env allocator\n");
+	        return NULL;
+	    }
+	}
 	return python_call(wsgi_req->async_app, wsgi_req->async_args, uwsgi.catch_exceptions, wsgi_req);
 }
 

--- a/plugins/python/web3_subhandler.c
+++ b/plugins/python/web3_subhandler.c
@@ -103,7 +103,12 @@ void *uwsgi_request_subhandler_web3(struct wsgi_request *wsgi_req, struct uwsgi_
 
 	// call
 
-	PyTuple_SetItem(wsgi_req->async_args, 0, wsgi_req->async_environ);
+	if (PyTuple_GetItem(wsgi_req->async_args, 0) != wsgi_req->async_environ) {
+	    if (PyTuple_SetItem(wsgi_req->async_args, 0, wsgi_req->async_environ)) {
+	        uwsgi_log_verbose("unable to set environ to the python application callable, consider using the holy env allocator\n");
+	        return NULL;
+	    }
+	}
 	return python_call(wsgi_req->async_app, wsgi_req->async_args, uwsgi.catch_exceptions, wsgi_req);
 }
 


### PR DESCRIPTION
In the case where the uwsgi_python_create_env_cheat env behavior is
used, the async_args PyTuple is reused on every request.

In some cases, the reference count on async_args may be > 1 at the end
of a request/response cycle. If PyTuple_SetItem is called with a
reference count > 1, a SystemError is raised.

When the cheat env behavior is used, the environ dictionary is also
reused between requests. This enables the elimination of redundant
PyTuple_SetItem calls by first checking to see if the environ dictionary
is already in the async_args tuple.