### PR TITLE
Add explicit breaks to avoid implicit passthrough.

### DIFF
--- a/core/hash.c
+++ b/core/hash.c
@@ -42,11 +42,14 @@ static uint32_t murmur2_hash(char *key, uint64_t keylen) {
 	switch (keylen) {
 		case 3:
         		h ^= key[2] << 16;
+        		break;
     		case 2:
         		h ^= key[1] << 8;
+        		break;
     		case 1:
         		h ^= key[0];
         		h *= 0x5bd1e995;
+        		break;
     	}
 
 	h ^= h >> 13;


### PR DESCRIPTION
-Werror=implicit-fallthrough was added in gcc 7.1, which will
throw a compile error if a switch has an implicit passthrough.

Seeing as how this switch doesn't appear to depend on passthrough to
function correctly, I've added explicit breaks to the switch.

From https://gcc.gnu.org/gcc-7/changes.html:

-Wimplicit-fallthrough warns when a switch case falls through. This
warning has five different levels. The compiler is able to parse a wide
range of fallthrough comments, depending on the level. It also handles
control-flow statements, such as ifs. It's possible to suppress the
warning by either adding a fallthrough comment, or by using a null
statement: __attribute__ ((fallthrough)); (C, C++), or [[fallthrough]];
(C++17), or [[gnu::fallthrough]]; (C++11/C++14). This warning is enabled
by -Wextra.