### PR TITLE
Add --http-subscription-fallback-key and --fastrouter-subscription-fallback-key

### DIFF
--- a/plugins/corerouter/corerouter.c
+++ b/plugins/corerouter/corerouter.c
@@ -254,6 +254,18 @@ void uwsgi_opt_corerouter_ss(char *opt, char *value, void *cr) {
 }
 
 
+void uwsgi_opt_corerouter_fallback_key(char *opt, char *value, void *key) {
+    struct uwsgi_corerouter *ptr = (struct uwsgi_corerouter *) key;
+    if (!value) {
+        ptr->fallback_key = "";
+        ptr->fallback_key_len = 0;
+        return;
+    }
+    ptr->fallback_key = value;
+    ptr->fallback_key_len = strlen(value);
+}
+
+
 void corerouter_send_stats(struct uwsgi_corerouter *);
 
 void corerouter_manage_subscription(char *key, uint16_t keylen, char *val, uint16_t vallen, void *data) {

--- a/plugins/corerouter/cr.h
+++ b/plugins/corerouter/cr.h
@@ -293,6 +293,9 @@ struct uwsgi_corerouter {
 	socklen_t emperor_socket_addr_len;
 
 	int defer_connect_timeout;
+
+	char *fallback_key;
+	int fallback_key_len;
 };
 
 // a session is started when a client connect to the router
@@ -345,6 +348,8 @@ void uwsgi_opt_corerouter_use_pattern(char *, char *, void *);
 void uwsgi_opt_corerouter_zerg(char *, char *, void *);
 void uwsgi_opt_corerouter_cs(char *, char *, void *);
 void uwsgi_opt_corerouter_ss(char *, char *, void *);
+void uwsgi_opt_corerouter_fallback_key(char *, char *, void *);
+
 
 void corerouter_manage_subscription(char *, uint16_t, char *, uint16_t, void *);
 

--- a/plugins/corerouter/cr_map.c
+++ b/plugins/corerouter/cr_map.c
@@ -56,6 +56,9 @@ int uwsgi_cr_map_use_subscription(struct uwsgi_corerouter *ucr, struct coreroute
 	usc.cookie = NULL;
 
 	peer->un = uwsgi_get_subscribe_node(ucr->subscriptions, peer->key, peer->key_len, &usc);
+	if((peer->un == NULL) && (ucr->fallback_key != NULL)) {
+		peer->un = uwsgi_get_subscribe_node(ucr->subscriptions, ucr->fallback_key, ucr->fallback_key_len, &usc);
+	}
 	// check if the node is ready or it requires a vassal spawn
 	if (peer->un && (peer->un->len || peer->un->vassal_len)) {
 		peer->modifier1 = peer->un->modifier1;

--- a/plugins/fastrouter/fastrouter.c
+++ b/plugins/fastrouter/fastrouter.c
@@ -68,6 +68,8 @@ static struct uwsgi_option fastrouter_options[] = {
 	{"fastrouter-emperor-socket", required_argument, 0, "set the emperor command socket that will receive spawn commands", uwsgi_opt_set_str, &ufr.cr.emperor_socket, 0},
 	{"fastrouter-defer-connect-timeout", required_argument, 0, "set fastrouter defer connect timeout", uwsgi_opt_set_int, &ufr.cr.defer_connect_timeout, 0},
 	{"fastrouter-max-retries", required_argument, 0, "set fastrouter max retry attempts", uwsgi_opt_set_int, &ufr.cr.max_retries, 0},
+	{"fastrouter-subscription-fallback-key", required_argument, 0, "key to use for fallback fastrouter", uwsgi_opt_corerouter_fallback_key, &ufr.cr, 0},
+
 	UWSGI_END_OF_OPTIONS
 };
 

--- a/plugins/http/http.c
+++ b/plugins/http/http.c
@@ -31,6 +31,7 @@ struct uwsgi_option http_options[] = {
 	{"http-use-base", required_argument, 0, "use the specified base for mapping requests to unix sockets", uwsgi_opt_corerouter_use_base, &uhttp, 0},
 	{"http-events", required_argument, 0, "set the number of concurrent http async events", uwsgi_opt_set_int, &uhttp.cr.nevents, 0},
 	{"http-subscription-server", required_argument, 0, "enable the subscription server", uwsgi_opt_corerouter_ss, &uhttp, 0},
+	{"http-subscription-fallback-key", required_argument, 0, "key to use for fallback http handler", uwsgi_opt_corerouter_fallback_key, &uhttp.cr, 0},
 	{"http-timeout", required_argument, 0, "set internal http socket timeout", uwsgi_opt_set_int, &uhttp.cr.socket_timeout, 0},
 	{"http-manage-expect", optional_argument, 0, "manage the Expect HTTP request header (optionally checking for Content-Length)", uwsgi_opt_set_64bit, &uhttp.manage_expect, 0},
 	{"http-keepalive", optional_argument, 0, "HTTP 1.1 keepalive support (non-pipelined) requests", uwsgi_opt_set_int, &uhttp.keepalive, 0},


### PR DESCRIPTION
When using a subscription server with fastrouter or http, and no subscribed nodes match, try the fallback key.