### PR TITLE
Add a --ssl-verify-depth flag

### DIFF
--- a/core/ssl.c
+++ b/core/ssl.c
@@ -326,8 +326,7 @@ SSL_CTX *uwsgi_ssl_new_server_context(char *name, char *crt, char *key, char *ci
                 else {
                         SSL_CTX_set_verify(ctx, SSL_VERIFY_PEER, uwsgi_ssl_verify_callback);
                 }
-                // in the future we should allow to set the verify depth
-                SSL_CTX_set_verify_depth(ctx, 1);
+                SSL_CTX_set_verify_depth(ctx, uwsgi.ssl_verify_depth);
 
 		if (uwsgi.ssl_tmp_dir && !uwsgi_starts_with(client_ca, strlen(client_ca), "-----BEGIN ", 11)) {
 			if (!name) {

--- a/core/uwsgi.c
+++ b/core/uwsgi.c
@@ -702,6 +702,7 @@ static struct uwsgi_option uwsgi_base_options[] = {
 	{"snmp-community", required_argument, 0, "set the snmp community string", uwsgi_opt_snmp_community, NULL, 0},
 #ifdef UWSGI_SSL
 	{"ssl-verbose", no_argument, 0, "be verbose about SSL errors", uwsgi_opt_true, &uwsgi.ssl_verbose, 0},
+	{"ssl-verify-depth", optional_argument, 0, "set maximum certificate verification depth", uwsgi_opt_set_int, &uwsgi.ssl_verify_depth, 1},
 #ifdef UWSGI_SSL_SESSION_CACHE
 	// force master, as ssl sessions caching initialize locking early
 	{"ssl-sessions-use-cache", optional_argument, 0, "use uWSGI cache for ssl sessions storage", uwsgi_opt_set_str, &uwsgi.ssl_sessions_use_cache, UWSGI_OPT_MASTER},

--- a/uwsgi.h
+++ b/uwsgi.h
@@ -2892,6 +2892,10 @@ struct uwsgi_server {
 	char *mule_msg_recv_buf;
 
 	int http_path_info_no_decode_slashes;
+
+#ifdef UWSGI_SSL
+	int ssl_verify_depth;
+#endif
 };
 
 struct uwsgi_rpc {


### PR DESCRIPTION
Add ssl-verify-depth flag to set the max Client CA chain length

When verifying Certificates, OpenSSL will build a chain of trust from a
root CA to the Certificate, via intermediary CA(s). The chain was
hardcoded to 1 previously, which means that all Client Certificates
would have to be issued directly from a root CA.

This adds a new flag, --ssl-verify-depth with a default of 1 (existing
behavior) that will allow N intermediary CAs when building the chain of
trust.