### PR TITLE
Fix crash when application cleanup handler reads request body.

### DIFF
--- a/core/reader.c
+++ b/core/reader.c
@@ -68,6 +68,11 @@ int uwsgi_simple_wait_read2_hook(int fd0, int fd1, int timeout, int *fd) {
 */
 
 void uwsgi_request_body_seek(struct wsgi_request *wsgi_req, off_t pos) {
+        if (wsgi_req->request_finished) {
+                uwsgi_req_error("uwsgi_request_body_seek(): attempt to read request body in cleanup handler, which is not supported");
+                return;
+        }
+
 	if (wsgi_req->post_file) {
 		if (pos < 0) {
 			if (fseek(wsgi_req->post_file, pos, SEEK_CUR)) {
@@ -218,6 +223,10 @@ wait:
 // TODO take hint into account
 // readline_buf is allocated when needed and freed at the end of the request
 char *uwsgi_request_body_readline(struct wsgi_request *wsgi_req, ssize_t hint, ssize_t *rlen) {
+        if (wsgi_req->request_finished) {
+                uwsgi_req_error("uwsgi_request_body_readline(): attempt to read request body in cleanup handler, which is not supported");
+                return uwsgi.empty;
+        }
 
 	// return 0 if no post_cl or pos >= post_cl and no residual data
         if ((!wsgi_req->post_cl || wsgi_req->post_pos >= wsgi_req->post_cl ) && !wsgi_req->post_readline_pos) {
@@ -291,6 +300,10 @@ char *uwsgi_request_body_readline(struct wsgi_request *wsgi_req, ssize_t hint, s
 }
 
 char *uwsgi_request_body_read(struct wsgi_request *wsgi_req, ssize_t hint, ssize_t *rlen) {
+        if (wsgi_req->request_finished) {
+                uwsgi_req_error("uwsgi_request_body_read(): attempt to read request body in cleanup handler, which is not supported");
+                return uwsgi.empty;
+        }
 
 	int ret = -1;
 	size_t remains = hint;

--- a/core/utils.c
+++ b/core/utils.c
@@ -1009,20 +1009,29 @@ static void close_and_free_request(struct wsgi_request *wsgi_req) {
                 wsgi_req->socket->proto_close(wsgi_req);
         }
 
+        /* mark request as finished so uwsgi_request_body_*()
+         * knows to not use the below pointers anymore
+         */
+        wsgi_req->request_finished = 1;
+
         if (wsgi_req->post_file) {
                 fclose(wsgi_req->post_file);
+                wsgi_req->post_file = NULL;
         }
 
         if (wsgi_req->post_read_buf) {
                 free(wsgi_req->post_read_buf);
+                wsgi_req->post_read_buf = NULL;
         }
 
         if (wsgi_req->post_readline_buf) {
                 free(wsgi_req->post_readline_buf);
+                wsgi_req->post_readline_buf = NULL;
         }
 
         if (wsgi_req->proto_parser_buf) {
                 free(wsgi_req->proto_parser_buf);
+                wsgi_req->proto_parser_buf = NULL;
         }
 
 }

--- a/uwsgi.h
+++ b/uwsgi.h
@@ -1534,6 +1534,13 @@ struct wsgi_request {
 	// when set, do not send warnings about bad behaviours
 	int post_warning;
 
+        /* post_file and the buffers will be free'd before the
+         * cleanup handlers. so we need to make sure we really
+         * stop using them even if the application attempts to
+         * read the body in the cleanup handler.
+         */
+        int request_finished;
+
 	// deprecated fields: size_t is 32bit on 32bit platform
 	size_t __range_from;
 	size_t __range_to;


### PR DESCRIPTION
If an application cleanup handler tries to access the request body, it
will access dangling freed memory and a dangling closed FILE descriptor.
This can cause a crash of the uWSGI server.

uWSGI calls cleanup handlers after close_and_free_request(), which
closes and frees the post_buffering FILE descriptor and buffers.
The pointer are not set to NULL, but this is not enough as
uwsgi_request_body_read() will still use one of the buffers.

This commit adds a flag to stop using the buffers after they've been
freed. The uwsgi_request_body_*() method will return empty content.

**Example**

PSGI Script:
```
use Data::Dumper;

my $app = sub {
    my $env = shift;

    my $content;
    $env->{'psgi.input'}->read($content, 4096, 0);
    print STDERR "body: ${content}\n";

    push @{$env->{'psgix.cleanup.handlers'}}, sub {
        # This "Dumper()" will malloc() new memory and will over-write the FILE* handle with garbage.
        # Even without over-writing, newer libc will trigger an abort
        print Dumper($env); 

        # This will crash
        $env->{'psgi.input'}->seek(0, 0);
        my $content;
        $env->{'psgi.input'}->read($content, 4096, 0);
        print STDERR "(cleanup) body: ${content}\n";
    };

    return [
        200,
        [ 'Content-Type' => 'text/html' ],
        [ '<h1>Hello, world!</h1>' ],
    ];
};
```

Starting uWSGI:
```
gdb --args uwsgi/uwsgi --plugins-dir ./uwsgi/ --plugin psgi --http :8080 --http-modifier1 5 --post-buffering 1 --psgi test.psgi
```

Doing the request:
```
curl -XPOST http://localhost:8080/ -d'test'
<h1>Hello, world!</h1>
```

Original result:
```
Program received signal SIGSEGV, Segmentation fault.
0x00007ffff6b5d385 in fseek () from /usr/lib64/libc.so.6
```

Patched result:
```
Mon Oct  8 17:34:17 2018 - uwsgi_request_body_seek(): attempt to read request body in cleanup handler, which is not supported: Success [core/reader.c line 72] during POST / (127.0.0.1)
Mon Oct  8 17:34:17 2018 - uwsgi_request_body_read(): attempt to read request body in cleanup handler, which is not supported: Success [core/reader.c line 304] during POST / (127.0.0.1)
```
