### PR TITLE
fix psgi plugin for GCC 10

### DIFF
--- a/plugins/psgi/psgi.h
+++ b/plugins/psgi/psgi.h
@@ -93,3 +93,5 @@ void uwsgi_perl_check_auto_reload(void);
 void uwsgi_psgi_preinit_apps(void);
 
 int uwsgi_perl_add_app(struct wsgi_request *, char *, PerlInterpreter **, SV **, time_t);
+
+extern struct uwsgi_perl uperl;

--- a/plugins/psgi/psgi_loader.c
+++ b/plugins/psgi/psgi_loader.c
@@ -1,7 +1,6 @@
 #include "psgi.h" 
 
 extern struct uwsgi_server uwsgi;
-struct uwsgi_perl uperl;
 
 extern struct uwsgi_plugin psgi_plugin;
 

--- a/plugins/psgi/psgi_plugin.c
+++ b/plugins/psgi/psgi_plugin.c
@@ -3,11 +3,7 @@
 extern char **environ;
 extern struct uwsgi_server uwsgi;
 
-#ifdef __APPLE__
-extern struct uwsgi_perl uperl;
-#else
 struct uwsgi_perl uperl;
-#endif
 
 struct uwsgi_plugin psgi_plugin;
 


### PR DESCRIPTION
Following guide here https://gcc.gnu.org/gcc-10/porting_to.html

I am the fedora packager for uwsgi, this makes it possible for the psgi to build with gcc 10 again.