### PR TITLE
fix broken response when no_threads_wait option.

### DIFF
--- a/core/uwsgi.c
+++ b/core/uwsgi.c
@@ -1242,7 +1242,7 @@ void wait_for_threads() {
 			if (! is_busy){
 				break;
 			}
-			sleep(0.1);
+			sleep(0.001);
 		}
 		return;
 	}

--- a/core/uwsgi.c
+++ b/core/uwsgi.c
@@ -1234,7 +1234,18 @@ void wait_for_threads() {
 	int i, ret;
 
 	// on some platform thread cancellation is REALLY flaky
-	if (uwsgi.no_threads_wait) return;
+	if (uwsgi.no_threads_wait){
+		int is_busy;
+		for(;;){
+			is_busy = uwsgi_worker_is_busy(uwsgi.mywid);
+			uwsgi_log("wait_for_threads worker_is_busy? %d mywid:%d mypid:%d\n", is_busy, uwsgi.mywid, uwsgi.mypid);
+			if (! is_busy){
+				break;
+			}
+			sleep(0.1);
+		}
+		return;
+	}
 
 	int sudden_death = 0;
 

--- a/core/uwsgi.c
+++ b/core/uwsgi.c
@@ -1238,7 +1238,6 @@ void wait_for_threads() {
 		int is_busy;
 		for(;;){
 			is_busy = uwsgi_worker_is_busy(uwsgi.mywid);
-			uwsgi_log("wait_for_threads worker_is_busy? %d mywid:%d mypid:%d\n", is_busy, uwsgi.mywid, uwsgi.mypid);
 			if (! is_busy){
 				break;
 			}

--- a/core/uwsgi.c
+++ b/core/uwsgi.c
@@ -1241,7 +1241,7 @@ void wait_for_threads() {
 			if (! is_busy){
 				break;
 			}
-			sleep(0.001);
+			sleep(1);
 		}
 		return;
 	}

--- a/core/uwsgi.c
+++ b/core/uwsgi.c
@@ -1332,12 +1332,11 @@ void end_me(int signum) {
 }
 
 static void simple_goodbye_cruel_world(const char *reason) {
-
+	uwsgi.workers[uwsgi.mywid].manage_next_request = 0;
 	if (uwsgi.threads > 1 && !uwsgi_instance_is_dying) {
 		wait_for_threads();
 	}
 
-	uwsgi.workers[uwsgi.mywid].manage_next_request = 0;
 	uwsgi_log("...The work of process %d is done (%s). Seeya!\n", getpid(), (reason != NULL ? reason : "no reason given"));
 	exit(0);
 }


### PR DESCRIPTION
in `docker alpine` environment,  with `--max-requests` option make hung up worker, and end up worker killed by uwsgi_master_check_mercy() .

```
Thu Dec 15 22:38:00 2016 - worker 1 (pid: 1186) is taking too much time to die...NO MERCY !!!
```

may be `pthread_cancel/pthrad_join` not work properly in (docker alpine) `musl libc`.

next, I try `--no-threads-wait` option, but this make response content corruption sometimes.

so, I tried use uwsgi_worker_is_busy() instead of pthread_join(). 

```
# run uwsgi with --no-threads-wait
$ make
$ ./uwsgi --http=0.0.0.0:8000 --static-check=. --master --threads=2 --max-requests=1 \
    --min-worker-lifetime=1 --worker-reload-mercy=10 --reload-mercy=10 --no-threads-wait
```

it seems to work fine.

@unbit please review.
