### PR TITLE
Add http-path-info-no-decode-slashes option

### DIFF
--- a/core/utils.c
+++ b/core/utils.c
@@ -3255,7 +3255,7 @@ it manages:
 	stop at the first #
 
 */
-void http_url_decode(char *buf, uint16_t * len, char *dst) {
+void http_url_decode4(char *buf, uint16_t * len, char *dst, int no_slash_decode) {
 
 	enum {
 		zero = 0,
@@ -3312,8 +3312,15 @@ void http_url_decode(char *buf, uint16_t * len, char *dst) {
 			break;
 		case percent2:
 			value[1] = c;
-			*ptr++ = hex2num(value);
-			new_len++;
+			if (no_slash_decode && value[0] == '2' && (value[1] == 'F' || value[1] == 'f')) {
+				*ptr++ = '%';
+				*ptr++ = value[0];
+				*ptr++ = value[1];
+				new_len += 3;
+			} else {
+				*ptr++ = hex2num(value);
+				new_len++;
+			}
 			status = zero;
 			break;
 		case slash:

--- a/core/uwsgi.c
+++ b/core/uwsgi.c
@@ -49,6 +49,8 @@ static struct uwsgi_option uwsgi_base_options[] = {
 
 	{"http11-socket", required_argument, 0, "bind to the specified UNIX/TCP socket using HTTP 1.1 (Keep-Alive) protocol", uwsgi_opt_add_socket, "http11", 0},
 
+	{"http-path-info-no-decode-slashes", required_argument, 0, "don't URL decode encoded slashes in PATH_INFO when using HTTP(S) protocol", uwsgi_opt_true, &uwsgi.http_path_info_no_decode_slashes, 0},
+
 #ifdef UWSGI_SSL
 	{"https-socket", required_argument, 0, "bind to the specified UNIX/TCP socket using HTTPS protocol", uwsgi_opt_add_ssl_socket, "https", 0},
 	{"https-socket-modifier1", required_argument, 0, "force the specified modifier1 when using HTTPS protocol", uwsgi_opt_set_64bit, &uwsgi.https_modifier1, 0},

--- a/proto/http.c
+++ b/proto/http.c
@@ -241,7 +241,7 @@ static int http_parse(struct wsgi_request *wsgi_req, char *watermark) {
 				if (ptr - base > 0xffff) return -1;
 				uint16_t path_info_len = ptr - base;
 				char *path_info = uwsgi_malloc(path_info_len);
-				http_url_decode(base, &path_info_len, path_info);
+				http_url_decode4(base, &path_info_len, path_info, uwsgi.http_path_info_no_decode_slashes);
 				wsgi_req->len += proto_base_add_uwsgi_var(wsgi_req, "PATH_INFO", 9, path_info, path_info_len);
 				free(path_info);
 			}
@@ -259,7 +259,7 @@ static int http_parse(struct wsgi_request *wsgi_req, char *watermark) {
 					if (ptr - base > 0xffff) return -1;
                                 	uint16_t path_info_len = ptr - base;
 					char *path_info = uwsgi_malloc(path_info_len);
-                                	http_url_decode(base, &path_info_len, path_info);
+					http_url_decode4(base, &path_info_len, path_info, uwsgi.http_path_info_no_decode_slashes);
                                 	wsgi_req->len += proto_base_add_uwsgi_var(wsgi_req, "PATH_INFO", 9, path_info, path_info_len);
 					free(path_info);
                         	}

--- a/uwsgi.h
+++ b/uwsgi.h
@@ -2890,6 +2890,8 @@ struct uwsgi_server {
 
 	int mule_msg_recv_size;
 	char *mule_msg_recv_buf;
+
+	int http_path_info_no_decode_slashes;
 };
 
 struct uwsgi_rpc {
@@ -3737,7 +3739,9 @@ void uwsgi_fixup_fds(int, int, struct uwsgi_gateway *);
 
 void uwsgi_set_processname(char *);
 
-void http_url_decode(char *, uint16_t *, char *);
+void http_url_decode4(char *, uint16_t *, char *, int);
+#define http_url_decode(x, y, z) http_url_decode4(x, y, z, 0)
+
 void http_url_encode(char *, uint16_t *, char *);
 
 pid_t uwsgi_fork(char *);


### PR DESCRIPTION
The option disables encoded slash (%2F) decoding in PATH_INFO when using
HTTP(S) protocol. This is similar to AllowEncodedSlashes directive in Apache.