### PR TITLE
Alternative to marking explicit fallthrough.

### DIFF
--- a/core/hash.c
+++ b/core/hash.c
@@ -42,14 +42,14 @@ static uint32_t murmur2_hash(char *key, uint64_t keylen) {
 	switch (keylen) {
 		case 3:
         		h ^= key[2] << 16;
-        		break;
+			/* FALLTHRU */
     		case 2:
         		h ^= key[1] << 8;
-        		break;
+			/* FALLTHRU */
     		case 1:
         		h ^= key[0];
         		h *= 0x5bd1e995;
-        		break;
+			/* FALLTHRU */
     	}
 
 	h ^= h >> 13;

--- a/core/routing.c
+++ b/core/routing.c
@@ -1792,10 +1792,10 @@ static int uwsgi_route_condition_ipv6in(struct wsgi_request *wsgi_req, struct uw
 
 	int i = (pfxlen / 32);
 	switch (i) {
-	case 0: mask[0] = 0; break;
-	case 1: mask[1] = 0; break;
-	case 2: mask[2] = 0; break;
-	case 3: mask[3] = 0; break;
+	case 0: mask[0] = 0; /* FALLTHRU */
+	case 1: mask[1] = 0; /* FALLTHRU */
+	case 2: mask[2] = 0; /* FALLTHRU */
+	case 3: mask[3] = 0; /* FALLTHRU */
 	}
 
 	if (pfxlen % 32)


### PR DESCRIPTION
GCC supports comments to mark this, as documented in:
https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html

This PR is only presented as illustrative of an alternative to an already accepted patch.