### PR TITLE
Fix: bug in checking for log file type in logging.c

### DIFF
--- a/core/logging.c
+++ b/core/logging.c
@@ -498,11 +498,7 @@ void uwsgi_check_logrotate(void) {
 		return;
 	}
 
-	if (logstat.st_mode & S_IFIFO) {
-		return;
-	}
-
-	if (logstat.st_mode & S_IFSOCK) {
+	if (S_ISFIFO(logstat.st_mode) || S_ISSOCK(logstat.st_mode)) {
 		return;
 	}
 


### PR DESCRIPTION
While working on #2071 I noticed that the default (e.g. `logto`) logfile never rotated correctly when configured with `max-logsize`. 

This is because a check in `core/logging.c:uwsgi_check_logrotate` is incorrect (see change). This is why the standard ( https://pubs.opengroup.org/onlinepubs/009695399/basedefs/sys/stat.h.html ) provides and recommends using a set of macros to check for file type. :) 

You can't simply check if the st_mode & S_IFSOCK > 0. For example, note that on at least Linux and OS X, S_IFSOCK & S_IFREG != 0:

https://github.com/apple/darwin-xnu/blob/0a798f6738bc1db01281fc08ae024145e84df927/bsd/sys/_types/_s_ifmt.h#L35-L42
https://github.com/torvalds/linux/blob/6f0d349d922ba44e4348a17a78ea51b7135965b1/include/uapi/linux/stat.h#L9-L16