### PR TITLE
Add task decorator, a more pythonic approach for spooling

### DIFF
--- a/uwsgidecorators.py
+++ b/uwsgidecorators.py
@@ -158,6 +158,9 @@ def spool(f=None, pass_arguments=False):
     return spool_decorate(f, pass_arguments, _spool)
 
 
+task = partial(spool, pass_arguments=True)
+
+
 def spoolforever(f=None, pass_arguments=False):
     return spool_decorate(f, pass_arguments, _spoolforever)
 


### PR DESCRIPTION
Hi,

I'm using Python3 and I struggled quite a bit with the `spool` decorator to enqueue background tasks - on Python3, the `spool` decorator only allow arguments of `bytes` type.

After looking at the source code, I noticed that a nicer and more pythonic way is already supported though undocumented: setting the `pass_arguments` variable to `True` when using the `spool` decorator, which allow the following:

```
from uwsgidecorators import spool

@spool(pass_arguments=True)
def a_long_task(arg1, kwarg1=None):
    pass

def test_spooling():
    a_long_task.spool(42, kwarg1=['foo', 'bar'])
```

The purpose of this PR is to add a `task` decorator, which is just an alias on top of `spool`, but allowing everyone and especially Python3 developers to use a nicer/easier interface to enqueue background jobs, so the above code becomes:

```
from uwsgidecorators import task

@task
def a_long_task(arg1, kwarg1=None):
    pass

def test_spooling():
    a_long_task.spool(42, kwarg1=['foo', 'bar'])
```

If accepted, I'll also some lines into the documentation about it.