### PR TITLE
Allow to use autoport (socket :0) with custom socket backlog

### DIFF
--- a/core/uwsgi.c
+++ b/core/uwsgi.c
@@ -176,7 +176,7 @@ static struct uwsgi_option uwsgi_base_options[] = {
 	{"connect-and-read", required_argument, 0, "connect to a socket and wait for data from it", uwsgi_opt_connect_and_read, NULL, UWSGI_OPT_IMMEDIATE},
 	{"extract", required_argument, 0, "fetch/dump any supported address to stdout", uwsgi_opt_extract, NULL, UWSGI_OPT_IMMEDIATE},
 
-	{"listen", required_argument, 'l', "set the socket listen queue size", uwsgi_opt_set_int, &uwsgi.listen_queue, 0},
+	{"listen", required_argument, 'l', "set the socket listen queue size", uwsgi_opt_set_int, &uwsgi.listen_queue, UWSGI_OPT_IMMEDIATE},
 	{"max-vars", required_argument, 'v', "set the amount of internal iovec/vars structures", uwsgi_opt_max_vars, NULL, 0},
 	{"max-apps", required_argument, 0, "set the maximum number of per-worker applications", uwsgi_opt_set_int, &uwsgi.max_apps, 0},
 	{"buffer-size", required_argument, 'b', "set internal buffer size", uwsgi_opt_set_64bit, &uwsgi.buffer_size, 0},


### PR DESCRIPTION
When uWSGI starts with configuration like this

    uwsgi:
        socket: 0.0.0.0:0
        listen: 1000

we see in startup log messages like this

    uwsgi socket 0 bound to TCP address 0.0.0.0:46490 (port auto-assigned) fd 3
    ...
    your server socket listen backlog is limited to 1024 connections

but when ours application stubs we see different backlog size

    *** uWSGI listen queue of socket "1.2.3.4:46490" (fd: 3) full !!! (101/100) ***

and real socket backlog size is 100.

This happens because uwsgi binds socket with auto port (uwsgi_new_socket() at socket.c:1044) BEFORE reading parameter `listen` and uses its default value 100.