### PR TITLE
Add 'all', 'clean', 'check' to phony targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,4 +19,4 @@ tests:
 %:
 	$(PYTHON) uwsgiconfig.py --build $@
 
-.PHONY: tests
+.PHONY: all clean check tests


### PR DESCRIPTION
The only one currently useful is 'check': since there's a directory named 'check', `make check` always just returns `make: `check' is up to date.`. 

But, `all` and `clean` are also phony. 

Actually the other rule based targets are phony too but .PHONY doesn't work with pattern rules:

https://www.gnu.org/software/make/manual/make.html#Phony-Targets

> The implicit rule search (see Implicit Rules) is skipped for .PHONY targets. This is why declaring a target as .PHONY is good for performance, even if you are not worried about the actual file existing.