### PR TITLE
Drop support for EOL Python 2.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,6 @@ script:
   - UWSGICONFIG_PHPPATH=php-config7.2 /usr/bin/python uwsgiconfig.py --build travis
   - echo -e "\n\n>>> Building uWSGI binary"
   - make
-  - echo -e "\n\n>>> Building python26 plugin"
-  - /usr/bin/python2.6 -V
-  - /usr/bin/python2.6 uwsgiconfig.py --plugin plugins/python base python26
   - echo -e "\n\n>>> Building python27 plugin"
   - /usr/bin/python2.7 -V
   - /usr/bin/python2.7 uwsgiconfig.py --plugin plugins/python base python27
@@ -38,7 +35,7 @@ before_install:
   - sudo add-apt-repository ppa:deadsnakes/ppa -y
   - sudo add-apt-repository ppa:ondrej/php -y
   - sudo apt-get update -qq
-  - sudo apt-get install -qqyf python2.6-dev python3.4-dev python3.5-dev python3.6-dev
+  - sudo apt-get install -qqyf python3.4-dev python3.5-dev python3.6-dev
   - sudo apt-get install -qqyf libxml2-dev libpcre3-dev libcap2-dev
   - sudo apt-get install -qqyf php7.2-dev libphp7.2-embed libargon2-0-dev libsodium-dev
   - sudo apt-get install -qqyf liblua5.1-0-dev

--- a/contrib/runuwsgi.py
+++ b/contrib/runuwsgi.py
@@ -42,7 +42,7 @@ class Command(BaseCommand):
             os.environ['UWSGI_SOCKET'] = self.socket_addr
 
         # map admin static files
-        os.environ['UWSGI_STATIC_MAP'] = '%s=%s' % (settings.ADMIN_MEDIA_PREFIX, os.path.join(django.__path__[0], 'contrib', 'admin', 'media'))
+        os.environ['UWSGI_STATIC_MAP'] = '{}={}'.format(settings.ADMIN_MEDIA_PREFIX, os.path.join(django.__path__[0], 'contrib', 'admin', 'media'))
         # remove sockets/pidfile at exit
         os.environ['UWSGI_VACUUM'] = '1'
         # retrieve/set the PythonHome

--- a/examples/welcome.py
+++ b/examples/welcome.py
@@ -30,7 +30,7 @@ def hello_rpc(one, two, three):
     arg0 = one[::-1]
     arg1 = two[::-1]
     arg2 = three[::-1]
-    return "!%s-%s-%s!" % (arg1, arg2, arg0)
+    return "!{}-{}-{}!".format(arg1, arg2, arg0)
 
 
 @signal(17)
@@ -53,7 +53,7 @@ def serve_logo(e, sr):
 def serve_config(e, sr):
     sr('200 OK', [('Content-Type', 'text/html')])
     for opt in uwsgi.opt.keys():
-        yield "<b>%s</b> = %s<br/>" % (opt, uwsgi.opt[opt])
+        yield "<b>{}</b> = {}<br/>".format(opt, uwsgi.opt[opt])
 
 routes = {}
 routes['/xsendfile'] = xsendfile

--- a/plugins/jvm/uwsgiplugin.py
+++ b/plugins/jvm/uwsgiplugin.py
@@ -34,13 +34,13 @@ else:
     known_jvms = ('/usr/lib/jvm/java-7-openjdk', '/usr/local/openjdk7', '/usr/lib/jvm/java-6-openjdk', '/usr/local/openjdk', '/usr/java', '/usr/lib/jvm/java/', '/usr/lib/jvm/java-8-openjdk-%s' % arch)
     for jvm in known_jvms:
         if os.path.exists(jvm + '/include'):
-            JVM_INCPATH = ["-I%s/include/" % jvm, "-I%s/include/%s" % (jvm, operating_system)]
-            JVM_LIBPATH = ["-L%s/jre/lib/%s/server" % (jvm, arch)]
+            JVM_INCPATH = ["-I%s/include/" % jvm, "-I{}/include/{}".format(jvm, operating_system)]
+            JVM_LIBPATH = ["-L{}/jre/lib/{}/server".format(jvm, arch)]
             break
-        if os.path.exists("%s-%s/include" % (jvm, arch)):
-            jvm = "%s-%s" % (jvm, arch)
-            JVM_INCPATH = ["-I%s/include/" % jvm, "-I%s/include/%s" % (jvm, operating_system)]
-            JVM_LIBPATH = ["-L%s/jre/lib/%s/server" % (jvm, arch)]
+        if os.path.exists("{}-{}/include".format(jvm, arch)):
+            jvm = "{}-{}".format(jvm, arch)
+            JVM_INCPATH = ["-I%s/include/" % jvm, "-I{}/include/{}".format(jvm, operating_system)]
+            JVM_LIBPATH = ["-L{}/jre/lib/{}/server".format(jvm, arch)]
             break
 
 try:

--- a/plugins/python/uwsgi_python.h
+++ b/plugins/python/uwsgi_python.h
@@ -14,7 +14,6 @@
 #endif
 
 #if PY_MAJOR_VERSION < 3
-#define HAS_NOT_PyFrame_GetLineNumber
 #define HAS_NOT_PyOS_AfterFork_Child
 #endif
 

--- a/plugins/python/uwsgi_python.h
+++ b/plugins/python/uwsgi_python.h
@@ -9,43 +9,17 @@
 #define PYTHON_APP_TYPE_PUMP		3
 #define PYTHON_APP_TYPE_WSGI_LITE	4
 
-#if PY_MINOR_VERSION == 4 && PY_MAJOR_VERSION == 2
-#define Py_ssize_t ssize_t
-#define UWSGI_PYTHON_OLD
-#endif
-
-#if PY_MAJOR_VERSION == 2 && PY_MINOR_VERSION < 7
-#define HAS_NOT_PyMemoryView_FromBuffer
-#endif
-
-#if PY_MAJOR_VERSION == 2 && PY_MINOR_VERSION < 7
-#define HAS_NOT_PyFrame_GetLineNumber 
-#endif
-
-#if PY_MAJOR_VERSION == 3 && PY_MINOR_VERSION < 2
-#define HAS_NOT_PyFrame_GetLineNumber 
-#endif
-
-#if PY_MAJOR_VERSION == 3 && PY_MINOR_VERSION == 0
-#define HAS_NO_ERRORS_IN_PyFile_FromFd
-#endif
-
 #if PY_MAJOR_VERSION == 3 && PY_MINOR_VERSION < 7
 #define HAS_NOT_PyOS_AfterFork_Child
 #endif
 
 #if PY_MAJOR_VERSION < 3
+#define HAS_NOT_PyFrame_GetLineNumber
 #define HAS_NOT_PyOS_AfterFork_Child
 #endif
 
 #if PY_MAJOR_VERSION > 2
 #define PYTHREE
-#endif
-
-#if (PY_VERSION_HEX < 0x02060000)
-#ifndef Py_SIZE
-#define Py_SIZE(ob)             (((PyVarObject*)(ob))->ob_size)
-#endif
 #endif
 
 #define UWSGI_GET_GIL up.gil_get();

--- a/plugins/python/uwsgiplugin.py
+++ b/plugins/python/uwsgiplugin.py
@@ -44,27 +44,27 @@ if 'UWSGI_PYTHON_NOLIB' not in os.environ:
         # libdir does not exists, try to get it from the venv
         version = get_python_version()
         if not os.path.exists(libdir):
-            libdir = '%s/lib/python%s/config' % (sys.prefix, version)
+            libdir = '{}/lib/python{}/config'.format(sys.prefix, version)
         # try skipping abiflag
         if not os.path.exists(libdir) and version.endswith('m'):
             version = version[:-1]
-            libdir = '%s/lib/python%s/config' % (sys.prefix, version)
+            libdir = '{}/lib/python{}/config'.format(sys.prefix, version)
         # try 3.x style config dir
         if not os.path.exists(libdir):
-            libdir = '%s/lib/python%s/config-%s' % (sys.prefix, version, get_python_version())
+            libdir = '{}/lib/python{}/config-{}'.format(sys.prefix, version, get_python_version())
 
         # get cpu type
         uname = os.uname()
         if uname[4].startswith('arm'):
-            libpath = '%s/%s' % (libdir, sysconfig.get_config_var('LIBRARY'))
+            libpath = '{}/{}'.format(libdir, sysconfig.get_config_var('LIBRARY'))
             if not os.path.exists(libpath):
-                libpath = '%s/%s' % (libdir, sysconfig.get_config_var('LDLIBRARY'))
+                libpath = '{}/{}'.format(libdir, sysconfig.get_config_var('LDLIBRARY'))
         else:
-            libpath = '%s/%s' % (libdir, sysconfig.get_config_var('LDLIBRARY'))
+            libpath = '{}/{}'.format(libdir, sysconfig.get_config_var('LDLIBRARY'))
             if not os.path.exists(libpath):
-                libpath = '%s/%s' % (libdir, sysconfig.get_config_var('LIBRARY'))
+                libpath = '{}/{}'.format(libdir, sysconfig.get_config_var('LIBRARY'))
         if not os.path.exists(libpath):
-            libpath = '%s/libpython%s.a' % (libdir, version)
+            libpath = '{}/libpython{}.a'.format(libdir, version)
         LIBS.append(libpath)
         # hack for messy linkers/compilers
         if '-lutil' in LIBS:

--- a/plugins/rack/uwsgiplugin.py
+++ b/plugins/rack/uwsgiplugin.py
@@ -60,4 +60,4 @@ else:
         CFLAGS.append('-DUWSGI_RUBY_HEROKU')
     CFLAGS.append('-DUWSGI_RUBY_LIBDIR="\\"%s\\""' % rubylibdir)
     CFLAGS.append('-DUWSGI_RUBY_ARCHDIR="\\"%s\\""' % rubyarchdir)
-    GCC_LIST.append("%s/%s" % (libpath, os.popen(RUBYPATH + " -e \"require 'rbconfig';print %s::CONFIG['LIBRUBY_A']\"" % rbconfig).read().rstrip()))
+    GCC_LIST.append("{}/{}".format(libpath, os.popen(RUBYPATH + " -e \"require 'rbconfig';print %s::CONFIG['LIBRUBY_A']\"" % rbconfig).read().rstrip()))

--- a/setup.cpyext.py
+++ b/setup.cpyext.py
@@ -36,7 +36,7 @@ class uWSGIBuildExt(build_ext):
             os.unlink(self.uwsgi_config.get('bin_name'))
 
         # FIXME: else build fails :(
-        for baddie in set(self.compiler.compiler_so) & set(('-Wstrict-prototypes',)):
+        for baddie in set(self.compiler.compiler_so) & {'-Wstrict-prototypes'}:
             self.compiler.compiler_so.remove(baddie)
 
         build_ext.build_extensions(self)

--- a/setup.py
+++ b/setup.py
@@ -133,12 +133,12 @@ setup(
     license='GPLv2+',
     py_modules=['uwsgidecorators'],
     distclass=uWSGIDistribution,
+    python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*',
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'License :: OSI Approved :: GNU General Public License v2 or later (GPLv2+)',
         'Programming Language :: Python',
         'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.4',

--- a/tests/cpubound_async.py
+++ b/tests/cpubound_async.py
@@ -4,4 +4,4 @@ import time
 def application(env, start_response):
     start_response('200 OK', [('Content-Type', 'text/html')])
     for i in range(1, 1000):
-        yield "<h1>%s at %s</h1>" % (i, str(time.time()))
+        yield "<h1>{} at {}</h1>".format(i, str(time.time()))

--- a/tests/decoratortest.py
+++ b/tests/decoratortest.py
@@ -66,7 +66,7 @@ def an_infinite_task(args):
 # spool a task after 5 seconds
 @spool
 def delayed_task(args):
-    print("*** I am a delayed spool job. It is %s [%s]***" % (time.asctime(), str(args)))
+    print("*** I am a delayed spool job. It is {} [{}]***".format(time.asctime(), str(args)))
     # send a signal to all workers
     uwsgi.signal(100)
 

--- a/tests/queue.py
+++ b/tests/queue.py
@@ -26,7 +26,7 @@ def push_item():
 
 @app.route('/get', methods=['POST'])
 def get_item():
-    flash("slot %s value = %s" % (request.form['slot'], uwsgi.queue_get(int(request.form['slot']))))
+    flash("slot {} value = {}".format(request.form['slot'], uwsgi.queue_get(int(request.form['slot']))))
     return redirect('/')
 
 

--- a/tests/sendchunked.py
+++ b/tests/sendchunked.py
@@ -11,4 +11,4 @@ s.send("Transfer-Encoding: chunked\r\n\r\n")
 
 while True:
     msg = raw_input("msg >> ")
-    s.send("%X\r\n%s\r\n" % (len(msg), msg))
+    s.send("{:X}\r\n{}\r\n".format(len(msg), msg))

--- a/tests/websockets_chat_2.py
+++ b/tests/websockets_chat_2.py
@@ -22,7 +22,7 @@ class ClientManager(object):
 
     @classmethod
     def broadcast(cls, data):
-        data = "{0} {1}".format(time.time(), data)
+        data = "{} {}".format(time.time(), data)
         def do_broadcast():
             for c in cls.clients:
                 c.send(data)
@@ -57,7 +57,7 @@ class Client(object):
 
 
     def on_data(self, data):
-        print "GOT: {0}".format(data)
+        print "GOT: {}".format(data)
         ClientManager.broadcast(data)
 
 

--- a/tests/websockets_chat_async.py
+++ b/tests/websockets_chat_async.py
@@ -87,7 +87,7 @@ def application(env, sr):
                     if sys.version_info[0] > 2:
                         t = b'message'
                     if msg[0] == t:
-                        uwsgi.websocket_send("[%s] %s" % (time.time(), msg))
+                        uwsgi.websocket_send("[{}] {}".format(time.time(), msg))
             else:
                 # on timeout call websocket_recv_nb again to manage ping/pong
                 msg = uwsgi.websocket_recv_nb()

--- a/tests/websockets_chat_asyncio.py
+++ b/tests/websockets_chat_asyncio.py
@@ -133,7 +133,7 @@ def application(env, sr):
             # any redis message in the queue ?
             if f.done():
                 msg = f.result()
-                uwsgi.websocket_send("[%s] %s" % (time.time(), msg))
+                uwsgi.websocket_send("[{}] {}".format(time.time(), msg))
                 # restart coroutine
                 f = GreenFuture()
                 asyncio.Task(redis_wait(subscriber, f))

--- a/uwsgidecorators.py
+++ b/uwsgidecorators.py
@@ -34,11 +34,11 @@ def _decode1(val):
 
 
 def _encode_to_spooler(vars):
-    return dict((_encode1(K), _encode1(V)) for (K, V) in vars.items())
+    return {_encode1(K): _encode1(V) for (K, V) in vars.items()}
 
 
 def _decode_from_spooler(vars):
-    return dict((_decode1(K), _decode1(V)) for (K, V) in vars.items())
+    return {_decode1(K): _decode1(V) for (K, V) in vars.items()}
 
 
 def get_free_signal():
@@ -52,7 +52,7 @@ def get_free_signal():
 def manage_spool_request(vars):
     # To check whether 'args' is in vals or not - decode the keys first,
     # because in python3 all keys in 'vals' are have 'byte' types
-    vars = dict((_decode1(K), V) for (K, V) in vars.items())
+    vars = {_decode1(K): V for (K, V) in vars.items()}
     if 'args' in vars:
         for k in ('args', 'kwargs'):
             vars[k] = pickle.loads(vars.pop(k))


### PR DESCRIPTION
Python 2.6 is EOL and no longer receiving security updates (or any updates) from the core Python team.

Version | Release date | Supported until
--- | ---------- | ----------
2.6 | 2008-10-01 | 2013-10-29

Source: https://en.wikipedia.org/wiki/CPython#Version_history

They're also little used.

Here's download stats from PyPI for uwsgi for last month, and earlier:

| category | percent | downloads |
|----------|--------:|----------:|
|      2.7 |  47.71% |   351,883 |
|      3.6 |  28.87% |   212,951 |
|      3.5 |  10.31% |    76,023 |
|      3.4 |   8.69% |    64,095 |
|      3.7 |   4.03% |    29,746 |
| null     |   0.29% |     2,108 |
|      3.3 |   0.06% |       459 |
|      2.6 |   0.04% |       287 |
|      3.8 |   0.00% |        29 |
|      3.2 |   0.00% |         2 |
| Total    |         |   737,583 |

![image](https://user-images.githubusercontent.com/1324225/46909890-d13c9600-cf42-11e8-9377-9153eab2f38b.png)

https://pypistats.org/packages/uwsgi