### PR TITLE
Make mule msg receive size configurable

### DIFF
--- a/core/init.c
+++ b/core/init.c
@@ -191,6 +191,8 @@ void uwsgi_init_default() {
 	uwsgi_master_fifo_prepare();
 
 	uwsgi.notify_socket_fd = -1;
+
+	uwsgi.mule_msg_recv_size = 65536;
 }
 
 void uwsgi_setup_reload() {

--- a/core/mule.c
+++ b/core/mule.c
@@ -58,6 +58,8 @@ void uwsgi_mule(int id) {
 		uwsgi.mules[id - 1].pid = getpid();
 		uwsgi.mypid = uwsgi.mules[id - 1].pid;
 
+		uwsgi.mule_msg_recv_buf = uwsgi_malloc(uwsgi.mule_msg_recv_size);
+
 		uwsgi_fixup_fds(0, id, NULL);
 
 		uwsgi.my_signal_socket = uwsgi.mules[id - 1].signal_pipe[1];
@@ -170,8 +172,7 @@ void uwsgi_mule_handler() {
 	int rlen;
 	int interesting_fd;
 
-	// this must be configurable
-	char message[65536];
+	char *message = uwsgi.mule_msg_recv_buf;
 
 	int mule_queue = event_queue_init();
 
@@ -203,7 +204,11 @@ void uwsgi_mule_handler() {
 			}
 		}
 		else if (interesting_fd == uwsgi.mules[uwsgi.muleid - 1].queue_pipe[1] || interesting_fd == uwsgi.shared->mule_queue_pipe[1] || farm_has_msg(interesting_fd)) {
-			len = read(interesting_fd, message, 65536);
+			if(!message) {
+				uwsgi_log("*** MULE %d MESSAGE BUFFER IS NOT INITIALIZED ***\n", uwsgi.muleid);
+				continue;
+			}
+			len = read(interesting_fd, message, uwsgi.mule_msg_recv_size);
 			if (len < 0) {
 				if (errno != EAGAIN && errno != EINTR && errno != EWOULDBLOCK) {
 					uwsgi_error("uwsgi_mule_handler/read()");

--- a/core/uwsgi.c
+++ b/core/uwsgi.c
@@ -347,7 +347,8 @@ static struct uwsgi_option uwsgi_base_options[] = {
 	{"mule", optional_argument, 0, "add a mule", uwsgi_opt_add_mule, NULL, UWSGI_OPT_MASTER},
 	{"mules", required_argument, 0, "add the specified number of mules", uwsgi_opt_add_mules, NULL, UWSGI_OPT_MASTER},
 	{"farm", required_argument, 0, "add a mule farm", uwsgi_opt_add_farm, NULL, UWSGI_OPT_MASTER},
-	{"mule-msg-size", optional_argument, 0, "set mule message buffer size", uwsgi_opt_set_int, &uwsgi.mule_msg_size, UWSGI_OPT_MASTER},
+	{"mule-msg-size", required_argument, 0, "set mule message buffer size", uwsgi_opt_set_int, &uwsgi.mule_msg_size, UWSGI_OPT_MASTER},
+	{"mule-msg-recv-size", required_argument, 0, "set mule message recv buffer size", uwsgi_opt_set_int, &uwsgi.mule_msg_recv_size, UWSGI_OPT_MASTER},
 
 	{"signal", required_argument, 0, "send a uwsgi signal to a server", uwsgi_opt_signal, NULL, UWSGI_OPT_IMMEDIATE},
 	{"signal-bufsize", required_argument, 0, "set buffer size for signal queue", uwsgi_opt_set_int, &uwsgi.signal_bufsize, 0},

--- a/plugins/python/uwsgi_pymodule.c
+++ b/plugins/python/uwsgi_pymodule.c
@@ -2524,6 +2524,10 @@ PyObject *py_uwsgi_logsize(PyObject * self, PyObject * args) {
 	return PyLong_FromUnsignedLongLong(uwsgi.shared->logsize);
 }
 
+PyObject *py_uwsgi_mule_msg_recv_size(PyObject * self, PyObject *args) {
+	return PyLong_FromUnsignedLongLong(uwsgi.mule_msg_recv_size);
+}
+
 PyObject *py_uwsgi_mem(PyObject * self, PyObject * args) {
 
 	uint64_t rss=0, vsz = 0;
@@ -2724,6 +2728,7 @@ static PyMethodDef uwsgi_advanced_methods[] = {
 	{"request_id", py_uwsgi_request_id, METH_VARARGS, ""},
 	{"worker_id", py_uwsgi_worker_id, METH_VARARGS, ""},
 	{"mule_id", py_uwsgi_mule_id, METH_VARARGS, ""},
+	{"mule_msg_recv_size", py_uwsgi_mule_msg_recv_size, METH_VARARGS, ""},
 	{"log", py_uwsgi_log, METH_VARARGS, ""},
 	{"log_this_request", py_uwsgi_log_this, METH_VARARGS, ""},
 	{"set_logvar", py_uwsgi_set_logvar, METH_VARARGS, ""},

--- a/uwsgi.h
+++ b/uwsgi.h
@@ -2874,6 +2874,9 @@ struct uwsgi_server {
 	rlim_t reload_on_uss;
 	rlim_t reload_on_pss;
 #endif
+
+	int mule_msg_recv_size;
+	char *mule_msg_recv_buf;
 };
 
 struct uwsgi_rpc {


### PR DESCRIPTION
Adds the option `mule-msg-recv-size` to configure the maximum read size from the mule msg pipe. Unfortunately the previous `mule-msg-size` (defining the pipe buffer size) is slightly ambiguous, but what can you do. Also I've updated the `mule-msg-size` to be required_argument as I suspect getting a pipe buffer of 1 byte is *not* the expected behavior if someone forgets to define the size when using `--mule-msg-size`. Probably better to fail fast there, but I can take that out if backwards compatibility is a concern (who knows, maybe someone was depending on that 1 byte pipe size and can't be troubled to add an explicit `=1`?).

I've attached the receive buffer state to the mule's copy of the uwsgi global struct since it seemed most apt a location. If memory is more a concern than performance here we could simply re-allocate on each message read, that's an easy change just let me know. 