### PR TITLE
fix travis - build on xenial rather than trusty

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+dist: xenial
+
 language: c
 
 compiler:
@@ -35,6 +37,8 @@ script:
   - ./tests/travis.sh
 
 before_install:
+  - sudo apt-get update -qq
+  - sudo apt-get install -qqyf software-properties-common
   - sudo add-apt-repository ppa:deadsnakes/ppa -y
   - sudo add-apt-repository ppa:ondrej/php -y
   - sudo apt-get update -qq
@@ -49,6 +53,6 @@ before_install:
   - sudo apt-get install -qqyf libwrap0-dev libgeoip-dev libv8-dev libxslt1-dev
   - sudo apt-get install -qqyf libboost-thread-dev libboost-filesystem-dev
   - sudo apt-get install -qqyf libssl-dev libacl1-dev python-greenlet-dev
-  - sudo apt-get install -qqyf openjdk-7-jdk libgloox-dev gccgo
+  - sudo apt-get install -qqyf openjdk-8-jdk libgloox-dev gccgo
   - sudo apt-get install -qqyf cli-common-dev mono-devel mono-mcs uuid-dev
   - sudo apt-get install -qqyf curl


### PR DESCRIPTION
- trusty is EOL and the default is going to change to xenial anyways. See: https://blog.travis-ci.com/2019-04-15-xenial-default-build-environment

- PPA "ppa:ondrej/php" does not support EOL Ubuntu (trusty) and PHP packages are not found anymore.

  See: https://launchpad.net/~ondrej/+archive/ubuntu/php

- update to jdk-8 instead of using outdated PPA "ppa:openjdk-r/ppa"

  Last release was in 2016, See: https://launchpad.net/~openjdk-r/+archive/ubuntu/ppa?field.series_filter=xenial