### PR TITLE
Restore re-entrant crypt_r usage

### DIFF
--- a/plugins/router_basicauth/router_basicauth.c
+++ b/plugins/router_basicauth/router_basicauth.c
@@ -2,10 +2,8 @@
 
 #ifdef UWSGI_ROUTING
 
-#if defined(__linux__) && (defined(__GLIBC__) && __GLIBC__ == 2) && \
-    (defined(__GLIBC_MINOR__) && __GLIBC_MINOR__ >= 2 && __GLIBC_MINOR__ < 4)
-    /* work around glibc-2.2.5 bug,
-     * has been fixed at some time in glibc-2.3.X */
+// TODO: Add more crypt_r supported platfroms here
+#if defined(__linux__) && defined(__GLIBC__)
 #include <crypt.h>
 #elif defined(__CYGWIN__)
 #include <crypt.h>
@@ -69,14 +67,16 @@ static uint16_t htpasswd_check(char *filename, char *auth) {
 
 		if (clen > 13) cpwd[13] = 0;
 
-#if defined(__linux__) && (defined(__GLIBC__) && __GLIBC__ == 2) && \
-    (defined(__GLIBC_MINOR__) && __GLIBC_MINOR__ >= 2 && __GLIBC_MINOR__ < 4)
+#if defined(__linux__) && defined(__GLIBC__)
+		struct crypt_data cd;
+		memset(&cd, 0, sizeof(struct crypt_data));
     /* work around glibc-2.2.5 bug,
      * has been fixed at some time in glibc-2.3.X */
-		struct crypt_data cd;
-		cd.initialized = 0;
+#if (__GLIBC__ == 2) && \
+    (defined(__GLIBC_MINOR__) && __GLIBC_MINOR__ >= 2 && __GLIBC_MINOR__ < 4)
 		// we do as nginx here
 		cd.current_salt[0] = ~cpwd[0];
+#endif
 		crypted = crypt_r( colon+1, cpwd, &cd);
 #else
 		if (uwsgi.threads > 1) pthread_mutex_lock(&ur_basicauth_crypt_mutex);


### PR DESCRIPTION
The old glibc workaround removal
introduced by 00dce4265784903a3bf440834ab269fceaf5a14b also
removed the crypt_r usage.

This change limits the scope of workaround only
the known wrong glibc version and keep using the crypt_r on the others.

Very likely more libc and platform could use crypt_r instead of locking
but properly handling all platforms is out of the scope of this change.

Issue #1763: current_salt is a private member in libc