### PR TITLE
uwsgiconfig: quote bin_name when linking

### DIFF
--- a/uwsgiconfig.py
+++ b/uwsgiconfig.py
@@ -27,6 +27,10 @@ try:
 except ImportError:
     import configparser as ConfigParser
 
+try:
+    from shlex import quote
+except ImportError:
+    from pipes import quote
 
 PY3 = sys.version_info[0] == 3
 
@@ -566,13 +570,13 @@ def build_uwsgi(uc, print_only=False, gcll=None):
     print("*** uWSGI linking ***")
     if '--static' in ldflags:
         ldline = 'ar cru %s %s' % (
-            bin_name,
+            quote(bin_name),
             ' '.join(map(add_o, gcc_list))
         )
     else:
         ldline = "%s -o %s %s %s %s" % (
             GCC,
-            bin_name,
+            quote(bin_name),
             ' '.join(uniq_warnings(ldflags)),
             ' '.join(map(add_o, gcc_list)),
             ' '.join(uniq_warnings(libs))


### PR DESCRIPTION
If the path to the binary contains a space, the link step fails:

    $ python3 -m venv have\ space
    $ . have\ space/bin/activate
    (have space) $ pip install uwsgi
    ....
    *** uWSGI linking ***
    x86_64-linux-gnu-gcc -pthread -o /home/awelzel/projects/uwsgi/have space/bin/uwsgi -L/usr/lib -Wl,-rpat
    x86_64-linux-gnu-gcc: error: space/bin/uwsgi: No such file or directory

Further, if one builds into a venv called `;uptime;`, `uptime` is executed.

This is a minimal fix quoting `bin_name` and not considering any other cases.

Fixes #1939.