### PR TITLE
Fix MULE MSG QUEUE IS FULL message hint

### DIFF
--- a/core/mule.c
+++ b/core/mule.c
@@ -22,7 +22,7 @@ int mule_send_msg(int fd, char *message, size_t len) {
 			if (getsockopt(fd, SOL_SOCKET, SO_SNDBUF, &so_bufsize, &so_bufsize_len)) {
 				uwsgi_error("getsockopt()");
 			}
-			uwsgi_log("*** MULE MSG QUEUE IS FULL: buffer size %d bytes (you can tune it with --signal-bufsize) ***\n", so_bufsize);
+			uwsgi_log("*** MULE MSG QUEUE IS FULL: buffer size %d bytes (you can tune it with --mule-msg-size) ***\n", so_bufsize);
 		}
 		else {
 			uwsgi_error("mule_send_msg()");


### PR DESCRIPTION
Error message for unsuccessful `mule_send_msg` had a confusing message(to tune `signal-bufsize`),
but the actual buffer used here is one tuned with `mule-msg-size` param