### PR TITLE
ssl-option can't be set

### DIFF
--- a/core/uwsgi.c
+++ b/core/uwsgi.c
@@ -718,7 +718,7 @@ static struct uwsgi_option uwsgi_base_options[] = {
 	{"ssl-enable3", no_argument, 0, "enable SSLv3 (insecure)", uwsgi_opt_true, &uwsgi.sslv3, 0},
 	{"ssl-enable-sslv3", no_argument, 0, "enable SSLv3 (insecure)", uwsgi_opt_true, &uwsgi.sslv3, 0},
 	{"ssl-enable-tlsv1", no_argument, 0, "enable TLSv1 (insecure)", uwsgi_opt_true, &uwsgi.tlsv1, 0},
-	{"ssl-option", no_argument, 0, "set a raw ssl option (numeric value)", uwsgi_opt_add_string_list, &uwsgi.ssl_options, 0},
+	{"ssl-option", required_argument, 0, "set a raw ssl option (numeric value)", uwsgi_opt_add_string_list, &uwsgi.ssl_options, 0},
 #ifdef UWSGI_PCRE
 	{"sni-regexp", required_argument, 0, "add an SNI-governed SSL context (the key is a regexp)", uwsgi_opt_sni, NULL, 0},
 #endif


### PR DESCRIPTION
The ssl-option variable can't be set: it is designed to take a numeric argument but is specified as a "no_argument" option which results in an error when trying to set this option. This changeset sets the proper type.

Given the changeset which introduced this option with the ssl-enable3 option which is of type no_argument, I suspect someone copy/pasted the ssl-enable3 configuration file without testing the change.