### PR TITLE
not clear semaphore on forked master

### DIFF
--- a/core/lock.c
+++ b/core/lock.c
@@ -612,7 +612,7 @@ pid_t uwsgi_lock_ipcsem_check(struct uwsgi_lock_item *uli) {
 
 void uwsgi_ipcsem_clear(void) {
 
-	if (uwsgi.persistent_ipcsem && uwsgi.master_is_reforked) return;
+	if (uwsgi.persistent_ipcsem || uwsgi.master_is_reforked) return;
 
 	struct uwsgi_lock_item *uli = uwsgi.registered_locks;
 

--- a/core/lock.c
+++ b/core/lock.c
@@ -612,7 +612,7 @@ pid_t uwsgi_lock_ipcsem_check(struct uwsgi_lock_item *uli) {
 
 void uwsgi_ipcsem_clear(void) {
 
-	if (uwsgi.persistent_ipcsem) return;
+	if (uwsgi.persistent_ipcsem && uwsgi.master_is_reforked) return;
 
 	struct uwsgi_lock_item *uli = uwsgi.registered_locks;
 


### PR DESCRIPTION
If using semaphore as lock engine and the forked master is in a crash loop, it'll eventually bring down the old worker processes too.
The problems is the forked master shouldn't try to clear the state(semaphore in this case) inherited from the old master.

To repro, set worker number = 1, and 
1. start server and send a request - let worker touch the semaphore
2. kill -9 the worker process - kill the last process touched it
3. change uwsgi.ini to a bad one(in my case, I setup a cache items > blocks) then do master fork - fail the master fork
4. now old master fails too, the exception is uwsgi_lock_ipcsem()/semop(): Invalid argument [core/lock.c line 547] because semaphore cleared by new master..