### PR TITLE
Remove HTTPS_CLIENT_CERTIFICATE in favor of HTTPS_CC

### DIFF
--- a/plugins/http/https.c
+++ b/plugins/http/https.c
@@ -179,14 +179,6 @@ int hr_https_add_vars(struct http_session *hr, struct corerouter_peer *peer, str
 #endif
                 hr->ssl_client_cert = SSL_get_peer_certificate(hr->ssl);
                 if (hr->ssl_client_cert) {
-                        int client_cert_len;
-                        unsigned char *client_cert_der = NULL;
-                        client_cert_len = i2d_X509(hr->ssl_client_cert, &client_cert_der);
-                        if (client_cert_len < 0) return -1;
-			int ret = uwsgi_buffer_append_keyval(out, "HTTPS_CLIENT_CERTIFICATE", 24, (char*)client_cert_der, client_cert_len);
-			OPENSSL_free(client_cert_der);
-			if (ret) return -1;
-
                         X509_NAME *name = X509_get_subject_name(hr->ssl_client_cert);
                         if (name) {
                                 hr->ssl_client_dn = X509_NAME_oneline(name, NULL, 0);


### PR DESCRIPTION
HTTPS_CLIENT_CERTIFICATE contains the DER encoded Client Certificate.

f065171aa14120c66e1ebb6076ab6d53dd070dc1 adds in HTTPS_CC, which is
a PEM encoded Client Certificate. For Python 3, the HTTPS_CLIENT_CERTIFICATE
field was read as a `string`, not `bytes`, which leads to the runtime
(rightfully!) complaining.

Since PEM encoding the field is a better idea, I'm removing this code in
favor of just using --https-export-cert. This was only usable in Python
2, so this is of diminishing utility as time goes on.