### PR TITLE
Add max-worker-lifetime-delta that works like `max-requests-delta`

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -37,3 +37,4 @@ Vladimir Didenko
 Alexandre Bonnetain
 Darvame Hleran
 Sokolov Yura <funny.falcon@gmail.com>
+Marcin Lulek <info@webreactor.eu>

--- a/core/master_checks.c
+++ b/core/master_checks.c
@@ -224,7 +224,7 @@ int uwsgi_master_check_workers_deadline() {
 		// check if worker was running longer than allowed lifetime
 		if (uwsgi.workers[i].pid > 0 && uwsgi.workers[i].cheaped == 0 && uwsgi.max_worker_lifetime > 0) {
 			uint64_t lifetime = uwsgi_now() - uwsgi.workers[i].last_spawn;
-			if (lifetime > uwsgi.max_worker_lifetime && uwsgi.workers[i].manage_next_request == 1) {
+			if (lifetime > (uwsgi.max_worker_lifetime + (i-1) * uwsgi.max_worker_lifetime_delta)  && uwsgi.workers[i].manage_next_request == 1) {
 				uwsgi_log("worker %d lifetime reached, it was running for %llu second(s)\n", i, (unsigned long long) lifetime);
 				uwsgi.workers[i].manage_next_request = 0;
 				kill(uwsgi.workers[i].pid, SIGWINCH);

--- a/core/uwsgi.c
+++ b/core/uwsgi.c
@@ -299,6 +299,7 @@ static struct uwsgi_option uwsgi_base_options[] = {
 	{"max-requests-delta", required_argument, 0, "add (worker_id * delta) to the max_requests value of each worker", uwsgi_opt_set_64bit, &uwsgi.max_requests_delta, 0},
 	{"min-worker-lifetime", required_argument, 0, "number of seconds worker must run before being reloaded (default is 60)", uwsgi_opt_set_64bit, &uwsgi.min_worker_lifetime, 0},
 	{"max-worker-lifetime", required_argument, 0, "reload workers after the specified amount of seconds (default is disabled)", uwsgi_opt_set_64bit, &uwsgi.max_worker_lifetime, 0},
+	{"max-worker-lifetime-delta", required_argument, 0, "add (worker_id * delta) seconds to the max_worker_lifetime value of each worker", uwsgi_opt_set_int, &uwsgi.max_worker_lifetime_delta, 0},
 
 	{"socket-timeout", required_argument, 'z', "set internal sockets timeout", uwsgi_opt_set_int, &uwsgi.socket_timeout, 0},
 	{"no-fd-passing", no_argument, 0, "disable file descriptor passing", uwsgi_opt_true, &uwsgi.no_fd_passing, 0},

--- a/uwsgi.h
+++ b/uwsgi.h
@@ -1799,6 +1799,7 @@ struct uwsgi_server {
 	uint64_t max_requests;
 	uint64_t min_worker_lifetime;
 	uint64_t max_worker_lifetime;
+	uint64_t max_worker_lifetime_delta;
 
 	// daemontools-like envdir
 	struct uwsgi_string_list *envdirs;


### PR DESCRIPTION
Fixes #2020, Please note I'm not a C dev so I might have got some things wrong, however in my tests things worked as expected.

`uwsgi --http :9090 --wsgi-file app.py -p 3 --min-worker-lifetime=1 --max-worker-lifetime=10 --lazy-apps --master-fifo /tmp/uwsgimasterfifo --max-worker-lifetime-delta=2`