### PR TITLE
Fix possible deadlock in install

### DIFF
--- a/uwsgiconfig.py
+++ b/uwsgiconfig.py
@@ -220,11 +220,12 @@ int main()
 
 def spcall3(cmd):
     p = subprocess.Popen(cmd, shell=True, stdin=open('/dev/null'), stderr=subprocess.PIPE, stdout=subprocess.PIPE)
+    (out, err) = p.communicate()
 
-    if p.wait() == 0:
+    if p.returncode == 0:
         if sys.version_info[0] > 2:
-            return p.stderr.read().rstrip().decode()
-        return p.stderr.read().rstrip()
+            return err.rstrip().decode()
+        return err.rstrip()
     else:
         return None
 


### PR DESCRIPTION
When  using`stderr=subprocess.PIPE, stdout=subprocess.PIPE`, you can (will) deadlock on install of uwsgi from source if one of the output pipes fills up before the process exits. (In fact, it does just that on my system: hangs forever because clang is blocking trying to write to a full stderr pipe).