### PR TITLE
Correctly handle SERVER_PORT for IPv6 sockets

### DIFF
--- a/proto/http.c
+++ b/proto/http.c
@@ -311,7 +311,7 @@ static int http_parse(struct wsgi_request *wsgi_req, char *watermark) {
                 }
 	}
 	else {
-		char *server_port = strchr(wsgi_req->socket->name, ':');
+		char *server_port = strrchr(wsgi_req->socket->name, ':');
 		if (server_port) {
 			wsgi_req->len += proto_base_add_uwsgi_var(wsgi_req, "SERVER_PORT", 11, server_port+1, strlen(server_port+1));
 		}


### PR DESCRIPTION
When listening in IPv6, `wsgi_req->socket->name` may contain multiple `:` characters: the ones from the IPv6 address and the port separator. The current code looks for the first `:` in the string and takes the second part as the port, which is wrong. With `http-socket = [fd00::1:2345]:8100`, it would return `:1:2345]:8100`. 

We need to find the last `:` in the string instead, i.e. the first one backwards.