### PR TITLE
plugins/router_basicauth: Fix building with uClibc

### DIFF
--- a/plugins/router_basicauth/router_basicauth.c
+++ b/plugins/router_basicauth/router_basicauth.c
@@ -3,7 +3,7 @@
 #ifdef UWSGI_ROUTING
 
 // TODO: Add more crypt_r supported platfroms here
-#if defined(__linux__) && defined(__GLIBC__)
+#if defined(__linux__) && defined(__GLIBC__) && !defined(__UCLIBC__)
 #include <crypt.h>
 #elif defined(__CYGWIN__)
 #include <crypt.h>
@@ -67,7 +67,7 @@ static uint16_t htpasswd_check(char *filename, char *auth) {
 
 		if (clen > 13) cpwd[13] = 0;
 
-#if defined(__linux__) && defined(__GLIBC__)
+#if defined(__linux__) && defined(__GLIBC__) && !defined(__UCLIBC__)
 		struct crypt_data cd;
 		memset(&cd, 0, sizeof(struct crypt_data));
     /* work around glibc-2.2.5 bug,


### PR DESCRIPTION
The struct crypt_data does not exist with uClibc, so a check must be put in
place to make sure uClibc does not try to use this struct.