### PR TITLE
uwsgi_opt_set_int: use strtol() and warn on non-numeric data

### DIFF
--- a/check/check_core.c
+++ b/check/check_core.c
@@ -46,6 +46,10 @@ START_TEST(test_uwsgi_opt_set_int)
 
 	uwsgi_opt_set_int("", "60", &result);
 	ck_assert(result == 60);
+
+	// When used with "optional_argument", value will be passed as NULL
+	uwsgi_opt_set_int("", NULL, &result);
+	ck_assert(result == 1);
 }
 END_TEST
 

--- a/core/uwsgi.c
+++ b/core/uwsgi.c
@@ -4138,7 +4138,11 @@ void uwsgi_opt_safe_fd(char *opt, char *value, void *foobar) {
 void uwsgi_opt_set_int(char *opt, char *value, void *key) {
 	int *ptr = (int *) key;
 	if (value) {
-		*ptr = atoi((char *) value);
+		char *endptr;
+		*ptr = (int)strtol(value, &endptr, 10);
+		if (*endptr) {
+			uwsgi_log("[WARNING] non-numeric value \"%s\" for option \"%s\" - using %d !\n", value, opt, *ptr);
+		}
 	}
 	else {
 		*ptr = 1;


### PR DESCRIPTION
[related to #2018 - when reading "After a lot of trouble shooting and digging through the uWSGI source" I thought maybe that can be more friendly]

This should not change the existing behavior of using 0 when
a non-numeric value is provided, but loudly logs:

    $ uwsgi test.ini --processes 2x
    [uWSGI] getting INI configuration from test.ini
    [WARNING] non-numeric value "2x" for option "processes" - using 2 !
    [WARNING] non-numeric value "true" for option "http-keepalive" - using 0 !
    *** Starting uWSGI 2.1-dev-ade7d170 (64bit) on [Sun Jun 23 18:36:29 2019] ***
    compiled with version: 8.3.0 on 23 June 2019 16:22:05
    ...

It might be saner to not even start with invalid options. However,
hypothetical setups with http-keepalive=off or http-keepalive=false may
then fail to start at all and people might get unahppy.