### PR TITLE
Add a PCRE_CONFIG environment variable for cross-compiling

### DIFF
--- a/uwsgiconfig.py
+++ b/uwsgiconfig.py
@@ -1092,25 +1092,26 @@ class uConf(object):
         has_pcre = False
 
         # re-enable after pcre fix
+        pcreconfig = os.environ.get('PCRE_CONFIG','pcre-config')
         if self.get('pcre'):
             if self.get('pcre') == 'auto':
-                pcreconf = spcall('pcre-config --libs')
+                pcreconf = spcall(pcreconfig + ' --libs')
                 if pcreconf:
                     self.libs.append(pcreconf)
-                    pcreconf = spcall("pcre-config --cflags")
+                    pcreconf = spcall(pcreconfig + ' --cflags')
                     self.cflags.append(pcreconf)
                     self.gcc_list.append('core/regexp')
                     self.cflags.append("-DUWSGI_PCRE")
                     has_pcre = True
 
             else:
-                pcreconf = spcall('pcre-config --libs')
+                pcreconf = spcall(pcreconfig + ' --libs')
                 if pcreconf is None:
                     print("*** libpcre headers unavailable. uWSGI build is interrupted. You have to install pcre development package or disable pcre")
                     sys.exit(1)
                 else:
                     self.libs.append(pcreconf)
-                    pcreconf = spcall("pcre-config --cflags")
+                    pcreconf = spcall(pcreconfig + ' --cflags')
                     self.cflags.append(pcreconf)
                     self.gcc_list.append('core/regexp')
                     self.cflags.append("-DUWSGI_PCRE")


### PR DESCRIPTION
Currently, pcre-config is called out with no way to define a pcre-config path,
which causes uwsgi to use the host pcre-config, which will cause the pcre
library and cflag directories to point to the host.

Add a check for the PCRE_CONFIG environment variable, and if it exists,
use the resulting path instead.