### PR TITLE
core/uwsgi: Fix compilation with uClibc-ng

### DIFF
--- a/core/uwsgi.c
+++ b/core/uwsgi.c
@@ -1889,7 +1889,7 @@ void uwsgi_plugins_atexit(void) {
 
 void uwsgi_backtrace(int depth) {
 
-#if defined(__GLIBC__) || (defined(__APPLE__) && !defined(NO_EXECINFO)) || defined(UWSGI_HAS_EXECINFO)
+#if (!defined(__UCLIBC__) && defined(__GLIBC__)) || (defined(__APPLE__) && !defined(NO_EXECINFO)) || defined(UWSGI_HAS_EXECINFO)
 
 #include <execinfo.h>
 


### PR DESCRIPTION
uClibc-ng by default does not compile in execinfo support.