### PR TITLE
new plugin hook: early_post_jail

### DIFF
--- a/core/utils.c
+++ b/core/utils.c
@@ -514,6 +514,13 @@ void uwsgi_as_root() {
 #endif
 
 	if (in_jail || uwsgi.jailed) {
+		int i;
+		for (i = 0; i < uwsgi.gp_cnt; i++) {
+			if (uwsgi.gp[i]->early_post_jail) {
+				uwsgi.gp[i]->early_post_jail();
+			}
+		}
+
 		uwsgi_hooks_run(uwsgi.hook_post_jail, "post-jail", 1);
 		struct uwsgi_string_list *usl = NULL;
 		uwsgi_foreach(usl, uwsgi.mount_post_jail) {
@@ -566,8 +573,6 @@ void uwsgi_as_root() {
 			}
 		}
 
-
-		int i;
 		for (i = 0; i < uwsgi.gp_cnt; i++) {
 			if (uwsgi.gp[i]->post_jail) {
 				uwsgi.gp[i]->post_jail();

--- a/plugins/tuntap/tuntap.c
+++ b/plugins/tuntap/tuntap.c
@@ -534,6 +534,6 @@ end:
 struct uwsgi_plugin tuntap_plugin = {
 	.name = "tuntap",
 	.options = uwsgi_tuntap_options,
-	.post_jail = uwsgi_tuntap_client,
+	.early_post_jail = uwsgi_tuntap_client,
 	.jail = uwsgi_tuntap_router,
 };

--- a/uwsgi.h
+++ b/uwsgi.h
@@ -1071,6 +1071,7 @@ struct uwsgi_plugin {
 	uint64_t(*rpc) (void *, uint8_t, char **, uint16_t *, char **);
 
 	void (*jail) (int (*)(void *), char **);
+	void (*early_post_jail) (void);
 	void (*post_jail) (void);
 	void (*before_privileges_drop) (void);
 

--- a/uwsgi.h
+++ b/uwsgi.h
@@ -1071,7 +1071,6 @@ struct uwsgi_plugin {
 	uint64_t(*rpc) (void *, uint8_t, char **, uint16_t *, char **);
 
 	void (*jail) (int (*)(void *), char **);
-	void (*early_post_jail) (void);
 	void (*post_jail) (void);
 	void (*before_privileges_drop) (void);
 
@@ -1090,6 +1089,8 @@ struct uwsgi_plugin {
 	void (*vassal_before_exec)(struct uwsgi_instance *, char **);
 
 	int (*worker)(void);
+
+	void (*early_post_jail) (void);
 };
 
 #ifdef UWSGI_PCRE


### PR DESCRIPTION
post_jail plugin hooks runs after all other hooks in post_jail,
so it was not possible to configure for example tuntap interface
in a post-jail exec/hook, since it was not yet available.

This patch adds a early_post_jail phase that plugins can attach to,
and moves initialization of tuntap interface to this phase.