### PR TITLE
Ensure '-lrt' is included on the link line after linking to python li…

### DIFF
--- a/plugins/python/uwsgiplugin.py
+++ b/plugins/python/uwsgiplugin.py
@@ -69,6 +69,8 @@ if 'UWSGI_PYTHON_NOLIB' not in os.environ:
         # hack for messy linkers/compilers
         if '-lutil' in LIBS:
             LIBS.append('-lutil')
+        if '-lrt' in LIBS:
+            LIBS.append('-lrt')
     else:
         try:
             libdir = sysconfig.get_config_var('LIBDIR')


### PR DESCRIPTION
…brary. Python depends on clock_gettime() and other functions in librt. Nothing else in uwsgi has a dependency on librt so if this library is only specified early on the link line then the library is dropped by the linker.