### PR TITLE
fix execfile error in py3

### DIFF
--- a/uwsgiconfig.py
+++ b/uwsgiconfig.py
@@ -1396,7 +1396,8 @@ try:
 except NameError:
     def execfile(path, up):
         with open(path) as py:
-            code = __builtins__.compile(py.read(), path, 'exec')
+            import builtins
+            code = builtins.compile(py.read(), path, 'exec')
         exec(code, up)
 
 


### PR DESCRIPTION
If it's not in `__main__`, then `__builtins__` is `__builtin__.__dict__`