### PR TITLE
Reinitialize environ after uwsgi_setup_reload() when running as a CPython extension on macOS

### DIFF
--- a/core/uwsgi.c
+++ b/core/uwsgi.c
@@ -2151,6 +2151,14 @@ void uwsgi_setup(int argc, char *argv[], char *envp[]) {
 	// count/set the current reload status
 	uwsgi_setup_reload();
 
+#ifdef UWSGI_AS_SHARED_LIBRARY
+#ifdef __APPLE__
+	// environ is invalid after setenv()
+	envPtr = _NSGetEnviron();
+	environ = *envPtr;
+#endif
+#endif
+
 #ifdef __CYGWIN__
 	SYSTEM_INFO si;
 	GetSystemInfo(&si);


### PR DESCRIPTION
`setenv()` in `uwsgi_setup_reload()` makes `environ` invalid. This manifests as a memory access violation in `parse_sys_envs()` when the pointer is dereferenced:

```
!!! uWSGI process 21646 got Segmentation Fault !!!
*** backtrace of 21646 ***
0   uwsgi.so                            0x00000001087d97fc uwsgi_backtrace + 44
1   uwsgi.so                            0x00000001087d9d33 uwsgi_segfault + 51
2   libsystem_platform.dylib            0x00007fffc1c8eb3a _sigtramp + 26
3   libxpc.dylib                        0x00007fffc1cd2169 xpc_array_apply + 64
4   uwsgi.so                            0x000000010878cd64 parse_sys_envs + 484
5   uwsgi.so                            0x00000001087db659 uwsgi_setup + 5993
6   uwsgi.so                            0x00000001087ec755 pyuwsgi_setup + 1061
7   uwsgi.so                            0x00000001087ec823 pyuwsgi_run + 19
8   python                              0x00000001082e5821 PyCFunction_Call + 193
9   python                              0x00000001083b1bcc call_function + 1628
10  python                              0x00000001083abfa6 PyEval_EvalFrameEx + 65494
11  python                              0x000000010839bec3 PyEval_EvalCodeEx + 4979
12  python                              0x000000010839ab45 PyEval_EvalCode + 85
13  python                              0x00000001083ea892 run_mod + 98
14  python                              0x00000001083eacff PyRun_FileExFlags + 223
15  python                              0x00000001083ea059 PyRun_SimpleFileExFlags + 729
16  python                              0x00000001083e9a9c PyRun_AnyFileExFlags + 140
17  python                              0x000000010840d5d7 Py_Main + 3799
18  python                              0x000000010825f362 main + 34
19  libdyld.dylib                       0x00007fffc1a7f235 start + 1
*** end of backtrace ***
```

In testing with multiple people and environments, this segfault only occurs occurs on macOS (likely due to its [unique restrictions](https://developer.apple.com/legacy/library/documentation/Darwin/Reference/ManPages/man7/environ.7.html) on `environ` when running as a shared library), and only when logged in via ssh, not on console. Setting `$__CF_USER_TEXT_ENCODING` to any value, for whatever reason, reliably prevents this, although I don't know why.