### PR TITLE
plugins/python: fix spooler python references

### DIFF
--- a/plugins/python/uwsgi_pymodule.c
+++ b/plugins/python/uwsgi_pymodule.c
@@ -199,13 +199,11 @@ char *uwsgi_encode_pydict(PyObject * pydict, uint16_t * size) {
 
 		if (!PyTuple_Check(zero)) {
 			uwsgi_log("invalid python dictionary item\n");
-			Py_DECREF(zero);
 			continue;
 		}
 
 		if (PyTuple_Size(zero) < 2) {
 			uwsgi_log("invalid python dictionary item\n");
-			Py_DECREF(zero);
 			continue;
 		}
 		key = PyTuple_GetItem(zero, 0);
@@ -218,7 +216,6 @@ char *uwsgi_encode_pydict(PyObject * pydict, uint16_t * size) {
 		}
 
 		if (!PyString_Check(key) || !PyString_Check(val)) {
-			Py_DECREF(zero);
 			continue;
 		}
 
@@ -237,8 +234,6 @@ char *uwsgi_encode_pydict(PyObject * pydict, uint16_t * size) {
 			memcpy(bufptr, PyString_AsString(val), valsize);
 			bufptr += valsize;
 		}
-
-		Py_DECREF(zero);
 
 	}
 
@@ -1418,7 +1413,6 @@ PyObject *py_uwsgi_install_mule_msg_hook(PyObject *self, PyObject *args) {
 			return NULL;
 
 		if(PyDict_SetItemString(up.embedded_dict, "mule_msg_extra_hooks", msg_hook_list) == -1) {
-			Py_DECREF(msg_hook_list);
 			return NULL;
 		}
 	}
@@ -2204,7 +2198,6 @@ PyObject *py_uwsgi_send_spool(PyObject * self, PyObject * args, PyObject *kw) {
 					if (PyString_Check(val)) {
 						valsize = PyString_Size(val);
 						if (uwsgi_buffer_append_keyval(ub, PyString_AsString(key), keysize, PyString_AsString(val), valsize)) {
-							Py_DECREF(zero);
 							uwsgi_buffer_destroy(ub);
 							goto error;
 						}
@@ -2216,31 +2209,26 @@ PyObject *py_uwsgi_send_spool(PyObject * self, PyObject * args, PyObject *kw) {
 						PyObject *str = PyObject_Str(val);
 #endif
 						if (!str) {
-							Py_DECREF(zero);
 							uwsgi_buffer_destroy(ub);
 							goto error;
 						}
 						if (uwsgi_buffer_append_keyval(ub, PyString_AsString(key), keysize, PyString_AsString(str), PyString_Size(str))) {
-                                                        Py_DECREF(zero);
 							Py_DECREF(str);
-                                                        uwsgi_buffer_destroy(ub);
-                                                        goto error;
-                                                }
+							uwsgi_buffer_destroy(ub);
+							goto error;
+						}
 						Py_DECREF(str);
 					}
 				}
 				else {
-					Py_DECREF(zero);
 					uwsgi_buffer_destroy(ub);
                                         goto error;
 				}
 			}
 			else {
-				Py_DECREF(zero);
 				uwsgi_buffer_destroy(ub);
                                 goto error;
 			}
-			Py_DECREF(zero);
 		}
 		else {
 			uwsgi_buffer_destroy(ub);
@@ -2259,7 +2247,9 @@ PyObject *py_uwsgi_send_spool(PyObject * self, PyObject * args, PyObject *kw) {
 
 
 	if (pybody) {
-		Py_DECREF(pybody);
+		if (PyString_Check(pybody)) {
+			Py_DECREF(pybody);
+		}
 	}
 	
 	Py_DECREF(spool_vars);
@@ -2395,9 +2385,6 @@ PyObject *py_uwsgi_workers(PyObject * self, PyObject * args) {
 		}
 
 		apps_tuple = PyDict_GetItemString(worker_dict, "apps");
-		if (apps_tuple) {
-			Py_DECREF(apps_tuple);
-		}	
 
 		PyDict_Clear(worker_dict);
 


### PR DESCRIPTION
This code appears to often decref objects that have borrowed references. For example, the return value from PyList_GetItem should be a borrowed reference, as should PyDict_GetItemString, PyDict_GetItem.

It also decrefs an object that might not have had incref called in one scenario where the body is not a string.

When these reference counts get messed up, it seems to eventually lead to segfaults, although not necessarily directly when the function is called, but sometime later.