### PR TITLE
Build in current Rawhide (rb_funcall bogus arguments + do not require old hacks)

### DIFF
--- a/plugins/rack/rack_plugin.c
+++ b/plugins/rack/rack_plugin.c
@@ -71,7 +71,7 @@ static struct uwsgi_buffer *uwsgi_ruby_exception_class(struct wsgi_request *wsgi
 
 static struct uwsgi_buffer *uwsgi_ruby_exception_msg(struct wsgi_request *wsgi_req) {
 	VALUE err = rb_errinfo();
-	VALUE e = rb_funcall(err, rb_intern("message"), 0, 0);
+	VALUE e = rb_funcall(err, rb_intern("message"), 0);
 	struct uwsgi_buffer *ub = uwsgi_buffer_new(RSTRING_LEN(e));
 	if (uwsgi_buffer_append(ub, RSTRING_PTR(e), RSTRING_LEN(e))) {
 		uwsgi_buffer_destroy(ub);
@@ -114,7 +114,7 @@ error:
 static void uwsgi_ruby_exception_log(struct wsgi_request *wsgi_req) {
 	VALUE err = rb_errinfo();
 	VALUE eclass = rb_class_name(rb_class_of(err));
-	VALUE msg = rb_funcall(err, rb_intern("message"), 0, 0);
+	VALUE msg = rb_funcall(err, rb_intern("message"), 0);
 	
 	VALUE ary = rb_funcall(err, rb_intern("backtrace"), 0);
         int i;

--- a/plugins/router_basicauth/router_basicauth.c
+++ b/plugins/router_basicauth/router_basicauth.c
@@ -2,7 +2,10 @@
 
 #ifdef UWSGI_ROUTING
 
-#if defined(__linux__) && defined(__GLIBC__)
+#if defined(__linux__) && (defined(__GLIBC__) && __GLIBC__ == 2) && \
+    (defined(__GLIBC_MINOR__) && __GLIBC_MINOR__ >= 2 && __GLIBC_MINOR__ < 4)
+    /* work around glibc-2.2.5 bug,
+     * has been fixed at some time in glibc-2.3.X */
 #include <crypt.h>
 #elif defined(__CYGWIN__)
 #include <crypt.h>
@@ -66,7 +69,10 @@ static uint16_t htpasswd_check(char *filename, char *auth) {
 
 		if (clen > 13) cpwd[13] = 0;
 
-#if defined(__linux__) && defined(__GLIBC__)
+#if defined(__linux__) && (defined(__GLIBC__) && __GLIBC__ == 2) && \
+    (defined(__GLIBC_MINOR__) && __GLIBC_MINOR__ >= 2 && __GLIBC_MINOR__ < 4)
+    /* work around glibc-2.2.5 bug,
+     * has been fixed at some time in glibc-2.3.X */
 		struct crypt_data cd;
 		cd.initialized = 0;
 		// we do as nginx here


### PR DESCRIPTION
These changes makes it building with Fedora rawhide, where GCC is probably more strict about the bogus arguments.

The other patch is removing old workarounds and using again what is done by ngingx on new systems:

https://src.fedoraproject.org/cgit/rpms/nginx.git/tree/0001-unix-ngx_user-Apply-fix-for-really-old-bug-in-glibc-.patch

Now, I still have problems to build glusterfs plugin in rawhide, but it works in Fedora 28.