### PR TITLE
Allow setting the response headers buffer size.

### DIFF
--- a/core/uwsgi.c
+++ b/core/uwsgi.c
@@ -1009,6 +1009,7 @@ static struct uwsgi_option uwsgi_base_options[] = {
 	{"config-py", no_argument, 0, "dump the uwsgiconfig.py used for building the core  (useful for building external plugins)", uwsgi_opt_config_py, NULL, UWSGI_OPT_IMMEDIATE},
 	{"build-plugin", required_argument, 0, "build a uWSGI plugin for the current binary", uwsgi_opt_build_plugin, NULL, UWSGI_OPT_IMMEDIATE},
 	{"version", no_argument, 0, "print uWSGI version", uwsgi_opt_print, UWSGI_VERSION, 0},
+	{"response-headers-limit", required_argument, 0, "set response header maximum size (default: 64k)", uwsgi_opt_set_int, &uwsgi.response_header_limit, 0},
 	{0, 0, 0, 0, 0, 0, 0}
 };
 
@@ -2156,6 +2157,9 @@ void uwsgi_setup(int argc, char *argv[], char *envp[]) {
 	uwsgi.page_size = getpagesize();
 #endif
 	uwsgi.binary_path = uwsgi_get_binary_path(argv[0]);
+
+	if(uwsgi.response_header_limit == 0)
+		uwsgi.response_header_limit = UMAX16;
 
 	// ok we can now safely play with argv and environ
 	fixup_argv_and_environ(argc, argv, environ, envp);

--- a/core/writer.c
+++ b/core/writer.c
@@ -71,7 +71,7 @@ int uwsgi_response_prepare_headers(struct wsgi_request *wsgi_req, char *status, 
 
 	if (!wsgi_req->headers) {
 		wsgi_req->headers = uwsgi_buffer_new(uwsgi.page_size);
-		wsgi_req->headers->limit = UMAX16;
+		wsgi_req->headers->limit = uwsgi.response_header_limit;
 	}
 
 	// reset the buffer (could be useful for rollbacks...)
@@ -146,7 +146,7 @@ static int uwsgi_response_add_header_do(struct wsgi_request *wsgi_req, char *key
 
         if (!wsgi_req->headers) {
                 wsgi_req->headers = uwsgi_buffer_new(uwsgi.page_size);
-                wsgi_req->headers->limit = UMAX16;
+                wsgi_req->headers->limit = uwsgi.response_header_limit;
         }
 
         struct uwsgi_buffer *hh = wsgi_req->socket->proto_add_header(wsgi_req, key, key_len, value, value_len);

--- a/uwsgi.h
+++ b/uwsgi.h
@@ -2796,6 +2796,8 @@ struct uwsgi_server {
 #ifdef UWSGI_SSL
 	int ssl_verify_depth;
 #endif
+
+	size_t response_header_limit;
 };
 
 struct uwsgi_rpc {


### PR DESCRIPTION
Default size is system page size. This should allow for setting larger/smaller.