### PR TITLE
Add mode option to `logfile` plugin

### DIFF
--- a/core/utils.c
+++ b/core/utils.c
@@ -4558,22 +4558,25 @@ void uwsgi_setns(char *path) {
 mode_t uwsgi_mode_t(char *value, int *error) {
 	mode_t mode = 0;
 	*error = 0;
+	int len = strlen(value);
 
-        if (strlen(value) < 3) {
+	if (len < 3) {
 		*error = 1;
 		return mode;
 	}
 
-        if (strlen(value) == 3) {
-                mode = (mode << 3) + (value[0] - '0');
-                mode = (mode << 3) + (value[1] - '0');
-                mode = (mode << 3) + (value[2] - '0');
-        }
-        else {
-                mode = (mode << 3) + (value[1] - '0');
-                mode = (mode << 3) + (value[2] - '0');
-                mode = (mode << 3) + (value[3] - '0');
-        }
+	int i, start = 0;
+	if (len != 3) {
+		start = 1;
+	}
+
+	for (i = start; i < start + 3; i++) {
+		if (value[i] < '0' || value[i] > '7') {
+			*error = 1;
+			return 0;
+		}
+		mode = (mode << 3) + (value[i] - '0');
+	}
 
 	return mode;
 }

--- a/core/uwsgi.c
+++ b/core/uwsgi.c
@@ -4723,50 +4723,33 @@ void uwsgi_opt_log_date(char *opt, char *value, void *foobar) {
 
 void uwsgi_opt_chmod_socket(char *opt, char *value, void *foobar) {
 
-	int i;
-
 	uwsgi.chmod_socket = 1;
 	if (value) {
 		if (strlen(value) == 1 && *value == '1') {
 			return;
 		}
-		if (strlen(value) != 3) {
-			uwsgi_log("invalid chmod value: %s\n", value);
+
+                int error = 0;
+                mode_t permission = uwsgi_mode_t(value, &error);
+                if (error) {
+			uwsgi_log("invalid chmod value for chmod-socket: %s\n", value);
 			exit(1);
-		}
-		for (i = 0; i < 3; i++) {
-			if (value[i] < '0' || value[i] > '7') {
-				uwsgi_log("invalid chmod value: %s\n", value);
-				exit(1);
-			}
-		}
+                }
 
-		uwsgi.chmod_socket_value = (uwsgi.chmod_socket_value << 3) + (value[0] - '0');
-		uwsgi.chmod_socket_value = (uwsgi.chmod_socket_value << 3) + (value[1] - '0');
-		uwsgi.chmod_socket_value = (uwsgi.chmod_socket_value << 3) + (value[2] - '0');
+		uwsgi.chmod_socket_value = permission;
 	}
-
 }
 
 void uwsgi_opt_logfile_chmod(char *opt, char *value, void *foobar) {
 
-	int i;
+        int error = 0;
+        mode_t permission = uwsgi_mode_t(value, &error);
+        if (error) {
+                uwsgi_log("invalid chmod value for logfile-chmod: %s\n", value);
+                exit(1);
+        }
 
-	if (strlen(value) != 3) {
-		uwsgi_log("invalid chmod value: %s\n", value);
-		exit(1);
-	}
-	for (i = 0; i < 3; i++) {
-		if (value[i] < '0' || value[i] > '7') {
-			uwsgi_log("invalid chmod value: %s\n", value);
-			exit(1);
-		}
-	}
-
-	uwsgi.chmod_logfile_value = (uwsgi.chmod_logfile_value << 3) + (value[0] - '0');
-	uwsgi.chmod_logfile_value = (uwsgi.chmod_logfile_value << 3) + (value[1] - '0');
-	uwsgi.chmod_logfile_value = (uwsgi.chmod_logfile_value << 3) + (value[2] - '0');
-
+        uwsgi.chmod_logfile_value = permission;
 }
 
 void uwsgi_opt_max_vars(char *opt, char *value, void *foobar) {


### PR DESCRIPTION
* Add a new option to the `logfile` plugin to accept a `mode` argument, used to set flags when creating a new log file.
* Add stricter validation to `core/utils.c:uwsgi_mode_t`.
* Update argument parsing for `chmod-socket` and `logfile-chmod` to call `uwsgi_mode_t`. 