### PR TITLE
plugins/cgi: improve performance for santitizing file descriptors

### DIFF
--- a/plugins/cgi/cgi_plugin.c
+++ b/plugins/cgi/cgi_plugin.c
@@ -793,8 +793,21 @@ clear2:
 	close(cgi_pipe[1]);
 
 	// close all the fd > 2
-	for(i=3;i<(int)uwsgi.max_fd;i++) {
-		close(i);
+	DIR *dirp = opendir("/proc/self/fd");
+	if (dirp == NULL)
+		dirp = opendir("/dev/fd");
+	if (dirp != NULL) {
+		struct dirent *dent;
+		while ((dent = readdir(dirp)) != NULL) {
+			int fd = atoi(dent->d_name);
+			if ((fd > 2) && fd != dirfd(dirp))
+				close(fd);
+		}
+		closedir(dirp);
+	} else {
+		for(i=3;i<(int)uwsgi.max_fd;i++) {
+			close(i);
+		}
 	}
 
 	// fill cgi env


### PR DESCRIPTION
Only close file descriptors that are known to be open when /proc/self/fd
or /dev/fd exists. Fall back and loop over all when those are missing.

This improves performance significantly when number of max fds is high.

fixes #2053