### PR TITLE
Disable logrotate when logging into UDP socket

### DIFF
--- a/core/logging.c
+++ b/core/logging.c
@@ -502,6 +502,10 @@ void uwsgi_check_logrotate(void) {
 		return;
 	}
 
+	if (logstat.st_mode & S_IFSOCK) {
+		return;
+	}
+
 	logsize = lseek(logfd, 0, SEEK_CUR);
 	if (logsize < 0) {
 		uwsgi_error("uwsgi_check_logrotate()/lseek()");


### PR DESCRIPTION
If host:port is specified in logto parameter instead of a file, the destination log receiver(fluentd -> elasticsearch in my case) is flooded with messages:
uwsgi_check_logrotate()/lseek(): Illegal seek [core/logging.c line 494] 

This commit disables log file related checks if log file descriptor is a socket.