### PR TITLE
php: Unset uwsgi.need_app in uwsgi_php_init() to keep running

### DIFF
--- a/plugins/php/php_plugin.c
+++ b/plugins/php/php_plugin.c
@@ -744,6 +744,13 @@ static int uwsgi_php_init(void) {
 	uwsgi_sapi_module.startup(&uwsgi_sapi_module);
 	uwsgi_log("PHP %s initialized\n", PHP_VERSION);
 
+	// The PHP plugin does not register an app.
+	// Ensure uwsgi keeps running by disabling need_app.
+	if (uwsgi.need_app) {
+		uwsgi_log("php plugin forcing need_app=0\n");
+		uwsgi.need_app = 0;
+	}
+
 	return 0;
 }
 


### PR DESCRIPTION
Commit f2e0142 set the default for `uwsgi.need_app` to `1`. This results
in the termination of uWSGI when using the PHP plugin only as this plugin
does not register any app.

This feels a bit like a workaround.

I ran into this while attempting to test current master-tree (uwsgi-2.0 is not affected as f2e0142 isn't there) with the following PHP config file (and it was reported in #1987 as well).
```
[uwsgi]
master = true
workers = 16

plugins = http,php

http-modifier1 = 14
http = :8080

php-docroot = ./t/php/
php-index = test.php
```