### PR TITLE
Don't pass NULL pointer to log string format

### DIFF
--- a/core/logging.c
+++ b/core/logging.c
@@ -738,7 +738,8 @@ void uwsgi_logit_simple(struct wsgi_request *wsgi_req) {
 
 	}
 
-	rlen = snprintf(logpkt, 4096, "[pid: %d|app: %d|req: %d/%llu] %.*s (%.*s) {%d vars in %llu bytes} [%.*s] %.*s %.*s => generated %llu bytes in %llu %s%s(%.*s %d) %d headers in %llu bytes (%d switches on core %d)\n", (int) uwsgi.mypid, wsgi_req->app_id, app_req, (unsigned long long) uwsgi.workers[0].requests, wsgi_req->remote_addr_len, wsgi_req->remote_addr, wsgi_req->remote_user_len, wsgi_req->remote_user, wsgi_req->var_cnt, (unsigned long long) wsgi_req->len,
+	char *remote_user = wsgi_req->remote_user == NULL ? "" : wsgi_req->remote_user;
+	rlen = snprintf(logpkt, 4096, "[pid: %d|app: %d|req: %d/%llu] %.*s (%.*s) {%d vars in %llu bytes} [%.*s] %.*s %.*s => generated %llu bytes in %llu %s%s(%.*s %d) %d headers in %llu bytes (%d switches on core %d)\n", (int) uwsgi.mypid, wsgi_req->app_id, app_req, (unsigned long long) uwsgi.workers[0].requests, wsgi_req->remote_addr_len, wsgi_req->remote_addr, wsgi_req->remote_user_len, remote_user, wsgi_req->var_cnt, (unsigned long long) wsgi_req->len,
 			24, time_request, wsgi_req->method_len, wsgi_req->method, wsgi_req->uri_len, wsgi_req->uri, (unsigned long long) wsgi_req->response_size, (unsigned long long) rt, tsize, via, wsgi_req->protocol_len, wsgi_req->protocol, wsgi_req->status, wsgi_req->header_cnt, (unsigned long long) wsgi_req->headers_size, wsgi_req->switches, wsgi_req->async_id);
 
 	// not enough space for logging the request, just log a (safe) minimal message


### PR DESCRIPTION
On OpenBSD passing a NULL pointer to vfprintf will lead to error messages posted in /var/log/messages, such as:

> Apr 4 13:10:47 kobol uwsgi: vfprintf %s NULL in "[pid: %d|app: %d|req:%d/%llu] %.*s (%.*s) {%d vars in %llu bytes} [%.*s] %.*s %.*s => generated %llu bytes in %llu %s%s(%.*s %d) %d headers in %llu bytes (%d switches on core %d) "

This was also reported in #1667.
This patch fixes the error messages by making sure no NULL pointer is passed to `snprintf` via `wsgi_req->remote_addr`.

Further discussion:
[1]: https://www.tedunangst.com/flak/post/its-hard-work-printing-nothing
[2]: https://github.com/OtterBrowser/otter-browser/issues/1173