### PR TITLE
Add "secs" formatting variable

### DIFF
--- a/core/logging.c
+++ b/core/logging.c
@@ -1216,6 +1216,11 @@ static ssize_t uwsgi_lf_msecs(struct wsgi_request * wsgi_req, char **buf) {
 	return strlen(*buf);
 }
 
+static ssize_t uwsgi_lf_secs(struct wsgi_request * wsgi_req, char **buf) {
+	*buf = uwsgi_float2str((wsgi_req->end_of_request - wsgi_req->start_of_request) / 1000000.0);
+	return strlen(*buf);
+}
+
 static ssize_t uwsgi_lf_pid(struct wsgi_request * wsgi_req, char **buf) {
 	*buf = uwsgi_num2str(uwsgi.mypid);
 	return strlen(*buf);
@@ -1997,6 +2002,7 @@ void uwsgi_register_logchunks() {
 	r_logchunk(cl);
 	r_logchunk(micros);
 	r_logchunk(msecs);
+	r_logchunk(secs);
 	r_logchunk(tmsecs);
 	r_logchunk(tmicros);
 	r_logchunk(time);

--- a/core/utils.c
+++ b/core/utils.c
@@ -1929,6 +1929,14 @@ char *uwsgi_num2str(int num) {
 	return str;
 }
 
+char *uwsgi_float2str(float num) {
+
+	char *str = uwsgi_malloc(11);
+
+	snprintf(str, 11, "%f", num);
+	return str;
+}
+
 char *uwsgi_64bit2str(int64_t num) {
 	char *str = uwsgi_malloc(sizeof(MAX64_STR) + 1);
 	snprintf(str, sizeof(MAX64_STR) + 1, "%lld", (long long) num);

--- a/uwsgi.h
+++ b/uwsgi.h
@@ -3466,6 +3466,7 @@ void uwsgi_detach_daemons();
 
 void emperor_loop(void);
 char *uwsgi_num2str(int);
+char *uwsgi_float2str(float);
 char *uwsgi_64bit2str(int64_t);
 
 char *magic_sub(char *, size_t, size_t *, char *[]);


### PR DESCRIPTION
Returns the request time in seconds. Services like Stackdriver expect the request time to be sent in seconds.