### PR TITLE
Write x509 DER to the uwsgi buffer

### DIFF
--- a/plugins/http/https.c
+++ b/plugins/http/https.c
@@ -179,6 +179,12 @@ int hr_https_add_vars(struct http_session *hr, struct corerouter_peer *peer, str
 #endif
                 hr->ssl_client_cert = SSL_get_peer_certificate(hr->ssl);
                 if (hr->ssl_client_cert) {
+                        int client_cert_len;
+                        unsigned char *client_cert_der = NULL;
+                        client_cert_len = i2d_X509(hr->ssl_client_cert, &client_cert_der);
+                        if (client_cert_len < 0) return -1;
+                        if (uwsgi_buffer_append_keyval(out, "HTTPS_CLIENT_CERTIFICATE", 24, (char*)client_cert_der, client_cert_len)) return -1;
+
                         X509_NAME *name = X509_get_subject_name(hr->ssl_client_cert);
                         if (name) {
                                 hr->ssl_client_dn = X509_NAME_oneline(name, NULL, 0);


### PR DESCRIPTION
This will write the full x.509 DER into the buffer for use by clients
during runtime. This feature is intended to allow clients to handle
per-user ACL with the direct x.509 Certificate, without having to
configure the webserver to extract the right bits, which may or may not
be custom extensions.

One such example would be using and extracting the UPN SAN, or some
other exotic extension.