### PR TITLE
[Fixes #1639] Log error if python home does not exist.

### DIFF
--- a/plugins/python/python_plugin.c
+++ b/plugins/python/python_plugin.c
@@ -242,6 +242,10 @@ int uwsgi_python_init() {
 	}
 
 	if (up.home != NULL) {
+		if (!uwsgi_is_dir(up.home)) {
+			uwsgi_log("Python Home is not a directory: %s\n", up.home);
+			exit(1);
+		}
 #ifdef PYTHREE
 		// check for PEP 405 virtualenv (starting from python 3.3)
 		char *pep405_env = uwsgi_concat2(up.home, "/pyvenv.cfg");


### PR DESCRIPTION
Will fail loading of Python plugin.