### PR TITLE
Add docker-based build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,11 @@ tests:
 	$(PYTHON) uwsgiconfig.py --build unittest
 	cd check && make && make test
 
+docker-test:
+	docker build -t uwsgi-build -f docker/Dockerfile docker
+	docker run --rm -v $(PWD):/uwsgi:delegated -it --entrypoint /bin/bash uwsgi-build -c 'cd /uwsgi; make tests'
+
 %:
 	$(PYTHON) uwsgiconfig.py --build $@
 
-.PHONY: tests
+.PHONY: tests docker-test

--- a/docker/.gitignore
+++ b/docker/.gitignore
@@ -1,0 +1,1 @@
+mirror.local.txt

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,33 @@
+FROM ubuntu:xenial
+
+# The default ubuntu mirrors aren't particularly fast (at least in my location). 
+# You can add a mirror host in a file named 'mirror.local.txt' in this
+# directory that will be used to edit the mirror used in /etc/apt/sources.list .
+# Example contents: 
+# http://mirrors.rit.edu/ubuntu/
+COPY mirror.local* /tmp
+RUN /bin/bash -c '[ ! -e /tmp/mirror.local.txt ] || { mirror=$(< /tmp/mirror.local.txt) ; sed -i"" -n "/^deb/s| http[^ ]*| $mirror|p" /etc/apt/sources.list ; }' 
+
+RUN apt-get update -q
+RUN apt-get install -qyf software-properties-common
+
+# https://askubuntu.com/questions/490468/add-apt-repository-throws-python-error-unicodedecodeerror-ascii-codec-cant 
+RUN LC_ALL=C.UTF-8 add-apt-repository ppa:deadsnakes/ppa -y
+RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php -y
+
+RUN apt-get update -q
+
+RUN apt-get install -qyf python2.6-dev python3.4-dev python3.5-dev python3.6-dev \
+                         libxml2-dev libpcre3-dev libcap2-dev \
+                         php7.2-dev libphp7.2-embed libargon2-0-dev libsodium-dev \
+                         liblua5.1-0-dev \
+                         libjansson-dev libldap2-dev libpq-dev \
+                         libpam0g-dev libsqlite3-dev libyaml-dev \
+                         libzmq-dev libmatheval-dev libperl-dev \
+                         libonig-dev libdb-dev libqdbm-dev libbz2-dev \
+                         libwrap0-dev libgeoip-dev libv8-dev libxslt1-dev \
+                         libboost-thread-dev libboost-filesystem-dev \
+                         libssl-dev libacl1-dev python-greenlet-dev \
+                         openjdk-8-jdk libgloox-dev gccgo \
+                         cli-common-dev mono-devel mono-mcs uuid-dev \
+                         curl check


### PR DESCRIPTION
Having a simple way to build uwsgi locally in Docker with all
dependencies might be helpful. (It's at least been helpful for me 🙂).

This PR adds a Dockerfile (based on the Travis configuration)
and updates the Makefile to let you run `make docker-test`.

The first time will be slow as the image builds, but future runs
should be quick as the docker cache will be used.

It would be simple to update this and the .travis.yml to use the same script
for setting up the environment if that's preferable.