### PR TITLE
Issue #1648: Remove unused uninitialized tuple 'embedded_args'

### DIFF
--- a/plugins/python/pyloader.c
+++ b/plugins/python/pyloader.c
@@ -288,10 +288,12 @@ int init_uwsgi_app(int loader, void *arg1, struct wsgi_request *wsgi_req, PyThre
 			uwsgi_log("unable to allocate new tuple for app args\n");
 			exit(1);
 		}
+		Py_INCREF(Py_None);
+		PyTuple_SetItem(wi->args[i], 0, Py_None);
 
 		// add start_response on WSGI app
-		Py_INCREF((PyObject *)up.wsgi_spitout);
 		if (app_type == PYTHON_APP_TYPE_WSGI) {
+			Py_INCREF((PyObject *)up.wsgi_spitout);
 			if (PyTuple_SetItem(wi->args[i], 1, up.wsgi_spitout)) {
 				uwsgi_log("unable to set start_response in args tuple\n");
 				exit(1);

--- a/plugins/python/python_plugin.c
+++ b/plugins/python/python_plugin.c
@@ -1082,7 +1082,9 @@ void uwsgi_python_destroy_env_cheat(struct wsgi_request *wsgi_req) {
 void *uwsgi_python_create_env_holy(struct wsgi_request *wsgi_req, struct uwsgi_app *wi) {
 	wsgi_req->async_args = PyTuple_New(2);
 	// set start_response()
+        Py_INCREF(Py_None);
 	Py_INCREF(up.wsgi_spitout);
+	PyTuple_SetItem((PyObject *)wsgi_req->async_args, 0, Py_None);
 	PyTuple_SetItem((PyObject *)wsgi_req->async_args, 1, up.wsgi_spitout);
 	PyObject *env = PyDict_New();
 	return env;

--- a/plugins/python/python_plugin.c
+++ b/plugins/python/python_plugin.c
@@ -919,12 +919,6 @@ void init_uwsgi_embedded_module() {
 		}
 	}
 
-	up.embedded_args = PyTuple_New(2);
-	if (!up.embedded_args) {
-		PyErr_Print();
-		exit(1);
-	}
-
 	init_uwsgi_module_advanced(new_uwsgi_module);
 
 	if (uwsgi.spoolers) {

--- a/plugins/python/python_plugin.c
+++ b/plugins/python/python_plugin.c
@@ -1082,7 +1082,7 @@ void uwsgi_python_destroy_env_cheat(struct wsgi_request *wsgi_req) {
 void *uwsgi_python_create_env_holy(struct wsgi_request *wsgi_req, struct uwsgi_app *wi) {
 	wsgi_req->async_args = PyTuple_New(2);
 	// set start_response()
-        Py_INCREF(Py_None);
+	Py_INCREF(Py_None);
 	Py_INCREF(up.wsgi_spitout);
 	PyTuple_SetItem((PyObject *)wsgi_req->async_args, 0, Py_None);
 	PyTuple_SetItem((PyObject *)wsgi_req->async_args, 1, up.wsgi_spitout);

--- a/plugins/python/uwsgi_python.h
+++ b/plugins/python/uwsgi_python.h
@@ -183,7 +183,6 @@ struct uwsgi_python {
 
 	PyObject *workers_tuple;
 	PyObject *embedded_dict;
-	PyObject *embedded_args;
 
 	char *wsgi_env_behaviour;
 


### PR DESCRIPTION
This partially fixes issue #1648. There is still a problem with "async_args" being left in a partially uninitialized state, which I'll try to fix in another commit.