### PR TITLE
Fix segmentation fault during worker shutdown. 

### DIFF
--- a/core/uwsgi.c
+++ b/core/uwsgi.c
@@ -2176,8 +2176,6 @@ void uwsgi_setup(int argc, char *argv[], char *envp[]) {
 	atexit(vacuum);
 	// call user scripts
 	atexit(uwsgi_exec_atexit);
-	// call plugin specific exit hooks
-	atexit(uwsgi_plugins_atexit);
 #ifdef UWSGI_SSL
 	// call legions death hooks
 	atexit(uwsgi_legion_atexit);
@@ -3238,6 +3236,11 @@ next:
 	if (!uwsgi.lazy && !uwsgi.lazy_apps) {
 		uwsgi_init_all_apps();
 	}
+
+	// Register uwsgi atexit plugin callbacks after all applications have
+	// been loaded. This ensures plugin atexit callbacks are called prior
+	// to application registered atexit callbacks.
+	atexit(uwsgi_plugins_atexit);
 
 	if (!uwsgi.master_as_root) {
 		uwsgi_log("dropping root privileges after application loading\n");


### PR DESCRIPTION
Hi! We at @newrelic have gotten a number of customer reports pertaining to issue #1651. As a result, we've worked on root causing the segfault described in that issue.

Example Overview
-------------------
In the example described [here](https://github.com/unbit/uwsgi/issues/1651#issuecomment-423664117), `httplib` is used to make an ssl connection to a server.  `httplib` relies on the [ssl library](https://github.com/python/cpython/blob/master/Modules/_ssl.c) and [openssl](https://github.com/openssl/openssl) to establish connections. When SSL is imported in cpython, openssl [sets up an atexit callback](https://github.com/openssl/openssl/blob/0b1319ba94c85af9e87308e0d573d1260a802f53/crypto/init.c#L104) which cleans up allocations such as locks by calling functions such as [OBJ_NAME_cleanup ](https://github.com/openssl/openssl/blob/OpenSSL_1_1_0-stable/crypto/objects/o_names.c#L385).

uwsgi also sets up atexit callbacks during [uwsgi_setup](https://github.com/unbit/uwsgi/blob/8b5647cb055cb68a63d9bb9ae3ae3ac0947a830a/core/uwsgi.c#L2180) to run Python "plugin" level callbacks on server teardown.

The uwsgi atexit callbacks are set up prior to the openssl callbacks (which are set on application load). atexit callbacks are called in reverse order of registration.

This resulted in the openssl cleanup being called prior to the Python-level atexit function, resulting in a segfault when the cleaned-up openssl library was being used to make an http request.

Root cause
------------

Some plugins (such as python) rely on plugin-level atexit callbacks running before interpreter teardown (when system-level atexit callbacks are invoked).

Prior to this change uWSGI was loading Python applications after registering uwsgi atexit functions.

The segfault could be triggered if loading a Python application containing a C extension that registers an atexit callback. Due to the atexit load order, those atexit callbacks are triggered prior to full termination of the Python program. As a result, Python operates on a C extension that is already in a cleaned-up state.

Fix Overview
-------------
The uwsgi plugin atexit callbacks are now registered after application load / import.