### PR TITLE
Add mule_send_msg success indicator

### DIFF
--- a/core/mule.c
+++ b/core/mule.c
@@ -12,7 +12,7 @@ extern struct uwsgi_server uwsgi;
 
 void uwsgi_mule_handler(void);
 
-void mule_send_msg(int fd, char *message, size_t len) {
+int mule_send_msg(int fd, char *message, size_t len) {
 
 	socklen_t so_bufsize_len = sizeof(int);
 	int so_bufsize = 0;
@@ -27,7 +27,9 @@ void mule_send_msg(int fd, char *message, size_t len) {
 		else {
 			uwsgi_error("mule_send_msg()");
 		}
+		return -1;
 	}
+	return 0;
 }
 
 void uwsgi_mule(int id) {

--- a/plugins/python/uwsgi_pymodule.c
+++ b/plugins/python/uwsgi_pymodule.c
@@ -1392,6 +1392,7 @@ PyObject *py_uwsgi_mule_msg(PyObject * self, PyObject * args) {
 	PyObject *mule_obj = NULL;
 	int fd = -1;
 	int mule_id = -1;
+	int resp = -1;
 
 	if (!PyArg_ParseTuple(args, "s#|O:mule_msg", &message, &message_len, &mule_obj)) {
                 return NULL;
@@ -1402,7 +1403,7 @@ PyObject *py_uwsgi_mule_msg(PyObject * self, PyObject * args) {
 
 	if (mule_obj == NULL) {
 		UWSGI_RELEASE_GIL
-		mule_send_msg(uwsgi.shared->mule_queue_pipe[0], message, message_len);
+		resp = mule_send_msg(uwsgi.shared->mule_queue_pipe[0], message, message_len);
 		UWSGI_GET_GIL
 	}
 	else {
@@ -1431,14 +1432,19 @@ PyObject *py_uwsgi_mule_msg(PyObject * self, PyObject * args) {
 
 		if (fd > -1) {
 			UWSGI_RELEASE_GIL
-			mule_send_msg(fd, message, message_len);
+			resp = mule_send_msg(fd, message, message_len);
 			UWSGI_GET_GIL
 		}
 	}
 
-	Py_INCREF(Py_None);
-	return Py_None;
-	
+	if(!resp) {
+		Py_INCREF(Py_True);
+		return Py_True;
+	}
+
+	Py_INCREF(Py_False);
+	return Py_False;
+
 }
 
 PyObject *py_uwsgi_mule_get_msg(PyObject * self, PyObject * args, PyObject *kwargs) {

--- a/uwsgi.h
+++ b/uwsgi.h
@@ -3809,7 +3809,7 @@ struct uwsgi_subscribe_slot {
 
 };
 
-void mule_send_msg(int, char *, size_t);
+int mule_send_msg(int, char *, size_t);
 
 uint32_t djb33x_hash(char *, uint64_t);
 void create_signal_pipe(int *);


### PR DESCRIPTION
This change is backwards compatible to existing mule uses and opens up the option for taking some action on failure to dispatch mule functions. 

Our particular use case involves offloading logging to a mule as python socket behavior can be quite... lethargic. However in some scenarios large amounts of logging information can be generated and we'd like to be able to decide how to respond to a full mule msg pipe rather than simply dropping the log data. 

Quick side note: I stuck with the
```c
Py_INCREF(Py_True);
return Py_True;
```
model for the python plugin, but is there any reason not to use the `Py_RETURN_TRUE` macros that encapsulate this behavior? Just wondering.