### PR TITLE
plugins/python: Enable handling unix signals with python in master

### DIFF
--- a/plugins/python/python_plugin.c
+++ b/plugins/python/python_plugin.c
@@ -2047,11 +2047,18 @@ static int uwsgi_python_worker() {
 }
 
 static void uwsgi_python_master_cycle() {
-	// run python signal handlers if any scheduled
-	if (up.master_check_signals && PyErr_CheckSignals()) {
-		uwsgi_log("exception in python signal handler\n");
-		PyErr_Print();
-		exit(1);
+	if (up.master_check_signals) {
+                UWSGI_GET_GIL;
+
+                // run python signal handlers if any scheduled
+                if (PyErr_CheckSignals()) {
+			uwsgi_log("exception in python signal handler\n");
+			PyErr_Print();
+			UWSGI_RELEASE_GIL;
+			exit(1);
+		}
+
+		UWSGI_RELEASE_GIL;
 	}
 }
 

--- a/plugins/python/uwsgi_python.h
+++ b/plugins/python/uwsgi_python.h
@@ -222,6 +222,8 @@ struct uwsgi_python {
 	char *worker_override;
 
 	int wsgi_manage_chunked_input;
+
+	int master_check_signals;
 };
 
 


### PR DESCRIPTION
Pull request for https://github.com/unbit/uwsgi/issues/1808
master_cycle callback added for python plugin. It calls PyErr_CheckSignals to check if any signal handlers scheduled. Exceptions in signal handlers are fatal.