### PR TITLE
Enable python plugin to load and run compiled python files (.so).

### DIFF
--- a/plugins/python/python_plugin.c
+++ b/plugins/python/python_plugin.c
@@ -105,7 +105,7 @@ void uwsgi_opt_ini_paste(char *opt, char *value, void *foobar) {
 }
 
 struct uwsgi_option uwsgi_python_options[] = {
-	{"wsgi-file", required_argument, 0, "load .wsgi file", uwsgi_opt_set_str, &up.file_config, 0},
+	{"wsgi-file", required_argument, 0, "load .py and .so files", uwsgi_opt_set_str, &up.file_config, 0},
 	{"file", required_argument, 0, "load .wsgi file", uwsgi_opt_set_str, &up.file_config, 0},
 	{"eval", required_argument, 0, "eval python code", uwsgi_opt_set_str, &up.eval, 0},
 	{"module", required_argument,'w', "load a WSGI module", uwsgi_opt_set_str, &up.wsgi_config, 0},
@@ -475,7 +475,7 @@ PyObject *uwsgi_pyimport_by_filename(char *name, char *filename) {
 
 	FILE *pyfile;
 	struct _node *py_file_node = NULL;
-	PyObject *py_compiled_node, *py_file_module;
+	PyObject *py_compiled_node, *py_file_module = NULL;
 	int is_a_package = 0;
 	struct stat pystat;
 	char *real_filename = filename;
@@ -1197,7 +1197,7 @@ void uwsgi_python_init_apps() {
 
 	struct uwsgi_string_list *upli = up.import_list;
 	while(upli) {
-		if (strchr(upli->value, '/') || uwsgi_endswith(upli->value, ".py")) {
+		if (strchr(upli->value, '/') || uwsgi_endswith(upli->value, ".py") || uwsgi_endswith(upli->value, ".so")) {
 			uwsgi_pyimport_by_filename(uwsgi_pythonize(upli->value), upli->value);
 		}
 		else {


### PR DESCRIPTION
# Introduction.
The core idea of this PR is to enable uwsgi to run with compiled python modules (via tools like [Nuitka](https://nuitka.net/)).
So we could improve performances while beeing able to ship professionnal uwsgi-based python solution without shipping the source code and without allowing the client to edit it (Wich is the worst nightmare of any support team!).

# How to use?

## Compiling a python file.
Here we will compile the "Wello World" example from [uwsgi documentation](https://uwsgi-docs.readthedocs.io/en/latest/WSGIquickstart.html).

```python
#foobar.py
def application(env, start_response):
    start_response('200 OK', [('Content-Type','text/html')])
    return [b"Hello World"]
```
Installing nuitka:
`python -m pip install nuitka`

Now let's build it:
`python -m nuitka --module --follow-imports foobar.py`

The so file is now created.
Then remove the python file:
`rm foobar.py`

Note: For multiple python file, we can basically compile each of them as module, it will be easier to maintain and debug than a single compiled module.

## Using it.
Basically as follow:
`uwsgi --http :9090 --wsgi-file foobar.so`
So now you can check it works with curl or any web browser (localhost):
`curl http://127.0.0.1:9090`

# How does it works?

Python allows natively loading compiled modules basically with `import my_module`. So basically we will create a temp python file containing one line of code: `from my_module import *`, run it and then delete it because Python interpreter cannot run directly compiled modules...
So the temp file is just importing all the module's method inside the uwsgi context.
So it will cost a bit more perfs on application startup, however it should be faster once started.

That's my first contribution to this project (and one of my first on GitHube)... I hope I didn't break any rules! (If so feel free to tell me!)
Waiting for your comments!