### PR TITLE
Backport PR #800 (safe-pidfile, safe-pidfile2) to 2.0

### DIFF
--- a/core/utils.c
+++ b/core/utils.c
@@ -3617,6 +3617,13 @@ void uwsgi_write_pidfile(char *pidfile_name) {
 	}
 }
 
+void uwsgi_write_pidfile_explicit(char *pidfile_name, pid_t pid) {
+	uwsgi_log("writing pidfile to %s\n", pidfile_name);
+	if (uwsgi_write_intfile(pidfile_name, (int) pid)) {
+		uwsgi_log("could not write pidfile.\n");
+	}
+}
+
 char *uwsgi_expand_path(char *dir, int dir_len, char *ptr) {
 	char src[PATH_MAX + 1];
 	memcpy(src, dir, dir_len);

--- a/core/uwsgi.c
+++ b/core/uwsgi.c
@@ -350,6 +350,8 @@ static struct uwsgi_option uwsgi_base_options[] = {
 
 	{"pidfile", required_argument, 0, "create pidfile (before privileges drop)", uwsgi_opt_set_str, &uwsgi.pidfile, 0},
 	{"pidfile2", required_argument, 0, "create pidfile (after privileges drop)", uwsgi_opt_set_str, &uwsgi.pidfile2, 0},
+	{"safe-pidfile", required_argument, 0, "create safe pidfile (before privileges drop)", uwsgi_opt_set_str, &uwsgi.safe_pidfile, 0},
+	{"safe-pidfile2", required_argument, 0, "create safe pidfile (after privileges drop)", uwsgi_opt_set_str, &uwsgi.safe_pidfile2, 0},
 	{"chroot", required_argument, 0, "chroot() to the specified directory", uwsgi_opt_set_str, &uwsgi.chroot, 0},
 #ifdef __linux__
 	{"pivot-root", required_argument, 0, "pivot_root() to the specified directories (new_root and put_old must be separated with a space)", uwsgi_opt_set_str, &uwsgi.pivot_root, 0},
@@ -1612,6 +1614,22 @@ static void vacuum(void) {
 					uwsgi_log("VACUUM: pidfile2 removed.\n");
 				}
 			}
+			if (uwsgi.safe_pidfile && !uwsgi.uid) {
+				if (unlink(uwsgi.safe_pidfile)) {
+					uwsgi_error("unlink()");
+				}
+				else {
+					uwsgi_log("VACUUM: safe pidfile removed.\n");
+				}
+			}
+			if (uwsgi.safe_pidfile2) {
+				if (unlink(uwsgi.safe_pidfile2)) {
+					uwsgi_error("unlink()");
+				}
+				else {
+					uwsgi_log("VACUUM: safe pidfile2 removed.\n");
+				}
+			}
 			if (uwsgi.chdir) {
 				if (chdir(uwsgi.chdir)) {
 					uwsgi_error("chdir()");
@@ -2420,6 +2438,10 @@ void uwsgi_setup(int argc, char *argv[], char *envp[]) {
 		uwsgi_log("*** running under screen session %s ***\n", uwsgi.screen_session);
 	}
 
+	if (uwsgi.pidfile && !uwsgi.is_a_reload) {
+		uwsgi_write_pidfile(uwsgi.pidfile);
+	}
+
 	uwsgi_log_initial("detected binary path: %s\n", uwsgi.binary_path);
 
 	if (uwsgi.is_a_reload) {
@@ -2520,8 +2542,8 @@ void uwsgi_setup(int argc, char *argv[], char *envp[]) {
 	}
 #endif
 
-	if (uwsgi.pidfile && !uwsgi.is_a_reload) {
-		uwsgi_write_pidfile_explicit(uwsgi.pidfile, masterpid);
+	if (uwsgi.safe_pidfile && !uwsgi.is_a_reload) {
+		uwsgi_write_pidfile_explicit(uwsgi.safe_pidfile, masterpid);
 	}
 }
 
@@ -2599,6 +2621,10 @@ int uwsgi_start(void *v_argv) {
 			uwsgi_error("chdir()");
 			exit(1);
 		}
+	}
+
+	if (uwsgi.pidfile2 && !uwsgi.is_a_reload) {
+		uwsgi_write_pidfile(uwsgi.pidfile2);
 	}
 
 	if (!uwsgi.master_process && !uwsgi.command_mode) {
@@ -3252,8 +3278,8 @@ next2:
 		}
 	}
 
-	if (uwsgi.pidfile2 && !uwsgi.is_a_reload) {
-		uwsgi_write_pidfile_explicit(uwsgi.pidfile2, masterpid);
+	if (uwsgi.safe_pidfile2 && !uwsgi.is_a_reload) {
+		uwsgi_write_pidfile_explicit(uwsgi.safe_pidfile2, masterpid);
 	}
 
 	// END OF INITIALIZATION
@@ -4939,6 +4965,12 @@ void uwsgi_update_pidfiles() {
 	}
 	if (uwsgi.pidfile2) {
 		uwsgi_write_pidfile(uwsgi.pidfile2);
+	}
+	if (uwsgi.safe_pidfile) {
+		uwsgi_write_pidfile(uwsgi.safe_pidfile);
+	}
+	if (uwsgi.safe_pidfile2) {
+		uwsgi_write_pidfile(uwsgi.safe_pidfile2);
 	}
 }
 

--- a/core/uwsgi.c
+++ b/core/uwsgi.c
@@ -2420,10 +2420,6 @@ void uwsgi_setup(int argc, char *argv[], char *envp[]) {
 		uwsgi_log("*** running under screen session %s ***\n", uwsgi.screen_session);
 	}
 
-	if (uwsgi.pidfile && !uwsgi.is_a_reload) {
-		uwsgi_write_pidfile(uwsgi.pidfile);
-	}
-
 	uwsgi_log_initial("detected binary path: %s\n", uwsgi.binary_path);
 
 	if (uwsgi.is_a_reload) {
@@ -2523,6 +2519,10 @@ void uwsgi_setup(int argc, char *argv[], char *envp[]) {
 #if defined(__linux__) && !defined(__ia64__)
 	}
 #endif
+
+	if (uwsgi.pidfile && !uwsgi.is_a_reload) {
+		uwsgi_write_pidfile_explicit(uwsgi.pidfile, masterpid);
+	}
 }
 
 
@@ -2599,10 +2599,6 @@ int uwsgi_start(void *v_argv) {
 			uwsgi_error("chdir()");
 			exit(1);
 		}
-	}
-
-	if (uwsgi.pidfile2 && !uwsgi.is_a_reload) {
-		uwsgi_write_pidfile(uwsgi.pidfile2);
 	}
 
 	if (!uwsgi.master_process && !uwsgi.command_mode) {
@@ -3256,6 +3252,9 @@ next2:
 		}
 	}
 
+	if (uwsgi.pidfile2 && !uwsgi.is_a_reload) {
+		uwsgi_write_pidfile_explicit(uwsgi.pidfile2, masterpid);
+	}
 
 	// END OF INITIALIZATION
 	return 0;

--- a/uwsgi.h
+++ b/uwsgi.h
@@ -2433,9 +2433,6 @@ struct uwsgi_server {
 	char *pidfile;
 	char *pidfile2;
 
-	char *safe_pidfile;
-	char *safe_pidfile2;
-
 	char *flock2;
 	char *flock_wait2;
 
@@ -2817,6 +2814,8 @@ struct uwsgi_server {
 #endif
 
 	size_t response_header_limit;
+	char *safe_pidfile;
+	char *safe_pidfile2;
 };
 
 struct uwsgi_rpc {

--- a/uwsgi.h
+++ b/uwsgi.h
@@ -3967,6 +3967,7 @@ void uwsgi_setup_post_buffering(void);
 struct uwsgi_lock_item *uwsgi_lock_ipcsem_init(char *);
 
 void uwsgi_write_pidfile(char *);
+void uwsgi_write_pidfile_explicit(char *, pid_t);
 int uwsgi_write_intfile(char *, int);
 
 void uwsgi_protected_close(int);

--- a/uwsgi.h
+++ b/uwsgi.h
@@ -2433,6 +2433,9 @@ struct uwsgi_server {
 	char *pidfile;
 	char *pidfile2;
 
+	char *safe_pidfile;
+	char *safe_pidfile2;
+
 	char *flock2;
 	char *flock_wait2;
 


### PR DESCRIPTION
These options added in #800 are referenced in the 2.0 documentation but were never backported to 2.0. Fixes #1417.