### PR TITLE
Fix Unix socket inheritance after reload on FreeBSD

### DIFF
--- a/core/socket.c
+++ b/core/socket.c
@@ -1089,6 +1089,7 @@ void uwsgi_add_socket_from_fd(struct uwsgi_socket *uwsgi_sock, int fd) {
 	union uwsgi_sockaddr usa;
 	int abstract = 0;
 
+	memset(&usa, 0, sizeof(usa));
 	socket_type_len = sizeof(struct sockaddr_un);
 	gsa.sa = &usa.sa;
 	if (!getsockname(fd, gsa.sa, &socket_type_len)) {


### PR DESCRIPTION
On FreeBSD Unix socket path returned by getsockname() in
uwsgi_add_socket_from_fd() can contain garbage trailing character(s).

Clear a structure before passing it to getsockname() as a workaround.

Problem with reloading through SIGHUP on FreeBSD was also reported in #1471