### PR TITLE
fix uwsgi_request_body_readline without new lines found 

### DIFF
--- a/core/reader.c
+++ b/core/reader.c
@@ -283,7 +283,7 @@ char *uwsgi_request_body_readline(struct wsgi_request *wsgi_req, ssize_t hint, s
                 }
 
 	// no line found, let's return all
-        *rlen = wsgi_req->post_readline_size - wsgi_req->post_readline_pos;
+        *rlen = wsgi_req->post_readline_watermark - wsgi_req->post_readline_pos;
         char *buf = wsgi_req->post_readline_buf + wsgi_req->post_readline_pos;
 	wsgi_req->post_readline_pos = 0;
 	return buf;

--- a/t/core/readline/app.py
+++ b/t/core/readline/app.py
@@ -1,0 +1,16 @@
+#!/usr/bin/python3
+# uwsgi --plugin python,http --http 0.0.0.0:8000 -w app
+
+from werkzeug.wrappers import Request, Response
+
+
+def application(env, start_response):
+    request = Request(env)
+    lines = b""
+    while True:
+        line = request.stream.readline()
+        if not line:
+            break;
+        lines += line
+    response = Response(lines)
+    return response(env, start_response)

--- a/t/core/readline/client.py
+++ b/t/core/readline/client.py
@@ -1,0 +1,8 @@
+import requests
+
+headers = {'Content-Type': 'application/octet-stream'}
+data = '\n'.join(['{:04}'.format(i) for i in range(1001)] + ['final'])
+
+r = requests.post("http://127.0.0.1:8000", data=data, headers=headers)
+
+assert r.text == data

--- a/t/core/readline/requirements.txt
+++ b/t/core/readline/requirements.txt
@@ -1,0 +1,2 @@
+requests
+Werkzeug


### PR DESCRIPTION
The language-independent readline implementation in uwsgi's
core/reader.c appears to contain a flaw causing it to append extra bytes
from the readline buffer to the final line returned, if the request body
is not terminated by a newline. Reproducing this seems to require that
the request body is at least 4KB in size.

While this reproduction only causes extra data from the readline buffer
to be returned, we have also seen cases where the returned extra bytes
seem to be other unrelated data from the process heap. This has probably
been caused by consume_body_for_readline() having realloced the buffer
just before.

Fixes #1412 