### PR TITLE
Fix segmentation fault with --py-autoreload in Python 3.7

### DIFF
--- a/plugins/python/python_plugin.c
+++ b/plugins/python/python_plugin.c
@@ -1531,6 +1531,7 @@ void *uwsgi_python_autoreloader_thread(void *interpreter) {
 			if (!PyObject_HasAttrString(mod, "__file__")) continue;
 			PyObject *mod_file = PyObject_GetAttrString(mod, "__file__");
 			if (!mod_file) continue;
+			if (mod_file == Py_None) continue;
 #ifdef PYTHREE
 			PyObject *zero = PyUnicode_AsUTF8String(mod_file);
 			char *mod_filename = PyString_AsString(zero);


### PR DESCRIPTION
In Python 3.7, `__file__` attribute returns None if it is namespace module.

https://docs.python.org/3/whatsnew/3.7.html#other-cpython-implementation-changes

> Fixed some consistency problems with namespace package module attributes. Namespace module objects now have an __file__ that is set to None (previously unset), and their __spec__.origin is also set to None (previously the string "namespace"). See bpo-32305. Also, the namespace module object’s __spec__.loader is set to the same value as __loader__ (previously, the former was set to None). See bpo-32303.

Reproduction code is here: https://gist.github.com/akiym/0e8bc77b59a325fc82430b5181d51c02

```
*** Starting uWSGI 2.0.17 (64bit) on [Sat Jul  7 12:42:17 2018] ***
compiled with version: 6.3.0 20170516 on 07 July 2018 12:17:45
os: Linux-4.9.93-linuxkit-aufs #1 SMP Wed Jun 6 16:55:56 UTC 2018
nodename: 5e37572f6076
machine: x86_64
clock source: unix
pcre jit disabled
detected number of CPU cores: 2
current working directory: /app
detected binary path: /usr/local/bin/uwsgi
uWSGI running as root, you can use --uid/--gid/--chroot options
*** WARNING: you are running uWSGI as root !!! (use the --uid flag) ***
your memory page size is 4096 bytes
detected max file descriptor number: 1048576
lock engine: pthread robust mutexes
thunder lock: disabled (you can enable it with --thunder-lock)
uWSGI http bound on :9090 fd 4
uwsgi socket 0 bound to TCP address 127.0.0.1:38065 (port auto-assigned) fd 3
uWSGI running as root, you can use --uid/--gid/--chroot options
*** WARNING: you are running uWSGI as root !!! (use the --uid flag) ***
Python version: 3.7.0 (default, Jul  4 2018, 02:21:01)  [GCC 6.3.0 20170516]
Python main interpreter initialized at 0x558edc0b1e20
uWSGI running as root, you can use --uid/--gid/--chroot options
*** WARNING: you are running uWSGI as root !!! (use the --uid flag) ***
python threads support enabled
your server socket listen backlog is limited to 100 connections
your mercy for graceful operations on workers is 60 seconds
mapped 145840 bytes (142 KB) for 1 cores
*** Operational MODE: single process ***
WSGI app 0 (mountpoint='') ready in 0 seconds on interpreter 0x558edc0b1e20 pid: 1 (default app)
uWSGI running as root, you can use --uid/--gid/--chroot options
*** WARNING: you are running uWSGI as root !!! (use the --uid flag) ***
*** uWSGI is running in multiple interpreter mode ***
spawned uWSGI master process (pid: 1)
spawned uWSGI worker 1 (pid: 6, cores: 1)
spawned uWSGI http 1 (pid: 7)
Python auto-reloader enabled
!!! uWSGI process 6 got Segmentation Fault !!!
*** backtrace of 6 ***
uwsgi(uwsgi_backtrace+0x35) [0x558eda7f6a45]
uwsgi(uwsgi_segfault+0x23) [0x558eda7f6df3]
/lib/x86_64-linux-gnu/libc.so.6(+0x33060) [0x7f93f7dc9060]
/usr/local/lib/libpython3.7m.so.1.0(PyBytes_AsString+0) [0x7f93f8400a40]
uwsgi(uwsgi_python_autoreloader_thread+0x166) [0x558eda80e1a6]
/lib/x86_64-linux-gnu/libpthread.so.0(+0x7494) [0x7f93f9f20494]
/lib/x86_64-linux-gnu/libc.so.6(clone+0x3f) [0x7f93f7e7eacf]
*** end of backtrace ***
DAMN ! worker 1 (pid: 6) died, killed by signal 11 :( trying respawn ...
Respawned uWSGI worker 1 (new pid: 9)
```