### PR TITLE
[Fixes #1619] Clean up by reversing how we made the mess.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: precise
 language: c
 
 compiler:

--- a/plugins/python/python_plugin.c
+++ b/plugins/python/python_plugin.c
@@ -1091,9 +1091,10 @@ void *uwsgi_python_create_env_holy(struct wsgi_request *wsgi_req, struct uwsgi_a
 }
 
 void uwsgi_python_destroy_env_holy(struct wsgi_request *wsgi_req) {
-	// in non-multithread modes, we set uwsgi.env incrementing the refcount of the environ
 	if (uwsgi.threads < 2) {
-		Py_DECREF((PyObject *)wsgi_req->async_environ);
+		// in non-multithread modes, we set uwsgi.env, so let's remove it now
+		// to equalise the refcount of the environ
+		PyDict_DelItemString(up.embedded_dict, "env");
 	}
 	Py_DECREF((PyObject *) wsgi_req->async_args);
 	Py_DECREF((PyObject *)wsgi_req->async_environ);


### PR DESCRIPTION
Since we inc the refcount on env by adding it to our dict, we clean up by removing it, not just decrementing the refcount.