### PR TITLE
Fix for respawn with fork-server and emperor

### DIFF
--- a/core/emperor.c
+++ b/core/emperor.c
@@ -2160,7 +2160,10 @@ void emperor_loop() {
 						// temporarily set frequency to a low value , so we can eventually fast-restart the instance
 						freq = ui_current->status;
 					}
-					emperor_curse(ui_current);
+					if (uwsgi.emperor_use_fork_server &&
+					    ui_current->last_mod - uwsgi_now() < 1) {
+						emperor_curse(ui_current);
+					}
 				}
 				else {
 					if (byte == 17) {


### PR DESCRIPTION
Fix for respawn with fork-server and emperor
A fix for emperor cursing vassels on respawn
The emperor will curse forked vassals when they
attempt a respawn, this will in turn cause the
vassal to get killed when it is finished
respawning. To prevent this emperor now checks
if it uses a fork-server and if the last_mod
on the vassal is less then 1 sec old.