### PR TITLE
Leverage Linux's getcwd

### DIFF
--- a/core/utils.c
+++ b/core/utils.c
@@ -175,7 +175,9 @@ void daemonize(char *logfile) {
 
 // get current working directory
 char *uwsgi_get_cwd() {
-
+#if defined(__GLIBC__)
+	return getcwd(NULL, 0);
+#else
 	// set this to static to avoid useless reallocations in stats mode
 	static size_t newsize = 256;
 
@@ -193,6 +195,7 @@ char *uwsgi_get_cwd() {
 	}
 
 	return cwd;
+#endif
 
 }
 


### PR DESCRIPTION
According to the man page:

       As an extension to the POSIX.1-2001 standard, glibc's getcwd() allocates the buffer dynamically using malloc(3) if buf is NULL.  In this case, the allocated buf‐
       fer has the length size unless size is zero, when buf is allocated as big as necessary.  The caller should free(3) the returned buffer.

So to save us some work, just call getcwd(NULL, 0);