### PR TITLE
pyuwsgi more like default.ini and offer no SSL

### DIFF
--- a/buildconf/pyuwsgi.ini
+++ b/buildconf/pyuwsgi.ini
@@ -1,9 +1,5 @@
 [uwsgi]
-main_plugin = pyuwsgi,python,stats_pusher_statsd
-xml = expat
-yaml = false
-json = false
-ssl = false
+main_plugin = pyuwsgi,python,gevent,stats_pusher_statsd
 inherit = base
 bin_name = pyuwsgi.so
 as_shared_library = true

--- a/buildconf/pyuwsginossl.ini
+++ b/buildconf/pyuwsginossl.ini
@@ -1,0 +1,3 @@
+[uwsgi]
+inherit = pyuwsgi
+ssl = false


### PR DESCRIPTION
@unbit let me know if there is a better way to do this

pyuwsgi will be the default for anyone building the wheel from an sdist
on PyPI, but we can build the wheels for distribution with
UWSGI_PROFILE=pyuwsginossl to avoid the security quagmire of bundling SSL.