### PR TITLE
Fixes for gevent after running with valgrind

### DIFF
--- a/core/io.c
+++ b/core/io.c
@@ -1280,7 +1280,10 @@ void uwsgi_setup_schemes() {
 
 struct uwsgi_string_list *uwsgi_check_scheme(char *file) {
 	struct uwsgi_string_list *usl;
+	size_t len = strlen(file);
 	uwsgi_foreach(usl, uwsgi.schemes) {
+		if (len < usl->len+3)
+			continue;
 		char *url = uwsgi_concat2(usl->value, "://");
 		int ret = uwsgi_startswith(file, url, strlen(url));
 		free(url);

--- a/core/routing.c
+++ b/core/routing.c
@@ -535,6 +535,7 @@ int uwsgi_route_api_func(struct wsgi_request *wsgi_req, char *router, char *args
 	return -1;
 found:
 	ur = uwsgi_calloc(sizeof(struct uwsgi_route));
+	uwsgi_fixup_routes(ur);
 	// initialize the virtual route
 	if (r->func(ur, args)) {
 		free(ur);

--- a/plugins/python/python_plugin.c
+++ b/plugins/python/python_plugin.c
@@ -1092,7 +1092,6 @@ void *uwsgi_python_create_env_holy(struct wsgi_request *wsgi_req, struct uwsgi_a
 }
 
 void uwsgi_python_destroy_env_holy(struct wsgi_request *wsgi_req) {
-	Py_DECREF((PyObject *)wsgi_req->async_environ);
 	Py_DECREF((PyObject *) wsgi_req->async_args);
 	// in non-multithread modes, we set uwsgi.env incrementing the refcount of the environ
 	if (uwsgi.threads < 2) {


### PR DESCRIPTION
My attempt at fixing reference errors when running with `gevent`.  I was experiencing strange crashes while running through the article on [uWSGI and SSE's](http://uwsgi-docs.readthedocs.io/en/latest/articles/OffloadingWebsocketsAndSSE.html).

The "real" change is in 3039e3501c0b294302970746dd74aa7320502802 and might not be correct, but the two calls to `Py_DECREF` look suspect to me.  I've arbitrarily removed one and a series of strange crashes stopped occuring for me.  Threading and gevent seems to be unsupported at the moment, hence saying there are two calls.  I don't know the code well enough to do any better with this at the moment!

Let me know if you think this is about right!