### PR TITLE
plugin/http: Fix compilation

### DIFF
--- a/plugins/http/common.h
+++ b/plugins/http/common.h
@@ -5,7 +5,7 @@ extern struct uwsgi_server uwsgi;
 #include "../corerouter/cr.h"
 
 #ifdef UWSGI_SSL
-#ifdef OPENSSL_NPN_UNSUPPORTED
+#if !defined(OPENSSL_NO_NEXTPROTONEG) && defined(OPENSSL_NPN_UNSUPPORTED)
 #ifdef UWSGI_ZLIB
 #define UWSGI_SPDY
 #endif


### PR DESCRIPTION
Fix compilation when OpenSSL is compiled without NPN support. The flags
for NPN are always defined, but OPENSSL_NO_NEXTPROTONEG is defined if
the npn support is disabled at OpenSSL compile time.

This is the default for FreeBSD OpenSSL 1.0+ via ports.