### PR TITLE
Do not override environ if not necessary

### DIFF
--- a/core/uwsgi.c
+++ b/core/uwsgi.c
@@ -1823,8 +1823,8 @@ static void fixup_argv_and_environ(int argc, char **argv, char **environ, char *
 	uwsgi.argv = uwsgi_malloc(sizeof(char *) * (argc + 1));
 
 	for (i = 0; i < argc; i++) {
-		if (i == 0 || argv[0] + uwsgi.max_procname + 1 == argv[i]) {
-			uwsgi.max_procname += strlen(argv[i]) + 1;
+		if (i == 0 || argv[0] + uwsgi.argv_len == argv[i]) {
+			uwsgi.argv_len += strlen(argv[i]) + 1;
 		}
 		uwsgi.argv[i] = strdup(argv[i]);
 	}
@@ -1832,13 +1832,10 @@ static void fixup_argv_and_environ(int argc, char **argv, char **environ, char *
 	// required by execve
 	uwsgi.argv[i] = NULL;
 
-	uwsgi.max_procname++;
-
 	for (i = 0; environ[i] != NULL; i++) {
-		// useless
-		//if ((environ[0] + uwsgi.max_procname + 1) == environ[i]) {
-		uwsgi.max_procname += strlen(environ[i]) + 1;
-		//}
+		if (environ[0] + uwsgi.environ_len == environ[i]) {
+			uwsgi.environ_len += strlen(environ[i]) + 1;
+		}
 		env_count++;
 	}
 
@@ -1853,7 +1850,8 @@ static void fixup_argv_and_environ(int argc, char **argv, char **environ, char *
 	uwsgi.environ[env_count] = NULL;
 
 #ifdef UWSGI_DEBUG
-	uwsgi_log("max space for custom process name = %d\n", uwsgi.max_procname);
+	uwsgi_log("total length of argv = %u\n", (unsigned int)uwsgi.argv_len);
+	uwsgi_log("total length of environ = %u\n", (unsigned int)uwsgi.environ_len);
 #endif
 	//environ = uwsgi.environ;
 

--- a/uwsgi.h
+++ b/uwsgi.h
@@ -1778,6 +1778,7 @@ struct uwsgi_server {
 	char **orig_argv;
 	char **argv;
 	int argc;
+	// replaced by argv_len + environ_len, kept for ABI compatibility
 	int max_procname;
 	int auto_procname;
 	char **environ;
@@ -2905,6 +2906,8 @@ struct uwsgi_server {
 
 	int http_path_info_no_decode_slashes;
 
+	size_t argv_len;
+	size_t environ_len;
 };
 
 struct uwsgi_rpc {


### PR DESCRIPTION
On Linux, initial process environment can be accessed from outside via /proc/<pid>/environ. We'd like to use this for uwsgi as well, but uwsgi clears the memory for this in the beginning so the file looks completely empty. The memory for argv and environ is used for a custom process name.

With the changes in this PR,
- argv_len is computed correctly (before, the length of all argv except the first was ignored due to off by one error)
- argv_len and environ_len is stored separately and if the new procname can fit into argv, environ is kept untouched