### PR TITLE
core/lock: expose robust mutex watchdog for thunder lock.

### DIFF
--- a/core/uwsgi.c
+++ b/core/uwsgi.c
@@ -80,6 +80,7 @@ static struct uwsgi_option uwsgi_base_options[] = {
 	{"processes", required_argument, 'p', "spawn the specified number of workers/processes", uwsgi_opt_set_int, &uwsgi.numproc, 0},
 	{"workers", required_argument, 'p', "spawn the specified number of workers/processes", uwsgi_opt_set_int, &uwsgi.numproc, 0},
 	{"thunder-lock", no_argument, 0, "serialize accept() usage (if possible)", uwsgi_opt_true, &uwsgi.use_thunder_lock, 0},
+	{"thunder-lock-watchdog", no_argument, 0, "watchdog for buggy pthread robust mutexes", uwsgi_opt_true, &uwsgi.use_thunder_lock_watchdog, 0},
 	{"harakiri", required_argument, 't', "set harakiri timeout", uwsgi_opt_set_int, &uwsgi.harakiri_options.workers, 0},
 	{"harakiri-verbose", no_argument, 0, "enable verbose mode for harakiri", uwsgi_opt_true, &uwsgi.harakiri_verbose, 0},
 	{"harakiri-no-arh", no_argument, 0, "do not enable harakiri during after-request-hook", uwsgi_opt_true, &uwsgi.harakiri_no_arh, 0},
@@ -2858,7 +2859,10 @@ int uwsgi_start(void *v_argv) {
 
 	// setup locking
 	uwsgi_setup_locking();
-	if (uwsgi.use_thunder_lock) {
+	if (uwsgi.use_thunder_lock && uwsgi.use_thunder_lock_watchdog) {
+		uwsgi_log_initial("thunder lock: enabled (with robust mutex watchdog)\n");
+	}
+	else if (uwsgi.use_thunder_lock) {
 		uwsgi_log_initial("thunder lock: enabled\n");
 	}
 	else {

--- a/uwsgi.h
+++ b/uwsgi.h
@@ -2493,6 +2493,7 @@ struct uwsgi_server {
 	pthread_mutex_t lock_static;
 
 	int use_thunder_lock;
+	int use_thunder_lock_watchdog;
 	struct uwsgi_lock_item *the_thunder_lock;
 
 	/* the list of workers */


### PR DESCRIPTION
Makes the robust mutex watchdog available to all via the new option
--thunder-lock-watchdog to workaround buggy pthread robust mutexes in
older libc causing deadlocks and unresponsive uwsgi.

Resolves #1571.