### PR TITLE
Add PLUGIN_BASE_DIR variable

### DIFF
--- a/uwsgiconfig.py
+++ b/uwsgiconfig.py
@@ -27,7 +27,7 @@ try:
 except ImportError:
     import configparser as ConfigParser
 
-
+PLUGIN_BASE_DIR = os.environ.get('PLUGIN_BASE_DIR', '')
 PY3 = sys.version_info[0] == 3
 
 if uwsgi_os == 'Darwin':
@@ -1463,7 +1463,7 @@ def build_plugin(path, uc, cflags, ldflags, libs, name=None):
         pass
 
     if uc:
-        plugin_dest = uc.get('plugin_build_dir', uc.get('plugin_dir')) + '/' + name + '_plugin'
+        plugin_dest = PLUGIN_BASE_DIR + uc.get('plugin_build_dir', uc.get('plugin_dir')) + '/' + name + '_plugin'
     else:
         plugin_dest = name + '_plugin'
 


### PR DESCRIPTION
Currently, when cross-compiling, if the plugin_dir points to the target
directory, uwsgi will embed the full path during compiling. This whole path
results in uwsgi trying to load a full target path instead of /usr/lib/uwsgi
when running on the target.

For example with Buildroot, instead of using /usr/lib/uwsgi as the plugin_dir,
uwsgi would try to use /path/to/buildroot/output/target/usr/lib/uwsgi.

Creating a new PLUGIN_BASE_DIR variable and prefixing plugin_dir allows the
plugin to be installed to the appropriate directory but still have uwsgi load
the plugins from the correct folder when ran from on the cross-compiled target.