### PR TITLE
Also take into account skip_atexit when a process is respawn

### DIFF
--- a/core/uwsgi.c
+++ b/core/uwsgi.c
@@ -1336,7 +1336,11 @@ static void simple_goodbye_cruel_world(const char *reason) {
 
 	uwsgi.workers[uwsgi.mywid].manage_next_request = 0;
 	uwsgi_log("...The work of process %d is done (%s). Seeya!\n", getpid(), (reason != NULL ? reason : "no reason given"));
-	exit(0);
+ 	if (getpid() != masterpid && uwsgi.skip_atexit) {
+		_exit(0);
+	} else {
+		exit(0);
+	}
 }
 
 void goodbye_cruel_world(const char *reason_fmt, ...) {


### PR DESCRIPTION
Hi,

Needed to avoid atexit registered functions but found that skip-atexit was not taken in account when a process is respawn killed (mainly by setting max-requests).