### PR TITLE
Fixed logging issue - size of package shown as negative value

### DIFF
--- a/core/logging.c
+++ b/core/logging.c
@@ -1128,19 +1128,18 @@ static ssize_t uwsgi_lf_status(struct wsgi_request *wsgi_req, char **buf) {
 	return strlen(*buf);
 }
 
-
 static ssize_t uwsgi_lf_rsize(struct wsgi_request *wsgi_req, char **buf) {
-	*buf = uwsgi_num2str(wsgi_req->response_size);
+	*buf = uwsgi_size2str(wsgi_req->response_size);
 	return strlen(*buf);
 }
 
 static ssize_t uwsgi_lf_hsize(struct wsgi_request *wsgi_req, char **buf) {
-	*buf = uwsgi_num2str(wsgi_req->headers_size);
+	*buf = uwsgi_size2str(wsgi_req->headers_size);
 	return strlen(*buf);
 }
 
 static ssize_t uwsgi_lf_size(struct wsgi_request *wsgi_req, char **buf) {
-	*buf = uwsgi_num2str(wsgi_req->headers_size+wsgi_req->response_size);
+	*buf = uwsgi_size2str(wsgi_req->headers_size+wsgi_req->response_size);
 	return strlen(*buf);
 }
 

--- a/core/utils.c
+++ b/core/utils.c
@@ -1948,6 +1948,12 @@ char *uwsgi_64bit2str(int64_t num) {
 	return str;
 }
 
+char *uwsgi_size2str(size_t num) {
+	char *str = uwsgi_malloc(sizeof(UMAX64_STR) + 1);
+	snprintf(str, sizeof(UMAX64_STR) + 1, "%llu", (unsigned long long) num);
+	return str;	
+}
+
 int uwsgi_num2str2(int num, char *ptr) {
 
 	return snprintf(ptr, 11, "%d", num);

--- a/uwsgi.h
+++ b/uwsgi.h
@@ -3487,6 +3487,7 @@ void emperor_loop(void);
 char *uwsgi_num2str(int);
 char *uwsgi_float2str(float);
 char *uwsgi_64bit2str(int64_t);
+char *uwsgi_size2str(size_t);
 
 char *magic_sub(char *, size_t, size_t *, char *[]);
 void init_magic_table(char *[]);


### PR DESCRIPTION
* Fixed logging issue - size of package shown as negative value when it was greater than INT_MAX

* uwsgi_size2str(size_t) method refactored