### PR TITLE
Add explicit breaks to avoid implicit passthrough.

### DIFF
--- a/core/routing.c
+++ b/core/routing.c
@@ -1792,10 +1792,10 @@ static int uwsgi_route_condition_ipv6in(struct wsgi_request *wsgi_req, struct uw
 
 	int i = (pfxlen / 32);
 	switch (i) {
-	case 0: mask[0] = 0;
-	case 1: mask[1] = 0;
-	case 2: mask[2] = 0;
-	case 3: mask[3] = 0;
+	case 0: mask[0] = 0; break;
+	case 1: mask[1] = 0; break;
+	case 2: mask[2] = 0; break;
+	case 3: mask[3] = 0; break;
 	}
 
 	if (pfxlen % 32)


### PR DESCRIPTION
In addition to the changes in 0a14d0f0425f00421a69f0ca8e09a92cfdfc6a36, there were some additional case statements I missed because of my build configuration on my travel laptop.