### PR TITLE
plugins/redislog: fix redislog compilation on 32bit

### DIFF
--- a/plugins/redislog/redislog_plugin.c
+++ b/plugins/redislog/redislog_plugin.c
@@ -159,7 +159,7 @@ done:
 		uredislog->fd = uwsgi_connect(uredislog->address, uwsgi.socket_timeout, 0);
 		if (uredislog->password) {
 		  setup_iov.iov_len = snprintf(
-		    setup_buf, sizeof (setup_buf), "*2\r\n$4\r\nauth\r\n$%lu\r\n%*s\r\n",
+		    setup_buf, sizeof (setup_buf), "*2\r\n$4\r\nauth\r\n$%zu\r\n%*s\r\n",
 		    strlen(uredislog->password), (int)strlen(uredislog->password), uredislog->password);
 		  setup_iov.iov_base = setup_buf;
 		  ret = writev(uredislog->fd, &setup_iov, 1);
@@ -172,7 +172,7 @@ done:
 		}
 		if (uredislog->id) {
 		  setup_iov.iov_len = snprintf(
-		    setup_buf, sizeof (setup_buf), "*2\r\n$6\r\nselect\r\n$%lu\r\n%*s\r\n",
+		    setup_buf, sizeof (setup_buf), "*2\r\n$6\r\nselect\r\n$%zu\r\n%*s\r\n",
 	            strlen(uredislog->id), (int)strlen(uredislog->id), uredislog->id);
 		  setup_iov.iov_base = setup_buf;
 		  ret = writev(uredislog->fd, &setup_iov, 1);


### PR DESCRIPTION
In function ‘uwsgi_redis_logger’: plugins/redislog/redislog_plugin.c:162:38:
error: format ‘%lu’ expects argument of type ‘long unsigned int’, but argument 4
  has type ‘size_t {aka unsigned int}’ [-Werror=format=]

Fix #1828