### PR TITLE
uwsgi compatibility with windows

### DIFF
--- a/uwsgiconfig.py
+++ b/uwsgiconfig.py
@@ -5,10 +5,11 @@ uwsgi_version = '2.1-dev'
 import os
 import re
 import time
-uwsgi_os = os.environ.get('UWSGI_FORCE_OS', os.uname()[0])
-uwsgi_os_k = re.split('[-+_]', os.uname()[2])[0]
-uwsgi_os_v = os.uname()[3]
-uwsgi_cpu = os.uname()[4]
+import platform
+uwsgi_os = os.environ.get('UWSGI_FORCE_OS', platform.uname()[0])
+uwsgi_os_k = re.split('[-+_]', platform.uname()[2])[0]
+uwsgi_os_v = platform.uname()[3]
+uwsgi_cpu = platform.uname()[4]
 
 import sys
 import subprocess


### PR DESCRIPTION
change the import os and os.uname function calls with import platform and platform.uname. This makes uwsgi compatible accross all platforms and can be used in windows without restrictions.