### PR TITLE
fix offload-threads with honour-range

### DIFF
--- a/core/offload.c
+++ b/core/offload.c
@@ -674,11 +674,12 @@ void uwsgi_offload_engines_register_all() {
 	uwsgi.offload_engine_pipe = uwsgi_offload_register_engine("pipe", u_offload_pipe_prepare, u_offload_pipe_do);
 }
 
-int uwsgi_offload_request_sendfile_do(struct wsgi_request *wsgi_req, int fd, size_t len) {
+int uwsgi_offload_request_sendfile_do(struct wsgi_request *wsgi_req, int fd, size_t pos, size_t len) {
 	struct uwsgi_offload_request uor;
 	uwsgi_offload_setup(uwsgi.offload_engine_sendfile, &uor, wsgi_req, 1);
 	uor.fd = fd;
 	uor.len = len;
+	uor.pos = pos;
 	return uwsgi_offload_run(wsgi_req, &uor, NULL);
 }
 

--- a/core/writer.c
+++ b/core/writer.c
@@ -634,7 +634,7 @@ sendfile:
 			fd = tmp_fd;
 			can_close = 1;
 		}
-       		if (!uwsgi_offload_request_sendfile_do(wsgi_req, fd, len)) {
+		if (!uwsgi_offload_request_sendfile_do(wsgi_req, fd, pos, len)) {
                 	wsgi_req->via = UWSGI_VIA_OFFLOAD;
 			wsgi_req->response_size += len;
                         return 0;

--- a/plugins/router_static/router_static.c
+++ b/plugins/router_static/router_static.c
@@ -248,7 +248,7 @@ send:
         }
 
 	if (wsgi_req->socket->can_offload) {
-		if (!uwsgi_offload_request_sendfile_do(wsgi_req, fd, st.st_size)) {
+		if (!uwsgi_offload_request_sendfile_do(wsgi_req, fd, 0, st.st_size)) {
                         wsgi_req->via = UWSGI_VIA_OFFLOAD;
                         wsgi_req->response_size += st.st_size;
                 	// the fd will be closed by the offload engine

--- a/plugins/transformation_offload/offload.c
+++ b/plugins/transformation_offload/offload.c
@@ -25,7 +25,7 @@ static int transform_offload(struct wsgi_request *wsgi_req, struct uwsgi_transfo
 		struct uwsgi_transformation *orig_ut = (struct uwsgi_transformation *) ut->data;
 		// sendfile offload
 		if (orig_ut->fd > -1) {
-			if (!uwsgi_offload_request_sendfile_do(wsgi_req, orig_ut->fd, orig_ut->len)) {
+			if (!uwsgi_offload_request_sendfile_do(wsgi_req, orig_ut->fd, 0, orig_ut->len)) {
 				// the fd will be closed by the offload engine
 				orig_ut->fd = -1;
                         	wsgi_req->via = UWSGI_VIA_OFFLOAD;

--- a/uwsgi.h
+++ b/uwsgi.h
@@ -4483,7 +4483,7 @@ int uwsgi_offload_run(struct wsgi_request *, struct uwsgi_offload_request *, int
 void uwsgi_offload_engines_register_all(void);
 
 struct uwsgi_thread *uwsgi_offload_thread_start(void);
-int uwsgi_offload_request_sendfile_do(struct wsgi_request *, int, size_t);
+int uwsgi_offload_request_sendfile_do(struct wsgi_request *, int, size_t, size_t);
 int uwsgi_offload_request_net_do(struct wsgi_request *, char *, struct uwsgi_buffer *);
 int uwsgi_offload_request_memory_do(struct wsgi_request *, char *, size_t);
 int uwsgi_offload_request_pipe_do(struct wsgi_request *, int, size_t);


### PR DESCRIPTION
```
when using --offload-threads with static files, the range request
offset was not passed to the offload thread, meaning uwsgi would
respond with 206 Partial Content, but return the entire file.
```

I've tested this in our staging environment and it fixes the particular problem we were having: serving video requires range requests in most browsers, but we use offload-threads, and it caused playback to hang when the browser made the first range request.

It hasn't had a lot of testing, and there may still be other places it's broken, but I don't think it's introduced any new bugs.