### PR TITLE
get uwsgi.route() working again from python

### DIFF
--- a/core/routing.c
+++ b/core/routing.c
@@ -535,6 +535,7 @@ int uwsgi_route_api_func(struct wsgi_request *wsgi_req, char *router, char *args
 	return -1;
 found:
 	ur = uwsgi_calloc(sizeof(struct uwsgi_route));
+	uwsgi_fixup_routes(ur);
 	// initialize the virtual route
 	if (r->func(ur, args)) {
 		free(ur);


### PR DESCRIPTION
I was getting very similar crashes to that reported in #1041.  It crashes because `ur->condition_ub` and `ur->ovn` are `NULL` on entry to `uwsgi_routing_translate()`.

I'm presuming that these were supposed to be initialised somewhere else, but not sure where.  This was my first guess and appears to fix it for me!