### PR TITLE
plugins/{pypy,python}: get rid of unnecessary paste.script dependency

### DIFF
--- a/plugins/pypy/pypy_setup.py
+++ b/plugins/pypy/pypy_setup.py
@@ -340,10 +340,10 @@ def uwsgi_pypy_paste_loader(config):
     if c[0] != '/':
         c = os.getcwd() + '/' + c
     try:
-        from paste.script.util.logging_config import fileConfig
+        from logging.config import fileConfig
         fileConfig(c)
     except ImportError:
-        print("PyPy WARNING: unable to load paste.script.util.logging_config")
+        print("PyPy WARNING: unable to load logging.config")
     from paste.deploy import loadapp
     wsgi_application = loadapp('config:%s' % c)
 

--- a/plugins/python/pyloader.c
+++ b/plugins/python/pyloader.c
@@ -685,7 +685,7 @@ PyObject *uwsgi_paste_loader(void *arg1) {
 	uwsgi_log( "Loading paste environment: %s\n", paste);
 
 	if (up.paste_logger) {
-		PyObject *paste_logger_dict = get_uwsgi_pydict("paste.script.util.logging_config");	
+		PyObject *paste_logger_dict = get_uwsgi_pydict("logging.config");
 		if (paste_logger_dict) {
 			PyObject *paste_logger_fileConfig = PyDict_GetItemString(paste_logger_dict, "fileConfig");
 			if (paste_logger_fileConfig) {


### PR DESCRIPTION
paste.script.util.logging_config is an old copy of logging.config from
Python 2.5.1 (see [1]). There are no paste-specific details in it.

By using logging.config directly, Python WSGI environments no longer need to
have pastescript installed.

[1] https://bitbucket.org/wilig/pastescript/commits/04d0db6b2f5ab360bdaa5b10511d969a24fde0ec
