### PR TITLE
Fix #1978: Support Python 3.7's new pre- and post-fork handlers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,9 @@ script:
   - echo -e "\n\n>>> Building python36 plugin"
   - /usr/bin/python3.6 -V
   - /usr/bin/python3.6 uwsgiconfig.py --plugin plugins/python base python36
+  - echo -e "\n\n>>> Building python37 plugin"
+  - /usr/bin/python3.7 -V
+  - /usr/bin/python3.7 uwsgiconfig.py --plugin plugins/python base python37
   - echo -e "\n\n>>> Building rack plugin"
   - rvm use 2.4
   - ruby -v
@@ -38,7 +41,7 @@ before_install:
   - sudo add-apt-repository ppa:deadsnakes/ppa -y
   - sudo add-apt-repository ppa:ondrej/php -y
   - sudo apt-get update -qq
-  - sudo apt-get install -qqyf python2.6-dev python3.4-dev python3.5-dev python3.6-dev
+  - sudo apt-get install -qqyf python2.6-dev python3.4-dev python3.5-dev python3.6-dev python3.7-dev
   - sudo apt-get install -qqyf libxml2-dev libpcre3-dev libcap2-dev
   - sudo apt-get install -qqyf php7.2-dev libphp7.2-embed libargon2-0-dev libsodium-dev
   - sudo apt-get install -qqyf liblua5.1-0-dev

--- a/core/master.c
+++ b/core/master.c
@@ -639,6 +639,12 @@ int master_loop(char **argv, char **environ) {
 
 	}
 
+	for (i = 0; i < 256; i++) {
+		if (uwsgi.p[i]->master_start) {
+			uwsgi.p[i]->master_start();
+		}
+	}
+
 	// here really starts the master loop
 	uwsgi_hooks_run(uwsgi.hook_master_start, "master-start", 1);
 

--- a/plugins/python/python_plugin.c
+++ b/plugins/python/python_plugin.c
@@ -9,6 +9,7 @@
 */
 
 extern struct uwsgi_server uwsgi;
+extern pid_t masterpid;
 struct uwsgi_python up;
 
 #include <glob.h>
@@ -194,7 +195,7 @@ struct uwsgi_option uwsgi_python_options[] = {
 	{"py-sharedarea", required_argument, 0, "create a sharedarea from a python bytearray object of the specified size", uwsgi_opt_add_string_list, &up.sharedarea, 0},
 #endif
 
-	{"py-call-osafterfork", no_argument, 0, "enable child processes running cpython to trap OS signals", uwsgi_opt_true, &up.call_osafterfork, 0},
+	{"py-call-osafterfork", no_argument, 0, "enable child processes running cpython to trap OS signals (ignored in Python 3.7+, because PyOS_BeforeFork and PyOS_AfterFork_* are always called)", uwsgi_opt_true, &up.call_osafterfork, 0},
 
 	{"early-python", no_argument, 0, "load the python VM as soon as possible (useful for the fork server)", uwsgi_early_python, NULL, UWSGI_OPT_IMMEDIATE},
 	{"early-pyimport", required_argument, 0, "import a python module in the early phase", uwsgi_early_python_import, NULL, UWSGI_OPT_IMMEDIATE},
@@ -426,20 +427,46 @@ realstuff:
 	Py_Finalize();
 }
 
+void uwsgi_python_master_start() {
+#ifdef REQUIRES_PyOS_BeforeAndAfterFork_ParentAndChild
+	if (getpid() == masterpid) {
+		UWSGI_GET_GIL;
+#ifdef UWSGI_DEBUG
+		uwsgi_log("Running Python after-fork parent hook (pid: %d)\n", uwsgi.mypid);
+#endif
+		PyOS_AfterFork_Parent();
+		UWSGI_RELEASE_GIL;
+	} else {
+		uwsgi_log("*** WARNING: master_start called for worker process (pid: %d)! ***\n", uwsgi.mypid);
+	}
+#endif
+}
+
 void uwsgi_python_post_fork() {
 
 	if (uwsgi.i_am_a_spooler) {
 		UWSGI_GET_GIL
-	}	
+	}
 
+#ifdef REQUIRES_PyOS_BeforeAndAfterFork_ParentAndChild
+	if (getpid() == masterpid) {
+		uwsgi_log("*** WARNING: post_fork called for masterpid (pid: %d)! ***\n", uwsgi.mypid);
+	} else {
+#ifdef UWSGI_DEBUG
+		uwsgi_log("Running Python after-fork child hook (pid: %d)\n", uwsgi.mypid);
+#endif
+		PyOS_AfterFork_Child();
+	}
+#else
 	// reset python signal flags so child processes can trap signals
 	if (up.call_osafterfork) {
 #ifdef HAS_NOT_PyOS_AfterFork_Child
 		PyOS_AfterFork();
 #else
-                PyOS_AfterFork_Child();
+		PyOS_AfterFork_Child();
 #endif
 	}
+#endif
 
 	uwsgi_python_reset_random_seed();
 
@@ -1303,6 +1330,15 @@ void uwsgi_python_master_fixup(int step) {
 	static int master_fixed = 0;
 	static int worker_fixed = 0;
 
+#ifdef REQUIRES_PyOS_BeforeAndAfterFork_ParentAndChild
+	if (getpid() == masterpid) {
+#ifdef UWSGI_DEBUG
+		uwsgi_log("Running Python before-fork hook (pid: %d)\n", uwsgi.mypid);
+#endif
+		PyOS_BeforeFork();
+	}
+#endif
+
 	if (!uwsgi.master_process) return;
 
 	if (uwsgi.has_threads) {
@@ -2042,13 +2078,18 @@ static int uwsgi_python_worker() {
 	if (!up.worker_override)
 		return 0;
 	UWSGI_GET_GIL;
+
+#ifndef REQUIRES_PyOS_BeforeAndAfterFork_ParentAndChild
 	// ensure signals can be used again from python
-	if (!up.call_osafterfork)
+	if (!up.call_osafterfork) {
 #ifdef HAS_NOT_PyOS_AfterFork_Child
 		PyOS_AfterFork();
 #else
-                PyOS_AfterFork_Child();
+		PyOS_AfterFork_Child();
 #endif
+	}
+#endif
+
 	FILE *pyfile = fopen(up.worker_override, "r");
 	if (!pyfile) {
 		uwsgi_error_open(up.worker_override);
@@ -2129,4 +2170,5 @@ struct uwsgi_plugin python_plugin = {
 
 	.worker = uwsgi_python_worker,
 
+	.master_start = uwsgi_python_master_start,
 };

--- a/plugins/python/uwsgi_python.h
+++ b/plugins/python/uwsgi_python.h
@@ -34,8 +34,16 @@
 #define HAS_NOT_PyOS_AfterFork_Child
 #endif
 
+#if PY_MAJOR_VERSION == 3 && PY_MINOR_VERSION >= 7
+#define REQUIRES_PyOS_BeforeAndAfterFork_ParentAndChild
+#endif
+
 #if PY_MAJOR_VERSION < 3
 #define HAS_NOT_PyOS_AfterFork_Child
+#endif
+
+#if PY_MAJOR_VERSION >= 4
+#define REQUIRES_PyOS_BeforeAndAfterFork_ParentAndChild
 #endif
 
 #if PY_MAJOR_VERSION > 2

--- a/uwsgi.h
+++ b/uwsgi.h
@@ -1093,6 +1093,8 @@ struct uwsgi_plugin {
 	int (*worker)(void);
 
 	void (*early_post_jail) (void);
+
+	void (*master_start) (void);
 };
 
 #ifdef UWSGI_PCRE


### PR DESCRIPTION
This change addresses #1978 by ensuring that, in Python 3.7 and newer versions, the following always happens:

- `PyOS_BeforeFork()` is called before the parent process calls `fork()`
- `PyOS_AfterFork_Parent()` is called in the master process after the parent process calls `fork()`
- `PyOS_AfterFork_Child()` is called in all worker processes after the parent process calls `fork()`

This new behavior ignores the value of the `py-call-osafterfork` setting (only in Python 3.7 and newer), because not calling the before- and after-fork hooks is invalid behavior for CPython extensions in Python 3.7 and newer.

I tested this by compiling, installing, and using in our new Python 3.7 systems:

```
mkdir /usr/lib/uwsgi
mkdir /usr/lib/uwsgi/plugins
cd /usr/local/src
git clone https://github.com/nickwilliams-eventbrite/uwsgi.git
cd uwsgi
git checkout fix-py37-errors
python uwsgiconfig.py --build core
python uwsgiconfig.py --plugin plugins/rsyslog core rsyslog
python uwsgiconfig.py --plugin plugins/python core python3
UWSGI_PLUGINS_BUILDER_CFLAGS= python uwsgiconfig.py --extra-plugin https://github.com/Datadog/uwsgi-dogstatsd dogstatsd
cp -v ./uwsgi /usr/bin/uwsgi-core
cp -v ./dogstatsd_plugin.so ./python3_plugin.so ./rsyslog_plugin.so /usr/lib/uwsgi/plugins/
```

This also adds a Python 3.7 build to the Travis build (I won't know if that works until posting this PR).