### PR TITLE
Enable execinfo on DragonFly BSD

### DIFF
--- a/uwsgiconfig.py
+++ b/uwsgiconfig.py
@@ -831,7 +831,7 @@ class uConf(object):
             self.cflags.append('-DUWSGI_HAS_IFADDRS')
             report['ifaddrs'] = True
 
-        if uwsgi_os in ('FreeBSD', 'OpenBSD'):
+        if uwsgi_os in ('FreeBSD', 'DragonFly', 'OpenBSD'):
             if self.has_include('execinfo.h') or os.path.exists('/usr/local/include/execinfo.h'):
                 if os.path.exists('/usr/local/include/execinfo.h'):
                     self.cflags.append('-I/usr/local/include')


### PR DESCRIPTION
DragonFly BSD also has execinfo, so enable it.

I've tested this patch on DragonFly 5.1-master.

Cheers,
Aly