### PR TITLE
Fix cmdline override using --auto-procname

### DIFF
--- a/core/uwsgi.c
+++ b/core/uwsgi.c
@@ -1811,9 +1811,7 @@ static void fixup_argv_and_environ(int argc, char **argv, char **environ, char *
 	uwsgi.argv = uwsgi_malloc(sizeof(char *) * (argc + 1));
 
 	for (i = 0; i < argc; i++) {
-		if (i == 0 || argv[0] + uwsgi.max_procname + 1 == argv[i]) {
-			uwsgi.max_procname += strlen(argv[i]) + 1;
-		}
+		uwsgi.max_procname += strlen(argv[i]) + 1;
 		uwsgi.argv[i] = strdup(argv[i]);
 	}
 
@@ -1823,10 +1821,6 @@ static void fixup_argv_and_environ(int argc, char **argv, char **environ, char *
 	uwsgi.max_procname++;
 
 	for (i = 0; environ[i] != NULL; i++) {
-		// useless
-		//if ((environ[0] + uwsgi.max_procname + 1) == environ[i]) {
-		uwsgi.max_procname += strlen(environ[i]) + 1;
-		//}
 		env_count++;
 	}
 


### PR DESCRIPTION
I've noticed that the `--auto-procname` option doesn't always work well. It works fine if I run uWSGI like `uwsgi --http :9090 --wsgi-file foobar.py`, but it doesn't work in our prod environment. If I run `ps aux | grep uWSGI` there I get:
```
www-data 111557 67.3  3.2 1974168 997992 ?      Sl   16:01   0:24 yelp_main uWSGI worker 30                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       2 --http 127.0.0.1:2080 --stats 0.0.0.0:2081 --stats-http --route ^/status/uwsgi http:127.0.0.1:2081 --collect-header Content-Length BODY_SIZE --response-route-if equal:${BODY_SIZE};0 goto:error_404 --response-route-run last: --response-route-label error_404 --response-route-status 404 addvar:REDIRECT_STATUS=404 --response-route-status 404 uwsgi:127.0.0.1:2010,, --collect-header Content-Length BODY_SIZE --response-route-if equal:${BODY_SIZE};0 goto:error_500 --response-route-run last: --response-route-label error_500 --response-route-status 500 addvar:REDIRECT_STATUS=500 --response-route-status 500 uwsgi:127.0.0.1:2010,, --py-call-osafterfork --skip-atexit-teardown --log-master --threaded-logger
www-data 111718 73.7  3.1 1951912 976552 ?      Sl   16:01   0:20 yelp_main uWSGI worker 9                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        2 --http 127.0.0.1:2080 --stats 0.0.0.0:2081 --stats-http --route ^/status/uwsgi http:127.0.0.1:2081 --collect-header Content-Length BODY_SIZE --response-route-if equal:${BODY_SIZE};0 goto:error_404 --response-route-run last: --response-route-label error_404 --response-route-status 404 addvar:REDIRECT_STATUS=404 --response-route-status 404 uwsgi:127.0.0.1:2010,, --collect-header Content-Length BODY_SIZE --response-route-if equal:${BODY_SIZE};0 goto:error_500 --response-route-run last: --response-route-label error_500 --response-route-status 500 addvar:REDIRECT_STATUS=500 --response-route-status 500 uwsgi:127.0.0.1:2010,, --py-call-osafterfork --skip-atexit-teardown --log-master --threaded-logger
www-data 111719 67.5  3.1 1950768 976616 ?      Rl   16:01   0:18 yelp_main uWSGI worker 29                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       2 --http 127.0.0.1:2080 --stats 0.0.0.0:2081 --stats-http --route ^/status/uwsgi http:127.0.0.1:2081 --collect-header Content-Length BODY_SIZE --response-route-if equal:${BODY_SIZE};0 goto:error_404 --response-route-run last: --response-route-label error_404 --response-route-status 404 addvar:REDIRECT_STATUS=404 --response-route-status 404 uwsgi:127.0.0.1:2010,, --collect-header Content-Length BODY_SIZE --response-route-if equal:${BODY_SIZE};0 goto:error_500 --response-route-run last: --response-route-label error_500 --response-route-status 500 addvar:REDIRECT_STATUS=500 --response-route-status 500 uwsgi:127.0.0.1:2010,, --py-call-osafterfork --skip-atexit-teardown --log-master --threaded-logger
```
If you scroll far enough to the right, you'll see that some of the original command line options are still there.

AFAICT this only happens when execve is called with an envp (i.e. subprocess being called with env=...). To reproduce this bug use the following code (this is the simplest way I've found to reproduce the problem):
```C
#include <unistd.h>
 
int main() {
  char* argv[] = {"/home/drolando/Development/yelp/uwsgi/uwsgi", "--daemonize2", "/dev/null", "--chdir", "/home/drolando/Development/yelp/uwsgi_test", "-M", "--processes", "3", "--auto-procname", "--procname-prefix-spaced", "foo_bar", "--callable=application", "--need-app", "--http", ":12345", "--wsgi-file", "/home/drolando/Development/yelp/uwsgi/tests/cpubound_green.py", 0};
  char* envp[] = {"FOO=bar", 0};
 
  return execve(argv[0], &argv[0], envp);
}
```
----
I had a look at how uWSGI overrides the original cmdline string and tried to fix it, but I find this code quite confusing.

1. Why aren't we always incrementing `uwsgi.max_procname` by the length of argv[i]?
2. `argv[0] + uwsgi.max_procname + 1 == argv[i]` seems useless to me: that +1 makes it always false, if you remove the +1 it'll always be true since that's simple pointer aritmetic.
3. why adding the length of all environment variables to max_procname? They don't appear in the standard `/proc/<pid>/cmdline`, so that seems wrong.

What was the idea behind this code? Am I missing some corner case?

----
I manually tested my change by both running my example above and running uwsgi normally from the command line and it worked in both cases.