### PR TITLE
travis: bump ruby version for rack plugin

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,9 +20,10 @@ script:
   - echo -e "\n\n>>> Building python35 plugin"
   - /usr/bin/python3.5 -V
   - /usr/bin/python3.5 uwsgiconfig.py --plugin plugins/python base python35
-  - echo -e "\n\n>>> Building rack 1.9.1 plugin"
-  - /usr/bin/ruby1.9.1 -v
-  - UWSGICONFIG_RUBYPATH=/usr/bin/ruby1.9.1 /usr/bin/python uwsgiconfig.py --plugin plugins/rack base rack191
+  - echo -e "\n\n>>> Building rack plugin"
+  - rvm use 2.2.6
+  - ruby -v
+  - UWSGICONFIG_RUBYPATH=ruby /usr/bin/python uwsgiconfig.py --plugin plugins/rack base rack226
   - echo -e "\n\n>>> Building cgi plugin"
   - /usr/bin/python uwsgiconfig.py --plugin plugins/cgi base
   - echo -e "\n\n>>> Building dummy plugin"
@@ -35,7 +36,6 @@ before_install:
   - sudo add-apt-repository ppa:nathan-renniewaldock/ppa -y
   - sudo apt-get update -qq
   - sudo apt-get install -qqyf python2.6-dev python3.4-dev python3.5-dev
-  - sudo apt-get install -qqyf rubygems1.8 ruby1.9.1-dev
   - sudo apt-get install -qqyf libxml2-dev libpcre3-dev libcap2-dev
   - sudo apt-get install -qqyf php5-dev libphp5-embed liblua5.1-0-dev
   - sudo apt-get install -qqyf libjansson-dev libldap2-dev libpq-dev

--- a/tests/travis.sh
+++ b/tests/travis.sh
@@ -70,20 +70,10 @@ test_python() {
 test_rack() {
     date > reload.txt
     rm -f uwsgi.log
+    # the code assumes that ruby environment is activated by `rvm use`
     echo -e "${bldyel}================== TESTING $1 =====================${txtrst}"
-    case "$1" in
-    "rack187")
-        GEMS_BINARY="/usr/bin/gem1.8"
-        ;;
-    "rack191")
-        GEMS_BINARY="/usr/bin/gem1.9.1"
-        ;;
-    "rack193")
-        GEMS_BINARY="/usr/bin/gem1.9.3"
-        ;;
-    esac
-    echo -e "${bldyel}>>> Installing sinatra gem using ${GEMS_BINARY}${txtrst}"
-    $GEMS_BINARY install sinatra || die
+    echo -e "${bldyel}>>> Installing sinatra gem using gem${txtrst}"
+    gem install sinatra || die
     echo -e "${bldyel}>>> Spawning uWSGI rack app${txtrst}"
     echo -en "${bldred}"
     ./uwsgi --master --plugin 0:$1 --http :8080 --exit-on-reload --touch-reload reload.txt --rack examples/config2.ru --daemonize uwsgi.log


### PR DESCRIPTION
As rack build fails with ruby < 2.2.2. While at it simplify ruby
handling by using rvm.