### PR TITLE
[Fixes #1587] Support If-Range for static (partial)

### DIFF
--- a/core/protocol.c
+++ b/core/protocol.c
@@ -277,6 +277,11 @@ static void uwsgi_parse_http_range(char *buf, uint16_t len, enum uwsgi_range *pa
 
 static int uwsgi_proto_check_10(struct wsgi_request *wsgi_req, char *key, char *buf, uint16_t len) {
 
+	if (uwsgi.honour_range && !uwsgi_proto_key("HTTP_IF_RANGE", 13)) {
+		wsgi_req->if_range = buf;
+		wsgi_req->if_range_len = len;
+	}
+
 	if (uwsgi.honour_range && !uwsgi_proto_key("HTTP_RANGE", 10)) {
 		uwsgi_parse_http_range(buf, len, &wsgi_req->range_parsed,
 				&wsgi_req->range_from, &wsgi_req->range_to);

--- a/core/static.c
+++ b/core/static.c
@@ -493,9 +493,20 @@ int uwsgi_real_file_serve(struct wsgi_request *wsgi_req, char *real_filename, si
 		if (uwsgi_response_add_content_range(wsgi_req, -1, -1, st->st_size)) return -1;
 		return 0;
 	case UWSGI_RANGE_VALID:
-		fsize = wsgi_req->range_to - wsgi_req->range_from + 1;
-		if (uwsgi_response_prepare_headers(wsgi_req, "206 Partial Content", 19)) return -1;
-		break;
+		{
+			time_t when = 0;
+			if (wsgi_req->if_range != NULL) {
+				when = uwsgi_parse_http_date(wsgi_req->if_range, wsgi_req->if_range_len);
+				// an ETag will result in when == 0
+			}
+		
+			if (when < st->st_mtime) {
+				fsize = wsgi_req->range_to - wsgi_req->range_from + 1;
+				if (uwsgi_response_prepare_headers(wsgi_req, "206 Partial Content", 19)) return -1;
+				break;
+			}
+		}
+		/* fallthrough */
 	default: /* UWSGI_RANGE_NOT_PARSED */
 		if (uwsgi_response_prepare_headers(wsgi_req, "200 OK", 6)) return -1;
 	}

--- a/uwsgi.h
+++ b/uwsgi.h
@@ -1639,6 +1639,8 @@ struct wsgi_request {
 		struct sockaddr_un sun;
 	} client_addr;
 
+	char * if_range;
+	uint16_t if_range_len;
 };
 
 


### PR DESCRIPTION
Supports timestamps in If-Range on static assets.
Does not support ETags - will treat as implicitly correct.
None of the static system currently supports ETags.