### PR TITLE
support k_minor has a _xxx suffix

### DIFF
--- a/uwsgiconfig.py
+++ b/uwsgiconfig.py
@@ -6,7 +6,7 @@ import os
 import re
 import time
 uwsgi_os = os.environ.get('UWSGI_FORCE_OS', os.uname()[0])
-uwsgi_os_k = re.split('[-+]', os.uname()[2])[0]
+uwsgi_os_k = re.split('[-+_]', os.uname()[2])[0]
 uwsgi_os_v = os.uname()[3]
 uwsgi_cpu = os.uname()[4]
 


### PR DESCRIPTION
on my platform uname outputs 2.6.32_1-15-0-0, i think k_minor should be 32, but now 32_1 is extracted, which leads to int(k_minor) throws an exception