### PR TITLE
fix several issues with zend_register_string_constant

### DIFF
--- a/plugins/php/php_plugin.c
+++ b/plugins/php/php_plugin.c
@@ -225,17 +225,6 @@ static void sapi_uwsgi_register_variables(zval *track_vars_array TSRMLS_DC)
 		}
 		usl = usl->next;
 	}
-	usl = uphp.constants;
-	while(usl) {
-		char *equal = strchr(usl->value, '=');
-		if (equal) {
-			size_t name_len = equal-usl->value;
-			char *name = estrndup(usl->value, name_len);
-			char *strval = equal+1;
-			zend_register_string_constant(name, name_len, strval, CONST_CS, 0 TSRMLS_CC);
-		}
-		usl = usl->next;
-	}
 }
 
 static sapi_module_struct uwsgi_sapi_module;
@@ -265,6 +254,21 @@ void uwsgi_php_set(char *opt) {
 extern ps_module ps_mod_uwsgi;
 PHP_MINIT_FUNCTION(uwsgi_php_minit) {
 	php_session_register_module(&ps_mod_uwsgi);
+	struct uwsgi_string_list *usl = uphp.constants;
+	while(usl) {
+		char *equal = strchr(usl->value, '=');
+		if (equal) {
+			size_t name_len = equal - usl->value;
+			char *name = usl->value;
+			char *strval = equal + 1;
+			equal = NULL;
+#ifndef UWSGI_PHP7
+			name_len = name_len + 1;
+#endif
+			zend_register_string_constant(name, name_len, strval, CONST_CS | CONST_PERSISTENT, module_number TSRMLS_CC);
+		}
+		usl = usl->next;
+	}
 	return SUCCESS;
 }
 


### PR DESCRIPTION
* move the call in the PHP_MINIT_FUNCTION(uwsgi_php_minit) function and
make the constants persistent. they don't change
* there seems to be some difference between php5 and php7 how it wants
the `name_len` in the call. php5 wants to include the NULL terminator
too. (super weird)
* introduce module_number too - for whatever reason it is