### PR TITLE
systemd_logger: Don't generate build warnings when all is OK

### DIFF
--- a/plugins/systemd_logger/uwsgiplugin.py
+++ b/plugins/systemd_logger/uwsgiplugin.py
@@ -2,9 +2,13 @@ import os
 
 NAME = 'systemd_logger'
 
-CFLAGS = os.popen('pkg-config --cflags libsystemd-journal').read().rstrip().split()
-CFLAGS += os.popen('pkg-config --cflags libsystemd').read().rstrip().split()
+if os.popen('pkg-config --exists libsystemd-journal').close() is None:
+	CFLAGS = os.popen('pkg-config --cflags libsystemd-journal').read().rstrip().split()
+	LIBS = os.popen('pkg-config --libs libsystemd-journal').read().rstrip().split()
+else:
+	CFLAGS = os.popen('pkg-config --cflags libsystemd').read().rstrip().split()
+	LIBS = os.popen('pkg-config --libs libsystemd').read().rstrip().split()
+
 LDFLAGS = []
-LIBS = os.popen('pkg-config --libs libsystemd-journal').read().rstrip().split()
-LIBS += os.popen('pkg-config --libs libsystemd').read().rstrip().split()
+
 GCC_LIST = ['systemd_logger']


### PR DESCRIPTION
libsystemd-journal is only found with old versions of systemd - check it
is installed before querying.

---

These messages are found in the build.log with a current systemd version:

```
Package libsystemd-journal was not found in the pkg-config search path.
Perhaps you should add the directory containing `libsystemd-journal.pc'
to the PKG_CONFIG_PATH environment variable
No package 'libsystemd-journal' found
Package libsystemd-journal was not found in the pkg-config search path.
Perhaps you should add the directory containing `libsystemd-journal.pc'
to the PKG_CONFIG_PATH environment variable
No package 'libsystemd-journal' found
```
This change prevents them and stops the user having to think whether they matter.
