### PR TITLE
add mules add stats / add memory info to mules

### DIFF
--- a/core/init.c
+++ b/core/init.c
@@ -517,7 +517,7 @@ void sanitize_args() {
 		exit(1);
 	}
 
-	if (uwsgi.evil_reload_on_rss || uwsgi.evil_reload_on_as) {
+	if (uwsgi.logging_options.memory_report || uwsgi.evil_reload_on_rss || uwsgi.evil_reload_on_as) {
 		if (!uwsgi.mem_collector_freq) uwsgi.mem_collector_freq = 3;
 	}
 

--- a/core/master_utils.c
+++ b/core/master_utils.c
@@ -1327,6 +1327,57 @@ nocores:
 	if (uwsgi_stats_list_close(us))
 		goto end;
 
+	if (uwsgi.mules_cnt > 0) {
+		if (uwsgi_stats_comma(us))
+			goto end;
+
+		if (uwsgi_stats_key(us, "mules"))
+			goto end;
+
+		if (uwsgi_stats_list_open(us))
+			goto end;
+
+		for (i = 0; i < uwsgi.mules_cnt; i++) {
+			struct uwsgi_mule *mule = &uwsgi.mules[i];
+			if (uwsgi_stats_object_open(us))
+				goto end;
+
+			if (uwsgi_stats_keylong_comma(us, "id", (unsigned long long) mule->id))
+				goto end;
+
+			if (uwsgi_stats_keylong_comma(us, "pid", (unsigned long long) mule->pid))
+				goto end;
+
+			if (uwsgi_stats_keylong_comma(us, "signals", (unsigned long long) mule->signals))
+				goto end;
+
+			if (uwsgi_stats_keyval_comma(us, "mode", mule->patch ? "programmed" : "signal"))
+				goto end;
+
+			if (mule->patch) {
+				if (uwsgi_stats_keyval_comma(us, "patch", mule->patch))
+					goto end;
+			}
+
+			if (uwsgi_stats_keylong_comma(us, "rss", (unsigned long long) mule->rss_size))
+				goto end;
+
+			if (uwsgi_stats_keylong(us, "vsz", (unsigned long long) mule->vsz_size))
+				goto end;
+
+			if (uwsgi_stats_object_close(us))
+				goto end;
+
+			if (i < uwsgi.mules_cnt - 1) {
+				if (uwsgi_stats_comma(us))
+					goto end;
+			}
+		}
+
+		if (uwsgi_stats_list_close(us))
+			goto end;
+	}
+
 	struct uwsgi_spooler *uspool = uwsgi.spoolers;
 	if (uspool) {
 		if (uwsgi_stats_comma(us))

--- a/core/mule.c
+++ b/core/mule.c
@@ -32,6 +32,24 @@ int mule_send_msg(int fd, char *message, size_t len) {
 	return 0;
 }
 
+// Runs in a mule thread and periodically scans for memory usage.
+static void *mule_mem_collector(void *foobar) {
+	// block all signals
+        sigset_t smask;
+        sigfillset(&smask);
+        pthread_sigmask(SIG_BLOCK, &smask, NULL);
+	int id = uwsgi.muleid;
+	uwsgi_log_verbose("mem-collector thread started for mule %d\n", id);
+	for(;;) {
+		sleep(uwsgi.mem_collector_freq);
+		uint64_t rss = 0, vsz = 0;
+		get_memusage(&rss, &vsz);
+		uwsgi.mules[id - 1].rss_size = rss;
+		uwsgi.mules[id - 1].vsz_size = vsz;
+	}
+	return NULL;
+}
+
 void uwsgi_mule(int id) {
 
 	int i;
@@ -82,8 +100,13 @@ void uwsgi_mule(int id) {
 		}
 
 		uwsgi_hooks_run(uwsgi.hook_as_mule, "as-mule", 1);
-		uwsgi_mule_run();
 
+		if (uwsgi.logging_options.memory_report || uwsgi.force_get_memusage) {
+			pthread_t t;
+			pthread_create(&t, NULL, mule_mem_collector, NULL);
+		}
+
+		uwsgi_mule_run();
 	}
 	else if (pid > 0) {
 		uwsgi.mules[id - 1].id = id;

--- a/plugins/python/uwsgi_pymodule.c
+++ b/plugins/python/uwsgi_pymodule.c
@@ -1444,9 +1444,7 @@ PyObject *py_uwsgi_mule_msg(PyObject * self, PyObject * args) {
 		return PyErr_Format(PyExc_ValueError, "no mule configured");
 
 	if (mule_obj == NULL) {
-		UWSGI_RELEASE_GIL
-		resp = mule_send_msg(uwsgi.shared->mule_queue_pipe[0], message, message_len);
-		UWSGI_GET_GIL
+		fd = uwsgi.shared->mule_queue_pipe[0];
 	}
 	else {
 		if (PyString_Check(mule_obj)) {
@@ -1471,12 +1469,12 @@ PyObject *py_uwsgi_mule_msg(PyObject * self, PyObject * args) {
 		else {
 			return PyErr_Format(PyExc_ValueError, "invalid mule");
 		}
+	}
 
-		if (fd > -1) {
-			UWSGI_RELEASE_GIL
-			resp = mule_send_msg(fd, message, message_len);
-			UWSGI_GET_GIL
-		}
+	if (fd > -1) {
+		UWSGI_RELEASE_GIL
+		resp = mule_send_msg(fd, message, message_len);
+		UWSGI_GET_GIL
 	}
 
 	if(!resp) {

--- a/uwsgi.h
+++ b/uwsgi.h
@@ -3164,6 +3164,9 @@ struct uwsgi_mule {
 
 	time_t cursed_at;
 	time_t no_mercy_at;
+
+	uint64_t vsz_size;
+	uint64_t rss_size;
 };
 
 struct uwsgi_mule_farm {


### PR DESCRIPTION
Hello,

we're interested in having some basic mule stats fro the stats server output.
This PR adds this information. When the `--memory-report` option is set, a thread is started in each mule process collecting memory information every `mem-collector-freq` seconds. If `--memory-report` is not provided, the `rss` and `vsz` fields will be `0` in the stats output.

Following an example of the additional entries in the stats server output:
```
...
        ],
        "mules":[
                {
                        "id":1,
                        "pid":28214,
                        "signals":0,
                        "mode":"programmed",
                        "patch":"hello:mule",
                        "rss":14692352,
                        "vsz":142168064
                },
                {
                        "id":2,
                        "pid":28215,
                        "signals":0,
                        "mode":"programmed",
                        "patch":"./moo.py",
                        "rss":15179776,
                        "vsz":142172160
                },
                {
                        "id":3,
                        "pid":28216,
                        "signals":165,
                        "mode":"signal",
                        "rss":14798848,
                        "vsz":142168064
                }
        ]
}
```

Let me know if this is something you'd consider useful enough to be merged. I'd be also happy to hear about different ways to collect the memory usage, or whether a different approach should be used. Thanks!

There's a minor cleanup commit for the uwsgi python module related to message sending.