### PR TITLE
corerouter: set the proper client port (for REMOTE_PORT)

### DIFF
--- a/plugins/corerouter/corerouter.c
+++ b/plugins/corerouter/corerouter.c
@@ -649,7 +649,7 @@ struct corerouter_session *corerouter_alloc_session(struct uwsgi_corerouter *ucr
 				cs->client_port[0] = '0';
 				cs->client_port[1] = 0;
 			}
-			uwsgi_num2str2(cs->client_sockaddr.sa_in.sin_port, cs->client_port);
+			uwsgi_num2str2(ntohs(cs->client_sockaddr.sa_in.sin_port), cs->client_port);
 			break;
 #ifdef AF_INET6
 		case AF_INET6:
@@ -659,7 +659,7 @@ struct corerouter_session *corerouter_alloc_session(struct uwsgi_corerouter *ucr
 				cs->client_port[0] = '0';
 				cs->client_port[1] = 0;
 			}
-			uwsgi_num2str2(cs->client_sockaddr.sa_in6.sin6_port, cs->client_port);
+			uwsgi_num2str2(ntohs(cs->client_sockaddr.sa_in6.sin6_port), cs->client_port);
 			break;
 #endif
 		default:


### PR DESCRIPTION
When using the http server the "REMOTE_PORT" isn't set properly, and it needs to pass through ntohs().
I couldn't check ipv6, but I assumed it will have the same issue.