### PR TITLE
move plugin post_jail hooks to post_jail start

### DIFF
--- a/core/utils.c
+++ b/core/utils.c
@@ -514,6 +514,13 @@ void uwsgi_as_root() {
 #endif
 
 	if (in_jail || uwsgi.jailed) {
+		int i;
+		for (i = 0; i < uwsgi.gp_cnt; i++) {
+			if (uwsgi.gp[i]->post_jail) {
+				uwsgi.gp[i]->post_jail();
+			}
+		}
+
 		uwsgi_hooks_run(uwsgi.hook_post_jail, "post-jail", 1);
 		struct uwsgi_string_list *usl = NULL;
 		uwsgi_foreach(usl, uwsgi.mount_post_jail) {
@@ -563,14 +570,6 @@ void uwsgi_as_root() {
 					uwsgi_error("waitpid()");
 				}
 				_exit(0);
-			}
-		}
-
-
-		int i;
-		for (i = 0; i < uwsgi.gp_cnt; i++) {
-			if (uwsgi.gp[i]->post_jail) {
-				uwsgi.gp[i]->post_jail();
 			}
 		}
 	}


### PR DESCRIPTION
The tuntap router is the only included plugin that currently
uses the post_jail hooks to attach a the tuntap interface in
the new namespace. Move the execution of the plugin post_jail
hooks to before hook_post_jail/exec_post_jail to be able to
configure the interface just created before pivot_root