### PR TITLE
Allow to override build date

### DIFF
--- a/uwsgiconfig.py
+++ b/uwsgiconfig.py
@@ -404,7 +404,8 @@ def build_uwsgi(uc, print_only=False, gcll=None):
         cflags.append('-DUWSGI_CFLAGS=\\"\\"')
     else:
         cflags.append('-DUWSGI_CFLAGS=\\"%s\\"' % uwsgi_cflags)
-    cflags.append('-DUWSGI_BUILD_DATE="\\"%s\\""' % time.strftime("%d %B %Y %H:%M:%S"))
+    build_date = int(os.environ.get('SOURCE_DATE_EPOCH', time.time()))
+    cflags.append('-DUWSGI_BUILD_DATE="\\"%s\\""' % time.strftime("%d %B %Y %H:%M:%S", time.gmtime(build_date)))
 
     post_build = []
 


### PR DESCRIPTION
to allow for reproducible builds of uwsgi

See https://reproducible-builds.org/ for why this is good
and https://reproducible-builds.org/specs/source-date-epoch/
for the definition of this variable.