### PR TITLE
plugins/python: use PyOS_AfterFork_Child if available

### DIFF
--- a/plugins/python/python_plugin.c
+++ b/plugins/python/python_plugin.c
@@ -394,7 +394,11 @@ void uwsgi_python_post_fork() {
 
 	// reset python signal flags so child processes can trap signals
 	if (up.call_osafterfork) {
+#ifdef HAS_NOT_PyOS_AfterFork_Child
 		PyOS_AfterFork();
+#else
+		PyOS_AfterFork_Child();
+#endif
 	}
 
 	uwsgi_python_reset_random_seed();
@@ -1958,7 +1962,11 @@ static int uwsgi_python_worker() {
 	UWSGI_GET_GIL;
 	// ensure signals can be used again from python
 	if (!up.call_osafterfork)
+#ifdef HAS_NOT_PyOS_AfterFork_Child
 		PyOS_AfterFork();
+#else
+		PyOS_AfterFork_Child();
+#endif
 	FILE *pyfile = fopen(up.worker_override, "r");
 	if (!pyfile) {
 		uwsgi_error_open(up.worker_override);

--- a/plugins/python/uwsgi_python.h
+++ b/plugins/python/uwsgi_python.h
@@ -30,6 +30,14 @@
 #define HAS_NO_ERRORS_IN_PyFile_FromFd
 #endif
 
+#if PY_MAJOR_VERSION == 3 && PY_MINOR_VERSION < 7
+#define HAS_NOT_PyOS_AfterFork_Child
+#endif
+
+#if PY_MAJOR_VERSION < 3
+#define HAS_NOT_PyOS_AfterFork_Child
+#endif
+
 #if PY_MAJOR_VERSION > 2
 #define PYTHREE
 #endif


### PR DESCRIPTION
As PyOS_AfterFork has been deprecated.

Backport of #1814