### PR TITLE
uwsgi: fixup name clash on solaris

### DIFF
--- a/uwsgi.h
+++ b/uwsgi.h
@@ -1368,6 +1368,9 @@ enum uwsgi_range {
 	UWSGI_RANGE_INVALID,
 };
 
+// avoid name clashes on solaris
+#undef sun
+
 struct wsgi_request {
 	int fd;
 	struct uwsgi_header *uh;


### PR DESCRIPTION
Solaris defines sun to 1 which results in a compilation error:
./uwsgi.h:1646:22: error: expected identifier or ‘(’ before numeric constant struct sockaddr_un sun;

Fix #1933