### PR TITLE
[RFC] chroot: Do not chroot multiple times when root

### DIFF
--- a/core/utils.c
+++ b/core/utils.c
@@ -580,13 +580,15 @@ void uwsgi_as_root() {
 		}
 	}
 
-	if (uwsgi.chroot && !uwsgi.reloads) {
+	if (uwsgi.chroot && !uwsgi.is_chrooted && !uwsgi.reloads) {
 		if (!uwsgi.master_as_root)
 			uwsgi_log("chroot() to %s\n", uwsgi.chroot);
+
 		if (chroot(uwsgi.chroot)) {
 			uwsgi_error("chroot()");
 			exit(1);
 		}
+		uwsgi.is_chrooted = 1;
 #ifdef __linux__
 		if (uwsgi.logging_options.memory_report) {
 			uwsgi_log("*** Warning, on linux system you have to bind-mount the /proc fs in your chroot to get memory debug/report.\n");
@@ -987,7 +989,7 @@ void uwsgi_as_root() {
 	return;
 
 nonroot:
-	if (uwsgi.chroot && !uwsgi.is_a_reload) {
+	if (uwsgi.chroot && !uwsgi.is_chrooted && !uwsgi.is_a_reload) {
 		uwsgi_log("cannot chroot() as non-root user\n");
 		exit(1);
 	}

--- a/uwsgi.h
+++ b/uwsgi.h
@@ -2861,6 +2861,7 @@ struct uwsgi_server {
 
 	// uWSGI 2.0.19
 	int emperor_graceful_shutdown;
+	int is_chrooted;
 
 	size_t response_header_limit;
 	


### PR DESCRIPTION
From 2.0.15 to 2.0.16 the uwsgi_setup() sequence was modified such that
uwsgi_as_root() may be called multiple times. If the `uid` option is
used, then on later invocation most of this function is skipped.

However, if run as root, then most everything in this function is run
again. In #2128 it was reported that the second chroot() call fails.

This patch attempts to fix this for `chroot()` only. However, this is
a bit naive - the other sandboxing calls inside uwsgi_as_root() should
probably not be run multiple times either (unshare() / capabilities),
but I'm not 100% sure about the semantics, particularly concerning
uwsgi.master_as_root, so just presenting this as an RFC.

Related, uwsgi 2.0.18 + chroot + uid is not working:

    $ sudo uwsgi --uid 1000 --chroot /
    *** Starting uWSGI 2.0.18 (64bit) on [Sat Mar  7 22:05:18 2020] ***
    ...
    detected binary path: /home/awelzel/venv/bin/uwsgi
    uWSGI running as root, you can use --uid/--gid/--chroot options
    chroot() to /
    setuid() to 1000
    ...
    thunder lock: disabled (you can enable it with --thunder-lock)
    cannot chroot() as non-root user

This patch happens to fix the above issue.