### PR TITLE
fix Python 3.7 warning in pyuwsgi.c

### DIFF
--- a/plugins/pyuwsgi/pyuwsgi.c
+++ b/plugins/pyuwsgi/pyuwsgi.c
@@ -82,7 +82,7 @@ PyObject *pyuwsgi_setup(PyObject * self, PyObject * args, PyObject * kwds) {
 		PyObject *py_str = PyObject_Str(item);
 		PyList_Append(args_li, py_str);
 #ifdef PYTHREE
-		char *str = PyUnicode_AsUTF8(py_str);
+		const char *str = PyUnicode_AsUTF8(py_str);
 		size += strlen(str) + 1;
 #else
 		size += PyObject_Length(item) + 1;
@@ -102,7 +102,7 @@ PyObject *pyuwsgi_setup(PyObject * self, PyObject * args, PyObject * kwds) {
 	for (i = 0; i < new_argc; i++) {
 		PyObject *arg = PyList_GetItem(args_li, i);
 #ifdef PYTHREE
-		char *arg_str = PyUnicode_AsUTF8(arg);
+		const char *arg_str = PyUnicode_AsUTF8(arg);
 #else
 		char *arg_str = PyString_AsString(arg);
 #endif


### PR DESCRIPTION
Python 3.7 made `PyUnicode_AsUTF8` return const: https://bugs.python.org/issue28769

---

This PR is for `uwsgi-2.0` branch. It is based on 3dab0e4e67c763793c372acae7a9a722dd362fc1 that did not reach the `master` branch.