### PR TITLE
Python 3.x plugin: set thread name as unicode

### DIFF
--- a/plugins/python/python_plugin.c
+++ b/plugins/python/python_plugin.c
@@ -1361,7 +1361,11 @@ void uwsgi_python_set_thread_name(int core_id) {
                                         PyErr_Clear();
                                 }
                                 else {
+#ifdef PYTHREE
+                                        PyObject_SetAttrString(current_thread, "name", PyUnicode_FromFormat("uWSGIWorker%dCore%d", uwsgi.mywid, core_id));
+#else
                                         PyObject_SetAttrString(current_thread, "name", PyString_FromFormat("uWSGIWorker%dCore%d", uwsgi.mywid, core_id));
+#endif
                                         Py_INCREF(current_thread);
                                 }
                         }


### PR DESCRIPTION
Fixes #1580.

Without this patch it would be bytes, and using it in eg. log formatting
would look ugly.

Simple conversion to PyUnicode_FromFormat.