### PR TITLE
Add a XML2_CONFIG environment variable for cross-compiling

### DIFF
--- a/uwsgiconfig.py
+++ b/uwsgiconfig.py
@@ -1317,12 +1317,13 @@ class uConf(object):
                 self.gcc_list.append('core/legion')
                 report['ssl'] = True
 
+        xml2config = os.environ.get('XML2_CONFIG','xml2-config')
         if self.get('xml'):
             if self.get('xml') == 'auto':
-                xmlconf = spcall('xml2-config --libs')
+                xmlconf = spcall(xml2config + ' --libs')
                 if xmlconf and uwsgi_os != 'Darwin':
                     self.libs.append(xmlconf)
-                    xmlconf = spcall("xml2-config --cflags")
+                    xmlconf = spcall(xml2config + " --cflags")
                     self.cflags.append(xmlconf)
                     self.cflags.append("-DUWSGI_XML -DUWSGI_XML_LIBXML2")
                     self.gcc_list.append('core/xmlconf')
@@ -1333,13 +1334,13 @@ class uConf(object):
                     self.gcc_list.append('core/xmlconf')
                     report['xml'] = 'expat'
             elif self.get('xml') == 'libxml2':
-                xmlconf = spcall('xml2-config --libs')
+                xmlconf = spcall(xml2config + ' --libs')
                 if xmlconf is None:
                     print("*** libxml2 headers unavailable. uWSGI build is interrupted. You have to install libxml2 development package or use libexpat or disable XML")
                     sys.exit(1)
                 else:
                     self.libs.append(xmlconf)
-                    xmlconf = spcall("xml2-config --cflags")
+                    xmlconf = spcall(xml2config + " --cflags")
                     if xmlconf is None:
                         print("*** libxml2 headers unavailable. uWSGI build is interrupted. You have to install libxml2 development package or use libexpat or disable XML")
                         sys.exit(1)


### PR DESCRIPTION
Currently, xml2-config is called out with no way to define an xml2-config path.
This causes uwsgi to use the host xml2-config which will cause the xml2 library
and CFlag directories to point to the host instead of the cross-environment.

Add a check for the XML2_CONFIG environment variable, and if it exists, use
the resulting path instead.