### PR TITLE
gevent plugin: adapt to removal of deprecated interfaces in gevent 1.5.0

### DIFF
--- a/plugins/gevent/gevent.c
+++ b/plugins/gevent/gevent.c
@@ -452,7 +452,12 @@ static void gevent_loop() {
 	if (!ugevent.spawn) uwsgi_pyexit;
 
 	ugevent.signal = PyDict_GetItemString(gevent_dict, "signal_handler");
-	if (!ugevent.signal) uwsgi_pyexit;
+	if (!ugevent.signal) {
+		// gevent.signal_handler appears in gevent 1.3.
+		// On older gevent, fall back to the deprecated gevent.signal.
+		ugevent.signal = PyDict_GetItemString(gevent_dict, "signal");
+		if (!ugevent.signal) uwsgi_pyexit;
+	}
 
 	ugevent.greenlet_switch = PyDict_GetItemString(gevent_dict, "sleep");
 	if (!ugevent.greenlet_switch) uwsgi_pyexit;

--- a/plugins/gevent/gevent.c
+++ b/plugins/gevent/gevent.c
@@ -435,9 +435,6 @@ static void gevent_loop() {
 	PyObject *gevent_dict = get_uwsgi_pydict("gevent");
 	if (!gevent_dict) uwsgi_pyexit;
 
-	PyObject *gevent_signal_dict = get_uwsgi_pydict("gevent.signal");
-	if (!gevent_signal_dict) uwsgi_pyexit;
-
 	PyObject *gevent_version = PyDict_GetItemString(gevent_dict, "version_info");
 	if (!gevent_version) uwsgi_pyexit;
 
@@ -454,7 +451,7 @@ static void gevent_loop() {
 	ugevent.spawn = PyDict_GetItemString(gevent_dict, "spawn");
 	if (!ugevent.spawn) uwsgi_pyexit;
 
-	ugevent.signal = PyDict_GetItemString(gevent_signal_dict, "signal");
+	ugevent.signal = PyDict_GetItemString(gevent_dict, "signal_handler");
 	if (!ugevent.signal) uwsgi_pyexit;
 
 	ugevent.greenlet_switch = PyDict_GetItemString(gevent_dict, "sleep");

--- a/plugins/gevent/gevent.c
+++ b/plugins/gevent/gevent.c
@@ -435,6 +435,9 @@ static void gevent_loop() {
 	PyObject *gevent_dict = get_uwsgi_pydict("gevent");
 	if (!gevent_dict) uwsgi_pyexit;
 
+        PyObject *gevent_signal_dict = get_uwsgi_pydict("gevent.signal");
+	if (!gevent_signal_dict) uwsgi_pyexit;
+
 	PyObject *gevent_version = PyDict_GetItemString(gevent_dict, "version_info");
 	if (!gevent_version) uwsgi_pyexit;
 
@@ -451,7 +454,7 @@ static void gevent_loop() {
 	ugevent.spawn = PyDict_GetItemString(gevent_dict, "spawn");
 	if (!ugevent.spawn) uwsgi_pyexit;
 
-	ugevent.signal = PyDict_GetItemString(gevent_dict, "signal");
+	ugevent.signal = PyDict_GetItemString(gevent_signal_dict, "signal");
 	if (!ugevent.signal) uwsgi_pyexit;
 
 	ugevent.greenlet_switch = PyDict_GetItemString(gevent_dict, "sleep");

--- a/plugins/gevent/gevent.c
+++ b/plugins/gevent/gevent.c
@@ -435,7 +435,7 @@ static void gevent_loop() {
 	PyObject *gevent_dict = get_uwsgi_pydict("gevent");
 	if (!gevent_dict) uwsgi_pyexit;
 
-        PyObject *gevent_signal_dict = get_uwsgi_pydict("gevent.signal");
+	PyObject *gevent_signal_dict = get_uwsgi_pydict("gevent.signal");
 	if (!gevent_signal_dict) uwsgi_pyexit;
 
 	PyObject *gevent_version = PyDict_GetItemString(gevent_dict, "version_info");


### PR DESCRIPTION
Closes #2144 

Many thanks for @jamadden for finding the root cause of issues.

Note that I'm still having issues with uWSGI shutdown, looking into that.

And as noted by @jamadden , `gevent.version_info` will also be deprecated soon, I'll check if I could squash that too while at it.