### PR TITLE
Port to python 3.5

### DIFF
--- a/plugins/python/tracebacker.c
+++ b/plugins/python/tracebacker.c
@@ -28,10 +28,10 @@ char *uwsgi_python_get_thread_name(PyObject *thread_id) {
 			PyObject *thread_name = PyObject_GetAttrString(threads_list_next, "name");
 			if (!thread_name) goto clear2;
 #ifdef PYTHREE
-			PyObject *thread_name_utf8 = PyUnicode_AsUTF8String(thread_name);
+			PyObject *thread_name_utf8 = PyUnicode_AsEncodedString(thread_name, "ASCII", "strict");
 			if (!thread_name_utf8) goto clear2;
 			char *name = NULL;
-			char *tmp_name = PyString_AsString(thread_name_utf8);
+			char *tmp_name = PyBytes_AS_STRING(thread_name_utf8);
 			if (tmp_name) {
 				name = uwsgi_str(tmp_name);	
 				Py_DECREF(thread_name_utf8);
@@ -146,16 +146,26 @@ void *uwsgi_python_tracebacker_thread(void *foobar) {
 			while(st_items) {
 #ifdef PYTHREE
 				int thread_name_need_free = 0;
-#endif
-				PyObject *st_filename = PyTuple_GetItem(st_items, 0);
+
+			        	     	
+				PyObject *st_filename = PyObject_GetAttrString(st_items, "filename");
 				if (!st_filename) { Py_DECREF(st_items); goto next; }
-				PyObject *st_lineno = PyTuple_GetItem(st_items, 1);
+				PyObject *st_lineno = PyObject_GetAttrString(st_items, "lineno");
 				if (!st_lineno) {Py_DECREF(st_items); goto next;}
-				PyObject *st_name = PyTuple_GetItem(st_items, 2);
+				PyObject *st_name = PyObject_GetAttrString(st_items, "name");
 				if (!st_name) {Py_DECREF(st_items); goto next;}
 
+				PyObject *st_line = PyObject_GetAttrString(st_items, "line");
+#else
+				PyObject *st_filename = PyTuple_GetItem(st_items, 0);
+ 				if (!st_filename) { Py_DECREF(st_items); goto next; }
+				PyObject *st_lineno = PyTuple_GetItem(st_items, 1);
+ 				if (!st_lineno) {Py_DECREF(st_items); goto next;}
+				PyObject *st_name = PyTuple_GetItem(st_items, 2);
+ 				if (!st_name) {Py_DECREF(st_items); goto next;}
+ 
 				PyObject *st_line = PyTuple_GetItem(st_items, 3);
-
+#endif				
 				iov[0].iov_base = "thread_id = ";
 				iov[0].iov_len = 12;
 
@@ -174,12 +184,12 @@ void *uwsgi_python_tracebacker_thread(void *foobar) {
 				iov[2].iov_len = 12;
 
 #ifdef PYTHREE
-				PyObject *st_filename_utf8 = PyUnicode_AsUTF8String(st_filename);
+				PyObject *st_filename_utf8 = PyUnicode_AsEncodedString(st_filename, "ASCII", "strict");
 				if (!st_filename_utf8) {
 					if (thread_name_need_free) free(iov[1].iov_base);
 					goto next;
 				}
-				iov[3].iov_base = PyString_AsString(st_filename_utf8);
+				iov[3].iov_base = PyBytes_AS_STRING(st_filename_utf8);
 #else
 				iov[3].iov_base = PyString_AsString(st_filename);
 #endif
@@ -195,13 +205,13 @@ void *uwsgi_python_tracebacker_thread(void *foobar) {
 				iov[6].iov_len = 12 ;
 
 #ifdef PYTHREE
-                                PyObject *st_name_utf8 = PyUnicode_AsUTF8String(st_name);
+                                PyObject *st_name_utf8 = PyUnicode_AsEncodedString(st_name, "ASCII", "strict");
                                 if (!st_name_utf8) {
 					if (thread_name_need_free) free(iov[1].iov_base);
 					Py_DECREF(st_filename_utf8);
 					goto next;
 				}
-				iov[7].iov_base = PyString_AsString(st_name_utf8);
+				iov[7].iov_base = PyBytes_AS_STRING(st_name_utf8);
 #else
 				iov[7].iov_base = PyString_AsString(st_name);
 #endif
@@ -223,14 +233,14 @@ void *uwsgi_python_tracebacker_thread(void *foobar) {
 					iov[8].iov_base = " line = ";
 					iov[8].iov_len = 8;
 #ifdef PYTHREE
-                                	PyObject *st_line_utf8 = PyUnicode_AsUTF8String(st_line);
+                                	PyObject *st_line_utf8 = PyUnicode_AsEncodedString(st_line, "ASCII", "strict");
                                 	if (!st_line_utf8) {
 						if (thread_name_need_free) free(iov[1].iov_base);
                                         	Py_DECREF(st_filename_utf8);
                                         	Py_DECREF(st_name_utf8);
                                         	goto next;
                                 	}
-					iov[9].iov_base = PyString_AsString(st_line_utf8);
+					iov[9].iov_base = PyBytes_AS_STRING(st_line_utf8);
 #else
 					iov[9].iov_base = PyString_AsString(st_line);
 #endif


### PR DESCRIPTION
Enable support for structured FrameSummary object as found in Python
3.5.

Warning: this will only work on Python 3.5 and later.