### PR TITLE
Make mule_msg_hook extensible

### DIFF
--- a/plugins/python/uwsgi_pymodule.c
+++ b/plugins/python/uwsgi_pymodule.c
@@ -1403,6 +1403,35 @@ PyObject *py_uwsgi_farm_msg(PyObject * self, PyObject * args) {
 
 }
 
+PyObject *py_uwsgi_install_mule_msg_hook(PyObject *self, PyObject *args) {
+	PyObject *msg_hook_list;
+	PyObject *func;
+
+	if (!PyArg_ParseTuple(args, "O:install_mule_msg_hook", &func)) {
+		return NULL;
+	}
+
+	msg_hook_list = PyDict_GetItemString(up.embedded_dict, "mule_msg_extra_hooks");
+
+	if(!msg_hook_list) {
+		if((msg_hook_list = PyList_New(0)) == NULL)
+			return NULL;
+
+		if(PyDict_SetItemString(up.embedded_dict, "mule_msg_extra_hooks", msg_hook_list) == -1) {
+			Py_DECREF(msg_hook_list);
+			return NULL;
+		}
+	}
+
+	Py_INCREF(func);
+	if(PyList_Append(msg_hook_list, func) == -1) {
+		Py_DECREF(func);
+		return NULL;
+	}
+
+	Py_INCREF(Py_None);
+	return Py_None;
+}
 
 PyObject *py_uwsgi_mule_msg(PyObject * self, PyObject * args) {
 
@@ -2744,6 +2773,7 @@ PyObject *py_uwsgi_suspend(PyObject * self, PyObject * args) {
 
 }
 
+
 static PyMethodDef uwsgi_advanced_methods[] = {
 	{"reload", py_uwsgi_reload, METH_VARARGS, ""},
 	{"stop", py_uwsgi_stop, METH_VARARGS, ""},
@@ -2819,6 +2849,7 @@ static PyMethodDef uwsgi_advanced_methods[] = {
 	{"embedded_data", py_uwsgi_embedded_data, METH_VARARGS, ""},
 	{"extract", py_uwsgi_extract, METH_VARARGS, ""},
 
+	{"install_mule_msg_hook", py_uwsgi_install_mule_msg_hook, METH_VARARGS, ""},
 	{"mule_msg", py_uwsgi_mule_msg, METH_VARARGS, ""},
 	{"farm_msg", py_uwsgi_farm_msg, METH_VARARGS, ""},
 	{"mule_get_msg", (PyCFunction) py_uwsgi_mule_get_msg, METH_VARARGS|METH_KEYWORDS, ""},

--- a/uwsgidecorators.py
+++ b/uwsgidecorators.py
@@ -193,11 +193,15 @@ class mulefunc(object):
 
 
 def mule_msg_dispatcher(message):
-    msg = pickle.loads(message)
+    try:
+        msg = pickle.loads(message)
+    except pickle.UnpicklingError:
+        return
+
     if msg['service'] == 'uwsgi_mulefunc':
         return mule_functions[msg['func']](*msg['args'], **msg['kwargs'])
 
-uwsgi.mule_msg_hook = mule_msg_dispatcher
+uwsgi.install_mule_msg_hook(mule_msg_dispatcher)
 
 
 class rpc(object):


### PR DESCRIPTION
This extends the python plugin mule msg hook to allow a list of functions which messages are dispatched to on the mule side, rather than a single function pointer (however it maintains the old pointer for compatibility).

The use case which prompted this change is that I needed a lazily configurable patch of a function which might offload to a mule based on consumed configuration files, thus I couldn't use a decorator directly. Furthermore this situation required serializing tuples of strings, which is tremendously faster with `marshal` than `cPickle`. To solve this issue I explicitly import `uwsgidecorators` to ensure installation of its mule msg hook, then overrode the hook myself, chaining the dispatch to the `uwsgidecorator` dispatch function in the event that the message was generated via `mulefunc` decorator etc.

However this is a rather delicate setup which requires careful import ordering. Instead allowing modules to install any function, which the plugin then dispatches to all hooks removes any such dependency/chaining. It's important that hooks use some method of disambiguation (i.e. serialization format + perhaps a service key like `uwsgidecorators` uses) however that's up to the developer to decide. 