### PR TITLE
Log format rework

### DIFF
--- a/core/emperor.c
+++ b/core/emperor.c
@@ -1361,7 +1361,7 @@ int uwsgi_emperor_vassal_start(struct uwsgi_instance *n_ui) {
 	}
 
 	if (pid < 0) {
-		uwsgi_error("uwsgi_emperor_spawn_vassal()/fork()")
+		uwsgi_error("uwsgi_emperor_spawn_vassal()/fork()");
 	}
 	else if (pid > 0) {
 		n_ui->pid = pid;

--- a/core/logging.c
+++ b/core/logging.c
@@ -66,6 +66,30 @@ void _uwsgi_report(const char *file, int line,int loglevel, const char *fmt, ...
 	if (!uwsgi.logpid) {
 		rlen += sprintf(logpkt + rlen,"%d ",getpid());
 	}
+
+	if (!uwsgi.logflags) {
+		if(!uwsgi.logflagspretty) {
+			rlen += sprintf(logpkt +rlen, "[ ");
+			if(loglevel & ERROR) {
+				rlen += sprintf(logpkt + rlen,"ERROR ");
+			}
+			if(loglevel & DEBUG) {
+				rlen += sprintf(logpkt + rlen,"DEBUG ");
+			}
+			if(loglevel & INFO) {
+				rlen += sprintf(logpkt + rlen,"INFO ");
+			}
+			if(loglevel & ALARM) {
+				rlen += sprintf(logpkt + rlen,"ALARM ");
+			}
+			if(loglevel & DEBUG) {
+				rlen += sprintf(logpkt + rlen,"REQUEST ");
+			}
+			rlen += sprintf(logpkt +rlen, "] ");
+		} else {
+			rlen += sprintf(logpkt + rlen,"%d ",loglevel);
+		}
+	}
 	va_start(ap, fmt);
 	ret = vsnprintf(logpkt + rlen, 4096 - rlen, fmt, ap);
 	va_end(ap);

--- a/core/uwsgi.c
+++ b/core/uwsgi.c
@@ -800,6 +800,11 @@ static struct uwsgi_option uwsgi_base_options[] = {
 	{"log-maxsize", required_argument, 0, "set maximum logfile size", uwsgi_opt_set_64bit, &uwsgi.log_maxsize, UWSGI_OPT_MASTER|UWSGI_OPT_LOG_MASTER},
 	{"log-backupname", required_argument, 0, "set logfile name after rotation", uwsgi_opt_set_str, &uwsgi.log_backupname, 0},
 
+
+	{"logtrace", optional_argument, 0, "prefix logs with filename and line number", uwsgi_opt_false, &uwsgi.logtrace, 0},
+	{"logpid", optional_argument, 0, "prefix logs with pid", uwsgi_opt_false, &uwsgi.logpid, 0},
+	{"loglevel", optional_argument, 0, "Set at what level logs should be shown", uwsgi_opt_log_level, &uwsgi.loglevel, 0},
+
 	{"logdate", optional_argument, 0, "prefix logs with date or a strftime string", uwsgi_opt_log_date, NULL, 0},
 	{"log-date", optional_argument, 0, "prefix logs with date or a strftime string", uwsgi_opt_log_date, NULL, 0},
 	{"log-prefix", optional_argument, 0, "prefix logs with a string", uwsgi_opt_log_date, NULL, 0},
@@ -4719,6 +4724,27 @@ void uwsgi_opt_log_date(char *opt, char *value, void *foobar) {
 			uwsgi.log_strftime = value;
 		}
 	}
+}
+void uwsgi_opt_log_level(char *opt, char *value, void *key) {
+	int *ptr = (int *)key;
+	char *n = value;
+	*ptr = ERROR | DEBUG | INFO | ALARM | REQUEST;
+
+	do {
+		if(!strcasecmp(n,"error")){
+			*ptr ^= ERROR;
+		} else if (!strcasecmp(n,"debug")) {
+			*ptr ^= DEBUG;
+		} else if (!strcasecmp(n,"info")) {
+			*ptr ^= INFO;
+		} else if (!strcasecmp(n,"alarm")) {
+			*ptr ^= ALARM;
+		} else if (!strcasecmp(n,"request")) {
+			*ptr ^= REQUEST;
+		} else if (!strcasecmp(n,"all")) {
+			*ptr = 0;
+		}
+	} while((n = strchr(n,' ')) != NULL && n++);
 }
 
 void uwsgi_opt_chmod_socket(char *opt, char *value, void *foobar) {

--- a/core/uwsgi.c
+++ b/core/uwsgi.c
@@ -802,6 +802,8 @@ static struct uwsgi_option uwsgi_base_options[] = {
 
 
 	{"logtrace", optional_argument, 0, "prefix logs with filename and line number", uwsgi_opt_false, &uwsgi.logtrace, 0},
+	{"logflags", optional_argument, 0, "prefix logs with logflags", uwsgi_opt_false, &uwsgi.logflags, 0},
+	{"logflagspretty", optional_argument, 0, "print logflags with pretty", uwsgi_opt_false, &uwsgi.logflagspretty, 0},
 	{"logpid", optional_argument, 0, "prefix logs with pid", uwsgi_opt_false, &uwsgi.logpid, 0},
 	{"loglevel", optional_argument, 0, "Set at what level logs should be shown", uwsgi_opt_log_level, &uwsgi.loglevel, 0},
 

--- a/core/uwsgi.c
+++ b/core/uwsgi.c
@@ -802,6 +802,7 @@ static struct uwsgi_option uwsgi_base_options[] = {
 
 
 	{"logtrace", optional_argument, 0, "prefix logs with filename and line number", uwsgi_opt_false, &uwsgi.logtrace, 0},
+	{"logtraceshort", optional_argument, 0, "Only show filename of file no extension or linenumber", uwsgi_opt_false, &uwsgi.logtraceshort, 0},
 	{"logflags", optional_argument, 0, "prefix logs with logflags", uwsgi_opt_false, &uwsgi.logflags, 0},
 	{"logflagspretty", optional_argument, 0, "print logflags with pretty", uwsgi_opt_false, &uwsgi.logflagspretty, 0},
 	{"logpid", optional_argument, 0, "prefix logs with pid", uwsgi_opt_false, &uwsgi.logpid, 0},

--- a/uwsgi.h
+++ b/uwsgi.h
@@ -2135,6 +2135,7 @@ struct uwsgi_server {
 
 	int logdate;
 	int logtrace;
+	int logtraceshort;
 	int logpid;
 	int logflags;
 	int logflagspretty;

--- a/uwsgi.h
+++ b/uwsgi.h
@@ -1,5 +1,6 @@
 /* uWSGI */
 
+
 /* indent -i8 -br -brs -brf -l0 -npsl -nip -npcs -npsl -di1 -il0 */
 
 #ifdef __cplusplus
@@ -2135,6 +2136,8 @@ struct uwsgi_server {
 	int logdate;
 	int logtrace;
 	int logpid;
+	int logflags;
+	int logflagspretty;
 	int logfunc;
 	int loglevel;
 	int log_micros;

--- a/uwsgi.h
+++ b/uwsgi.h
@@ -18,17 +18,32 @@ extern "C" {
 
 #define UWSGI_END_OF_OPTIONS { NULL, 0, 0, NULL, NULL, NULL, 0},
 
-#define uwsgi_error(x)  uwsgi_log("%s: %s [%s line %d]\n", x, strerror(errno), __FILE__, __LINE__);
+#define BIT(x) (1 << x)
+
+enum LOGFLAGS {
+	ERROR   = BIT(0),
+	DEBUG   = BIT(1),
+	INFO    = BIT(2),
+	ALARM   = BIT(3),
+	REQUEST = BIT(4)
+};
+
+#define uwsgi_report(loglevel,...) _uwsgi_report(__FILE__,__LINE__,loglevel,__VA_ARGS__)
+
+#define uwsgi_log(...) uwsgi_report(INFO,__VA_ARGS__)
+#define uwsgi_error(x) uwsgi_report(ERROR,x" %s(%d)", strerror(errno), errno)
+#define uwsgi_log_verbose(...) uwsgi_log(__VA_ARGS__)
+
 #define uwsgi_error_realpath(x)  uwsgi_log("realpath() of %s failed: %s [%s line %d]\n", x, strerror(errno), __FILE__, __LINE__);
 #define uwsgi_log_safe(x)  if (uwsgi.original_log_fd != 2) dup2(uwsgi.original_log_fd, 2) ; uwsgi_log(x);
 #define uwsgi_error_safe(x)  if (uwsgi.original_log_fd != 2) dup2(uwsgi.original_log_fd, 2) ; uwsgi_log("%s: %s [%s line %d]\n", x, strerror(errno), __FILE__, __LINE__);
 #define uwsgi_log_initial if (!uwsgi.no_initial_output) uwsgi_log
-#define uwsgi_log_alarm(x, ...) uwsgi_log("[uwsgi-alarm" x, __VA_ARGS__)
+#define uwsgi_log_alarm(x, ...) uwsgi_log("[uwsgi-alarm" x, __VA_ARGS__);
 #define uwsgi_fatal_error(x) uwsgi_error(x); exit(1);
 #define uwsgi_error_open(x)  uwsgi_log("open(\"%s\"): %s [%s line %d]\n", x, strerror(errno), __FILE__, __LINE__);
 #define uwsgi_req_error(x)  if (wsgi_req->uri_len > 0 && wsgi_req->method_len > 0 && wsgi_req->remote_addr_len > 0) uwsgi_log_verbose("%s: %s [%s line %d] during %.*s %.*s (%.*s)\n", x, strerror(errno), __FILE__, __LINE__,\
 		wsgi_req->method_len, wsgi_req->method, wsgi_req->uri_len, wsgi_req->uri, wsgi_req->remote_addr_len, wsgi_req->remote_addr); else uwsgi_log_verbose("%s %s [%s line %d] \n",x, strerror(errno), __FILE__, __LINE__);
-#define uwsgi_debug(x, ...) uwsgi_log("[uWSGI DEBUG] " x, __VA_ARGS__);
+#define uwsgi_debug(fmt, ...) uwsgi_report(DEBUG,fmt, __VA_ARGS__)
 #define uwsgi_rawlog(x) if (write(2, x, strlen(x)) != strlen(x)) uwsgi_error("write()")
 #define uwsgi_str(x) uwsgi_concat2(x, (char *)"")
 
@@ -1194,7 +1209,7 @@ struct uwsgi_route {
 	pcre_extra *pattern_extra;
 
 	char *orig_route;
-	
+
 	// one for each core
 	int *ovn;
 	int **ovector;
@@ -2118,6 +2133,10 @@ struct uwsgi_server {
 	int forkbomb_delay;
 
 	int logdate;
+	int logtrace;
+	int logpid;
+	int logfunc;
+	int loglevel;
 	int log_micros;
 	char *log_strftime;
 
@@ -3306,8 +3325,10 @@ void sanitize_args(void);
 void env_to_arg(char *, char *);
 void parse_sys_envs(char **);
 
-void uwsgi_log(const char *, ...);
-void uwsgi_log_verbose(const char *, ...);
+//void uwsgi_log(const char *, ...);
+//
+void _uwsgi_report(const char *, int, int, const char *, ...);
+//void uwsgi_log_verbose(const char *, ...);
 void uwsgi_logfile_write(const char *, ...);
 
 
@@ -4022,6 +4043,9 @@ void uwsgi_opt_snmp(char *, char *, void *);
 void uwsgi_opt_snmp_community(char *, char *, void *);
 
 void uwsgi_opt_logfile_chmod(char *, char *, void *);
+
+
+void uwsgi_opt_log_level(char *, char *, void *);
 
 void uwsgi_opt_log_date(char *, char *, void *);
 void uwsgi_opt_chmod_socket(char *, char *, void *);


### PR DESCRIPTION
I tried to make the logging more consistent, so its easier to sort through and
understand the logs.

The new format looks like this
```
[time] [trace] [linenumber] [pid] [level/flags] [message]
```
Every field except of course message can be disabled in the configuration file.

With everything enabled and time format set to milles it will look like this:
```
1565357347413 uwsgi 13484 WARNING you are running uWSGI without its master process manager ***
1565357347413 uwsgi 13484 INFO your processes number limit is 63013
1565357347413 uwsgi 13484 INFO your memory page size is 4096 bytes
1565357347413 uwsgi 13484 INFO detected max file descriptor number: 1024
1565357347413 lock 13484 INFO lock engine: pthread robust mutexes
1565357347413 uwsgi 13484 INFO thunder lock: disabled (you can enable it with --thunder-lock)
1565357347413 uwsgi 13484 INFO dropping root privileges after socket binding
1565357347413 uwsgi 13484 INFO dropping root privileges after plugin initialization
```
## level/flags
Added a flags/level system with values:
 - ERROR
 - WARNING
 - DEBUG
 - INFO
 - ALARM
 - REQUEST

A log message can have from none to all of the flags.
It can be configured with the following options
```
loglevel = ERROR WARNING ALARM
// or
loglevel = ALL
// and
logflags = true
// and
logflagspretty = true
```
If logflags is enabled the logs will prepend the flags for that message,
If logflagspretty is enabled the logs wil prepend with | seperated string representations of the flags eks:
```
WARNING|ALARM this is my message
```

## trace
Added the option to prepend the filename of the caller.
And it has the following options.
```
logtrace = true
// and
logtraceshort = true
```
With just logtrace the output will look like:
```
core/uwsgi.c:2502 *** Starting uWSGI 2.1-dev-9274e779 (64bit) on [Fri Aug  9 15:29:14 2019] ***
```
with logtraceshort enabled it will remote the dir and extention part and look like:
```
uwsgi *** Starting uWSGI 2.1-dev-9274e779 (64bit) on [Fri Aug  9 15:29:14 2019] ***
```

## pid
Adds the logpid options that will prepend the pid 

