### PR TITLE
Fix invalid php session plugin behaviour

### DIFF
--- a/plugins/php/session.c
+++ b/plugins/php/session.c
@@ -18,7 +18,7 @@ PS_READ_FUNC(uwsgi) {
 	char *value = uwsgi_cache_magic_get((char *)key, strlen((char *)key), &valsize, NULL, cache);
 #endif
 	if (!value) {
-		*val = ZSTR_EMPTY_ALLOC();
+		*val = STR_EMPTY_ALLOC();
 		return SUCCESS;
 	}
 #ifdef UWSGI_PHP7

--- a/plugins/php/session.c
+++ b/plugins/php/session.c
@@ -17,7 +17,10 @@ PS_READ_FUNC(uwsgi) {
 #else
 	char *value = uwsgi_cache_magic_get((char *)key, strlen((char *)key), &valsize, NULL, cache);
 #endif
-        if (!value) return FAILURE;
+	if (!value) {
+		*val = ZSTR_EMPTY_ALLOC();
+		return SUCCESS;
+	}
 #ifdef UWSGI_PHP7
 	*val = zend_string_init(value, valsize, 0);
 #else


### PR DESCRIPTION
Make php session plugin return an empty string if the entry does not
exist.

As far as I can tell this has always been the right way, and php
accepting FAILURE was to support "broken" plugins. It seems that, at
least on my system, php 7.1 now requires correct behaviour.