### PR TITLE
Add smart-daemon2 option to notify it on reloads

### DIFF
--- a/uwsgi.h
+++ b/uwsgi.h
@@ -625,6 +625,8 @@ struct uwsgi_daemon {
 	char *chdir;
 
 	int max_throttle;
+
+	int notifypid;
 };
 
 struct uwsgi_logger {


### PR DESCRIPTION
We had a use-case of a smart-daemon that needed to be notified when the
uWSGI master was reloading.

That option needs to be explicitly enabled and requires the smart-daemon
to have a pidfile and a valid pid. It that is the case we send a signal
to it notifying the uWSGI master is reloading.