### PR TITLE
Add log-before option

### DIFF
--- a/core/protocol.c
+++ b/core/protocol.c
@@ -702,6 +702,14 @@ int uwsgi_parse_vars(struct wsgi_request *wsgi_req) {
 	}
 
 next:
+	if (uwsgi.log_before) {
+		uwsgi_log("[pid: %d] %.*s %.*s %.*s\n",
+			uwsgi.mypid,
+			wsgi_req->remote_addr_len, wsgi_req->remote_addr,
+			wsgi_req->method_len, wsgi_req->method,
+			wsgi_req->uri_len, wsgi_req->uri
+		);
+	}
 
 	// manage post buffering (if needed as post_file could be created before)
 	if (uwsgi.post_buffering > 0 && !wsgi_req->post_file) {

--- a/core/uwsgi.c
+++ b/core/uwsgi.c
@@ -1069,6 +1069,7 @@ static struct uwsgi_option uwsgi_base_options[] = {
 	{"build-plugin", required_argument, 0, "build a uWSGI plugin for the current binary", uwsgi_opt_build_plugin, NULL, UWSGI_OPT_IMMEDIATE},
 	{"version", no_argument, 0, "print uWSGI version", uwsgi_opt_print, UWSGI_VERSION, 0},
 	{"response-headers-limit", required_argument, 0, "set response header maximum size (default: 64k)", uwsgi_opt_set_int, &uwsgi.response_header_limit, 0},
+	{"log-before", no_argument, 0, "Log request URI as early as possible.", uwsgi_opt_true, &uwsgi.log_before, 0},
 	{0, 0, 0, 0, 0, 0, 0}
 };
 

--- a/uwsgi.h
+++ b/uwsgi.h
@@ -2902,6 +2902,8 @@ struct uwsgi_server {
 
 	int http_path_info_no_decode_slashes;
 
+	int log_before;
+
 };
 
 struct uwsgi_rpc {


### PR DESCRIPTION
Add an option to log the pid, remote address, request method and URI early, to aid in debugging.