### PR TITLE
Cheap worker uses SIGHUP

### DIFF
--- a/core/master_utils.c
+++ b/core/master_utils.c
@@ -206,7 +206,12 @@ safe:
 			uwsgi.workers[oldest_worker].rss_size = 0;
 			uwsgi.workers[oldest_worker].vsz_size = 0;
 			uwsgi.workers[oldest_worker].manage_next_request = 0;
-			uwsgi_curse(oldest_worker, SIGWINCH);
+			// Send SIGHUP to shutdown the worker. SIGWINCH doesn't work
+			// with workers that block on thunder lock (either pthread
+			// mutex or ipcsem, which uWSGI retries after EINTR).
+			// Since we're only choosing idle workers, it's fine to
+			// immediately shutdown with SIGHUP (end_me).
+			uwsgi_curse(oldest_worker, SIGHUP);
 		}
 	}
 


### PR DESCRIPTION
We used SIGWINCH to cheap a worker, by waking it up and making itself realize it should go away. 

But in certain cases like thunder lock, a worker could be blocked by the thunder lock instead of the `accept()` syscall, and many lock engine's acquire operation is not interruptible, which means in this case, the cheaped worker will hang until SIGKILLed. 

Since the change that we only cheap idle workers after 2.0.14, it should be fine to just send SIGHUP to make the worker go away directly. If there's concerns around this, we could make this an option.