### PR TITLE
fix compilation with php 7.1

### DIFF
--- a/plugins/php/php_plugin.c
+++ b/plugins/php/php_plugin.c
@@ -568,8 +568,11 @@ static int php_uwsgi_startup(sapi_module_struct *sapi_module)
 	}
 }
 
+#if ((PHP_MAJOR_VERSION >= 7) && (PHP_MINOR_VERSION >= 1))
+static void sapi_uwsgi_log_message(char *message, int syslog_type_int) {
+#else
 static void sapi_uwsgi_log_message(char *message TSRMLS_DC) {
-
+#endif
 	uwsgi_log("%s\n", message);
 }
 


### PR DESCRIPTION
php 7.1 changed the signature of the log_message function in
sapi_module_struct. Let's assume it will stay like this for all versions >= 7.1

fixes #1427 

applies to the uwsgi-2.0 branch too