### PR TITLE
Properly check item size in uwsgi_queue_push

### DIFF
--- a/core/queue.c
+++ b/core/queue.c
@@ -144,7 +144,7 @@ int uwsgi_queue_push(char *message, uint64_t size) {
 	struct uwsgi_queue_item *uqi;
 	char *ptr = (char *) uwsgi.queue;
 
-	if (size > uwsgi.queue_blocksize + sizeof(struct uwsgi_queue_item))
+	if (size > uwsgi.queue_blocksize - sizeof(struct uwsgi_queue_item))
 		return 0;
 
 	if (!size)


### PR DESCRIPTION
Very small, but very important change. The queue is allocated as `(block_size * num_elements) + 16`, as such there is no accommodation for the `uqi` header in each queue block thus the payload being pushed needs to be less than `block_size - sizeof(uqi)`. Likely this was just a typo that was glanced over.

Unfortunately the effects are fairly bad, a payload in the range `block_size < payload < block_size + sizeof(uqi)` will overwrite the next `uqi->size` field, resulting in a subsequent `uwsgi_queue_pull` to believe the block is valid, and return an arbitrary size value causing a malloc failure in the `py_uwsgi_queue_pull` function. This also causes the queue pull_pos to get out of sync resulting in a missed payload after the failure (assuming recovery).