### PR TITLE
correctly handle IPv6 sources in proto/http ; branch on top of 2.0.x

### DIFF
--- a/proto/base.c
+++ b/proto/base.c
@@ -98,15 +98,15 @@ int uwsgi_proto_base_accept(struct wsgi_request *wsgi_req, int fd) {
 
 	wsgi_req->c_len = sizeof(struct sockaddr_un);
 #if defined(__linux__) && defined(SOCK_NONBLOCK) && !defined(OBSOLETE_LINUX_KERNEL)
-        return accept4(fd, (struct sockaddr *) &wsgi_req->c_addr, (socklen_t *) & wsgi_req->c_len, SOCK_NONBLOCK);
+	return accept4(fd, (struct sockaddr *) &wsgi_req->client_addr, (socklen_t *) & wsgi_req->c_len, SOCK_NONBLOCK);
 #elif defined(__linux__)
-	int client_fd = accept(fd, (struct sockaddr *) &wsgi_req->c_addr, (socklen_t *) & wsgi_req->c_len);
+	int client_fd = accept(fd, (struct sockaddr *) &wsgi_req->client_addr, (socklen_t *) & wsgi_req->c_len);
 	if (client_fd >= 0) {
 		uwsgi_socket_nb(client_fd);
 	}
 	return client_fd;
 #else
-	return accept(fd, (struct sockaddr *) &wsgi_req->c_addr, (socklen_t *) & wsgi_req->c_len);
+	return accept(fd, (struct sockaddr *) &wsgi_req->client_addr, (socklen_t *) & wsgi_req->c_len);
 #endif
 }
 

--- a/proto/http.c
+++ b/proto/http.c
@@ -294,62 +294,55 @@ static int http_parse(struct wsgi_request *wsgi_req, char *watermark) {
 	}
 	else {
 		// TODO log something useful for AF_UNIX sockets
-		switch (http_sa->sa_family) {
-			case AF_INET6:
-				{
-					memset(ip, 0, sizeof(ip));
-					struct sockaddr_in6* http_sin = &wsgi_req->client_addr.sin6;
-					/* check if it's an IPv6-mapped-IPv4 address and, if so,
-					 * represent it as an IPv4 address
-					 *
-					 * Note: This macro isn't in any version of the POSIX
-					 * spec that I've found, but it's implemented on BSD,
-					 * Linux, and OS X.
-					 */
-					if (IN6_IS_ADDR_V4MAPPED(&http_sin->sin6_addr)) {
-						/* just grab the last 4 bytes and pretend they're
-						 * IPv4. Linux has a convenience wrapped to get the
-						 * componenets word-wise, but OS X/BSD do not.
-						 */
-						union {
-							unsigned char s6[4];
-							uint32_t s4;
-						} addr_parts;
-						addr_parts.s6[0] = http_sin->sin6_addr.s6_addr[12];
-						addr_parts.s6[1] = http_sin->sin6_addr.s6_addr[13];
-						addr_parts.s6[2] = http_sin->sin6_addr.s6_addr[14];
-						addr_parts.s6[3] = http_sin->sin6_addr.s6_addr[15];
-						uint32_t in4_addr = addr_parts.s4;
-						if (inet_ntop(AF_INET, (void*)&in4_addr, ip, INET_ADDRSTRLEN)) {
-							wsgi_req->uh->pktsize += proto_base_add_uwsgi_var(wsgi_req, "REMOTE_ADDR", 11, ip, strlen(ip));
-						} else {
-							uwsgi_error("inet_ntop()");
-							return -1;
-						}
-					} else {
-						if (inet_ntop(AF_INET6, (void *) &http_sin->sin6_addr, ip, INET6_ADDRSTRLEN)) {
-							wsgi_req->uh->pktsize += proto_base_add_uwsgi_var(wsgi_req, "REMOTE_ADDR", 11, ip, strlen(ip));
-						} else {
-							uwsgi_error("inet_ntop()");
-							return -1;
-						}
-					}
+		switch(http_sa->sa_family) {
+		case AF_INET6: {
+			struct sockaddr_in6* http_sin = &wsgi_req->client_addr.sin6;
+			memset(ip, 0, sizeof(ip));
+			/* check if it's an IPv6-mapped-IPv4 address and, if so,
+			 * represent it as an IPv4 address
+			 *
+			 * these IPv6 macros are defined in POSIX.1-2001.
+			 */
+			if (IN6_IS_ADDR_V4MAPPED(&http_sin->sin6_addr)) {
+				/* just grab the last 4 bytes and pretend they're
+				 * IPv4. None of the word/half-word convenience
+				 * functions are in POSIX, so just stick to .s6_addr
+				 */
+				union {
+					unsigned char s6[4];
+					uint32_t s4;
+				} addr_parts;
+				memcpy(addr_parts.s6, &http_sin->sin6_addr.s6_addr[12], 4);
+				uint32_t in4_addr = addr_parts.s4;
+				if (inet_ntop(AF_INET, (void*)&in4_addr, ip, INET_ADDRSTRLEN)) {
+					wsgi_req->uh->pktsize += proto_base_add_uwsgi_var(wsgi_req, "REMOTE_ADDR", 11, ip, strlen(ip));
+				} else {
+					uwsgi_error("inet_ntop()");
+					return -1;
 				}
-				break;
-			case AF_INET:
-			default:
-				{
-					struct sockaddr_in* http_sin = &wsgi_req->client_addr.sin;
-					memset(ip, 0, sizeof(ip));
-					if (inet_ntop(AF_INET, (void *) &http_sin->sin_addr, ip, INET_ADDRSTRLEN)) {
-						wsgi_req->uh->pktsize += proto_base_add_uwsgi_var(wsgi_req, "REMOTE_ADDR", 11, ip, strlen(ip));
-					}
-					else {
-						uwsgi_error("inet_ntop()");
-						return -1;
-					}
-				 }
-				break;
+			} else {
+				if (inet_ntop(AF_INET6, (void *) &http_sin->sin6_addr, ip, INET6_ADDRSTRLEN)) {
+					wsgi_req->uh->pktsize += proto_base_add_uwsgi_var(wsgi_req, "REMOTE_ADDR", 11, ip, strlen(ip));
+				} else {
+					uwsgi_error("inet_ntop()");
+					return -1;
+				}
+			}
+			}
+			break;
+		case AF_INET:
+		default: {
+			struct sockaddr_in* http_sin = &wsgi_req->client_addr.sin;
+			memset(ip, 0, sizeof(ip));
+			if (inet_ntop(AF_INET, (void *) &http_sin->sin_addr, ip, INET_ADDRSTRLEN)) {
+				wsgi_req->uh->pktsize += proto_base_add_uwsgi_var(wsgi_req, "REMOTE_ADDR", 11, ip, strlen(ip));
+			}
+			else {
+				uwsgi_error("inet_ntop()");
+				return -1;
+			}
+			}
+			break;
 		}
 	}
 

--- a/proto/http.c
+++ b/proto/http.c
@@ -328,8 +328,8 @@ static int http_parse(struct wsgi_request *wsgi_req, char *watermark) {
 					return -1;
 				}
 			}
-			}
 			break;
+		}
 		case AF_INET:
 		default: {
 			struct sockaddr_in* http_sin = &wsgi_req->client_addr.sin;

--- a/uwsgi.h
+++ b/uwsgi.h
@@ -1362,7 +1362,8 @@ struct wsgi_request {
 	char *appid;
 	uint16_t appid_len;
 
-	//this is big enough to contain sockaddr_in
+	// This structure should not be used any more
+	// in favor of the union client_addr at the end
 	struct sockaddr_un c_addr;
 	int c_len;
 
@@ -1617,6 +1618,15 @@ struct wsgi_request {
 
 	char * if_range;
 	uint16_t if_range_len;
+
+	// client address in a type-safe fashion; always use this over
+	// c_addr (which only exists to maintain binary compatibility in this
+	// struct)
+	union address {
+		struct sockaddr_in sin;
+		struct sockaddr_in6 sin6;
+		struct sockaddr_un sun;
+	} client_addr;
 };
 
 


### PR DESCRIPTION
This is #1203 rebased and squashed down on top of the 2.0 branch in case we get to do a 2.0.16, as requested by Curtis on the mailing list.