### PR TITLE
Make pypy WSGIfilewrapper a true iterable.

### DIFF
--- a/plugins/pypy/pypy_setup.py
+++ b/plugins/pypy/pypy_setup.py
@@ -382,6 +382,17 @@ class WSGIfilewrapper(object):
     def __iter__(self):
         return self
 
+    def __next__(self):
+        if self.chunksize:
+            data = self.f.read(self.chunksize)
+        else:
+            data = self.f.read()
+        if data:
+            return data
+        raise StopIteration()
+
+    next = __next__
+
     def sendfile(self):
         if hasattr(self.f, 'fileno'):
             lib.uwsgi_response_sendfile_do_can_close(self.wsgi_req, self.f.fileno(), 0, 0, 0)


### PR DESCRIPTION
According to [PEP 333](https://www.python.org/dev/peps/pep-0333/#optional-platform-specific-file-handling)

> The callable must return an iterable object

However, the `WSGIfilewrapper` as defined in `pypy_setup.py` is not an iterable because it does not have a `next` or `__next__` method.

Here is a sample application that when run with pypy reproduces the issue:

```python
def application(environ, start_response):
    status = '200 OK'
    response_headers = [('Content-type', 'text/plain')]
    start_response(status, response_headers)

    file_wrapper = environ.get('wsgi.file_wrapper')
    return file_wrapper(open('hello_world.txt'))

class ConsumingMiddleware(object):
    def __init__(self, application):
        self.application = application

    def __call__(self, environ, start_response):
        data = []
        for item in self.application(environ, start_response):
            data.append(item + '?')
        return data

application = ConsumingMiddleware(application)
```

When you run this, you'll see an error like the following:

```
From cffi callback <function uwsgi_pypy_wsgi_handler at 0x00007f144c981178>:        
Traceback (most recent call last):                                                  
  File "c callback", line 472, in uwsgi_pypy_wsgi_handler                           
  File "./app.py", line 16, in __call__                                             
    for item in self.application(environ, start_response):                          
TypeError: iter() returned non-iterator
```

The solution is to add `next` and `__next__` methods to the `WSGIfilewrapper` object.