### PR TITLE
cffi + asgi

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,7 @@ core/dot_h.c
 /uWSGI.egg-info/
 check/check_*
 !check/*.c
+
+.vscode
+/plugins/cffi/_*
+/plugins/cffi/cffi_plugin.c

--- a/plugins/cffi/Makefile
+++ b/plugins/cffi/Makefile
@@ -1,7 +1,7 @@
-cffi_plugin.c: cffi_plugin.py cffi_init.py uwsgiplugin.py constants.h _uwsgi.h types.h
+cffi_plugin.c: cffi_plugin.py cffi_init.py uwsgiplugin.py _constants.h _uwsgi.h types.h
 	python cffi_plugin.py
 
-constants.h: ../../uwsgi.h constants.py
+_constants.h: ../../uwsgi.h constants.py
 	python constants.py
 
 _uwsgi_preprocessed.h: ../../uwsgi.h

--- a/plugins/cffi/Makefile
+++ b/plugins/cffi/Makefile
@@ -1,0 +1,14 @@
+cffi_plugin.c: cffi_plugin.py cffi_init.py uwsgiplugin.py constants.h _uwsgi.h types.h
+	python cffi_plugin.py
+
+constants.h: ../../uwsgi.h constants.py
+	python constants.py
+
+_uwsgi_preprocessed.h: ../../uwsgi.h
+	cat ../../uwsgi.h | gcc -E - -D "__attribute__(x)"= > _uwsgi_preprocessed.h
+
+_uwsgi.h: _uwsgi_preprocessed.h filtercdefs.py
+	 python filtercdefs.py _uwsgi_preprocessed.h > _uwsgi.h
+
+clean:
+	rm _uwsgi.h _uwsgi_preprocessed.h constants.h cffi_plugin.c

--- a/plugins/cffi/Makefile
+++ b/plugins/cffi/Makefile
@@ -11,4 +11,4 @@ _uwsgi.h: _uwsgi_preprocessed.h filtercdefs.py
 	 python filtercdefs.py _uwsgi_preprocessed.h > _uwsgi.h
 
 clean:
-	rm _uwsgi.h _uwsgi_preprocessed.h constants.h cffi_plugin.c
+	rm _uwsgi.h _uwsgi_preprocessed.h _constants.h cffi_plugin.c

--- a/plugins/cffi/cffi_asyncio.py
+++ b/plugins/cffi/cffi_asyncio.py
@@ -1,0 +1,333 @@
+"""
+Direct port of plugins/asyncio.c
+"""
+
+import sys
+import asyncio
+
+from _uwsgi import ffi, lib
+
+uwsgi = lib.uwsgi
+
+
+def print(*values):
+    lib.uwsgi_log(" ".join(str(v) for v in values).encode("utf-8") + b"\n")
+
+
+def get_loop():
+    return asyncio.get_event_loop()
+
+
+# testing
+def request_id():
+    return (
+        lib.uwsgi.workers[lib.uwsgi.mywid].cores[lib.uwsgi.wsgi_req.async_id].requests
+    )
+
+
+# keep alive
+_ASYNCIO = ffi.new("char[]", "asyncio".encode("utf-8"))
+
+timeout_handles = {}  # or array with # of cores?
+
+ob_timeout_counter = 0
+
+
+def store_ob_timeout(wsgi_req, ob_timeout):
+    global ob_timeout_counter
+    # TODO check if wsgi_req.async_id is consistent enough for us
+    ob_timeout_counter += 1
+    wsgi_req.async_timeout = ffi.cast("struct uwsgi_rb_timer *", ob_timeout_counter)
+    timeout_handles[ob_timeout_counter] = ob_timeout
+
+
+def get_ob_timeout(wsgi_req):
+    ob_timeout_ = ffi.cast("ssize_t", wsgi_req.async_timeout)
+    wsgi_req.async_timeout = ffi.NULL
+    return timeout_handles.pop(ob_timeout_)
+
+
+def print_exc():
+    import traceback
+
+    traceback.print_exc()
+
+
+def setup_asyncio(threads):
+    setattr(uwsgi, "async", threads)  # keyword
+    if uwsgi.socket_timeout < 30:
+        uwsgi.socket_timeout = 30
+
+    uwsgi.loop = _ASYNCIO
+
+
+def free_req_queue(wsgi_req):
+    """
+    A #define that uses wsgi_req from context.
+    #define free_req_queue uwsgi.async_queue_unused_ptr++; uwsgi.async_queue_unused[uwsgi.async_queue_unused_ptr] = wsgi_req
+    """
+    lib.uwsgi.async_queue_unused_ptr = lib.uwsgi.async_queue_unused_ptr + 1
+    lib.uwsgi.async_queue_unused[lib.uwsgi.async_queue_unused_ptr] = wsgi_req
+    print("free_req_queue", lib.uwsgi.async_queue_unused_ptr, wsgi_req)
+
+
+@ffi.def_extern()
+def uwsgi_asyncio_wait_read_hook(fd, timeout):
+    print("enter read hook")
+    wsgi_req = uwsgi.current_wsgi_req()
+    loop = get_loop()
+    loop.add_reader(fd, uwsgi_asyncio_hook_fd, wsgi_req)
+    try:
+        ob_timeout = loop.call_later(timeout, hook_timeout, wsgi_req)
+        try:
+
+            # to loop
+            if uwsgi.schedule_to_main:
+                print("wait_read_hook", fd)
+                uwsgi.schedule_to_main(wsgi_req)
+            else:
+                print("no read hook", uwsgi.schedule_to_mani)
+            # from loop
+        finally:
+            ob_timeout.cancel()
+
+        if wsgi_req.async_timed_out:
+            return 0
+
+        return 1
+
+    except:
+        print_exc()
+        return -1
+
+    finally:
+        # returns False if not added
+        loop.remove_reader(fd)
+
+
+@ffi.def_extern()
+def uwsgi_asyncio_wait_write_hook(fd, timeout):
+    print("enter write hook")
+    wsgi_req = uwsgi.current_wsgi_req()
+    loop = get_loop()
+    loop.add_writer(fd, uwsgi_asyncio_hook_fd, wsgi_req)
+    try:
+        ob_timeout = loop.call_later(timeout, hook_timeout, wsgi_req)
+        try:
+            # to loop
+            if uwsgi.schedule_to_main:
+                print("wait_write_hook", fd)
+                uwsgi.schedule_to_main(wsgi_req)
+            # from loop
+
+        finally:
+            ob_timeout.cancel()
+
+        if wsgi_req.async_timed_out:
+            return 0
+
+        return 1
+
+    except:
+        print_exc()
+        return -1
+
+    finally:
+        loop.remove_writer(fd)
+
+
+def find_first_available_wsgi_req():
+    uwsgi = lib.uwsgi
+    wsgi_req = lib.find_first_available_wsgi_req()
+    print("accept wsgi_req", uwsgi.async_queue_unused_ptr, wsgi_req)
+    return wsgi_req
+
+
+def uwsgi_asyncio_request(wsgi_req, timed_out):
+    try:
+        loop = get_loop()
+        uwsgi.wsgi_req = wsgi_req
+
+        ob_timeout = get_ob_timeout(wsgi_req)
+        ob_timeout.cancel()
+
+        if timed_out > 0:
+            loop.remove_reader(wsgi_req.fd)
+            raise IOError("timed out")  # goto end
+
+        status = wsgi_req.socket.proto(wsgi_req)
+        print("status", status)
+
+        if status > 0:
+            ob_timeout = loop.call_later(
+                uwsgi.socket_timeout, uwsgi_asyncio_request, wsgi_req, True
+            )
+            store_ob_timeout(wsgi_req, ob_timeout)
+            # goto again
+            print("again a", request_id())
+            return None
+
+        else:
+            loop.remove_reader(wsgi_req.fd)
+
+            if status == 0:
+                # we call this two time... overengineering :(
+                uwsgi.async_proto_fd_table[wsgi_req.fd] = ffi.NULL
+                uwsgi.schedule_to_req()
+                # goto again
+                print("again b", request_id())
+                return None
+
+    except IOError:
+        loop.remove_reader(wsgi_req.fd)
+        print_exc()
+
+    except:
+        print("other exception")
+        print_exc()
+
+    # end
+    r_id = request_id()
+    print("normal request end {", r_id)
+    uwsgi.async_proto_fd_table[wsgi_req.fd] = ffi.NULL
+    lib.uwsgi_close_request(uwsgi.wsgi_req)
+    free_req_queue(wsgi_req)
+    print("} normal request end", r_id)
+
+
+def uwsgi_asyncio_accept(uwsgi_sock):
+    uwsgi = lib.uwsgi
+    wsgi_req = find_first_available_wsgi_req()
+    if wsgi_req == ffi.NULL:
+        lib.uwsgi_async_queue_is_full(lib.uwsgi_now())
+        print("queue is full")
+        return None
+
+    uwsgi.wsgi_req = wsgi_req
+    lib.wsgi_req_setup(wsgi_req, wsgi_req.async_id, uwsgi_sock)
+    uwsgi.workers[uwsgi.mywid].cores[wsgi_req.async_id].in_request = 1
+
+    if lib.wsgi_req_simple_accept(wsgi_req, uwsgi_sock.fd):
+        uwsgi.workers[uwsgi.mywid].cores[wsgi_req.async_id].in_request = 0
+        free_req_queue(wsgi_req)
+        print("no accept")
+        return None
+
+    wsgi_req.start_of_request = lib.uwsgi_micros()
+    wsgi_req.start_of_request_in_sec = wsgi_req.start_of_request // 1000000
+
+    # enter harakiri mode
+    if uwsgi.harakiri_options.workers > 0:
+        lib.set_harakiri(wsgi_req, uwsgi.harakiri_options.workers)
+
+    uwsgi.async_proto_fd_table[wsgi_req.fd] = wsgi_req
+
+    loop = get_loop()
+
+    # add callback for protocol
+    try:
+        loop.add_reader(wsgi_req.fd, uwsgi_asyncio_request, wsgi_req, False)
+        ob_timeout = loop.call_later(
+            uwsgi.socket_timeout, uwsgi_asyncio_request, wsgi_req, True
+        )
+        store_ob_timeout(wsgi_req, ob_timeout)
+
+    except:
+        loop.remove_reader(wsgi_req.fd)
+        free_req_queue(wsgi_req)
+        print_exc()
+        raise
+
+
+def uwsgi_asyncio_hook_fd(wsgi_req):
+    uwsgi = lib.uwsgi
+    print("hook fd", wsgi_req.fd)
+    uwsgi.wsgi_req = wsgi_req
+    uwsgi.schedule_to_req()
+
+
+def uwsgi_asyncio_hook_timeout(wsgi_req):
+    uwsgi = lib.uwsgi
+    print("timeout hook", wsgi_req.fd)
+    uwssgi.wsgi_req = wsgi_req
+    uwsgi.wsgi_req.async_timed_out = 1
+    uwsgi.schedule_to_req()
+
+
+def uwsgi_asyncio_hook_fix(wsgi_req):
+    print("fix hook", wsgi_req.fd)
+    uwsgi.wsgi_req = wsgi_req
+    uwsgi.schedule_to_req()
+
+
+@ffi.def_extern()
+def uwsgi_asyncio_schedule_fix(wsgi_req):
+    if wsgi_req:
+        print("fix schedule", wsgi_req.fd)
+    print("schedule_fix")
+    loop = get_loop()
+    loop.call_soon(uwsgi_asyncio_hook_fix, wsgi_req)
+
+
+@ffi.def_extern()
+def asyncio_loop():
+    """
+    Set up asyncio.
+    """
+
+    if not uwsgi.has_threads and uwsgi.mywid == 1:
+        print(
+            "!!! Running asyncio without threads IS NOT recommended, enable "
+            "them with --enable-threads !!!\n"
+        )
+
+    if uwsgi.socket_timeout < 30:
+        print(
+            "!!! Running asyncio with a socket-timeout lower than 30 seconds "
+            "is not recommended, tune it with --socket-timeout !!!\n"
+        )
+
+    if not uwsgi.async_waiting_fd_table:
+        uwsgi.async_waiting_fd_table = lib.uwsgi_calloc(
+            ffi.sizeof("struct wsgi_request *") * uwsgi.max_fd
+        )
+    if not uwsgi.async_proto_fd_table:
+        uwsgi.async_proto_fd_table = lib.uwsgi_calloc(
+            ffi.sizeof("struct wsgi_request *") * uwsgi.max_fd
+        )
+
+    uwsgi.wait_write_hook = lib.uwsgi_asyncio_wait_write_hook
+    uwsgi.wait_read_hook = lib.uwsgi_asyncio_wait_read_hook
+
+    assert lib.uwsgi.wait_write_hook == lib.uwsgi_asyncio_wait_write_hook
+
+    if getattr(uwsgi, "async") < 1:  # keyword
+        print("the async loop engine requires async mode (--async <n>)\n")
+        raise SystemExit(1)
+
+    if not uwsgi.schedule_to_main:
+        print(
+            "*** DANGER *** async mode without coroutine/greenthread engine loaded !!!\n"
+        )
+
+    # call uwsgi_cffi_setup_greenlets() first:
+    if not uwsgi.schedule_to_req:
+        print("set schedule_to_req")
+        uwsgi.schedule_to_req = lib.async_schedule_to_req
+    else:
+        print("set schedule_fix")
+        uwsgi.schedule_fix = lib.uwsgi_asyncio_schedule_fix
+
+    loop = get_loop()
+    uwsgi_sock = uwsgi.sockets
+    while uwsgi_sock != ffi.NULL:
+        sockname = ffi.string(uwsgi_sock.name, uwsgi_sock.name_len).decode("utf-8")
+        print(f"sock {sockname} fd {uwsgi_sock.fd}")
+        loop.add_reader(uwsgi_sock.fd, uwsgi_asyncio_accept, uwsgi_sock)
+        uwsgi_sock = uwsgi_sock.next
+
+    loop.run_forever()
+
+
+def async_init():
+    lib.uwsgi_register_loop(_ASYNCIO, lib.asyncio_loop)

--- a/plugins/cffi/cffi_asyncio.py
+++ b/plugins/cffi/cffi_asyncio.py
@@ -2,12 +2,15 @@
 Direct port of plugins/asyncio.c
 """
 
+import os
 import sys
 import asyncio
 
 from _uwsgi import ffi, lib
 
 uwsgi = lib.uwsgi
+
+wsgi_apps = sys.modules["wsgi_apps"]  # hack
 
 
 def print(*values):
@@ -144,6 +147,7 @@ def find_first_available_wsgi_req():
 
 
 def uwsgi_asyncio_request(wsgi_req, timed_out):
+    print("uwsgi_asyncio_request")
     try:
         loop = get_loop()
         uwsgi.wsgi_req = wsgi_req
@@ -157,6 +161,8 @@ def uwsgi_asyncio_request(wsgi_req, timed_out):
 
         status = wsgi_req.socket.proto(wsgi_req)
         print("status", status)
+
+        print("edge trigger", wsgi_req.socket.edge_trigger)
 
         if status > 0:
             ob_timeout = loop.call_later(
@@ -233,6 +239,7 @@ def uwsgi_asyncio_accept(uwsgi_sock):
         store_ob_timeout(wsgi_req, ob_timeout)
 
     except:
+        print("loop exception")
         loop.remove_reader(wsgi_req.fd)
         free_req_queue(wsgi_req)
         print_exc()
@@ -327,6 +334,255 @@ def asyncio_loop():
         uwsgi_sock = uwsgi_sock.next
 
     loop.run_forever()
+
+
+class WSGIfilewrapper(object):
+    """
+    class implementing wsgi.file_wrapper
+    """
+
+    def __init__(self, wsgi_req, f, chunksize=0):
+        self.wsgi_req = wsgi_req
+        self.f = f
+        self.chunksize = chunksize
+        if hasattr(f, "close"):
+            self.close = f.close
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        if self.chunksize:
+            data = self.f.read(self.chunksize)
+        else:
+            data = self.f.read()
+        if data:
+            return data
+        raise StopIteration()
+
+    next = __next__
+
+    def sendfile(self):
+        if hasattr(self.f, "fileno"):
+            lib.uwsgi_response_sendfile_do_can_close(
+                self.wsgi_req, self.f.fileno(), 0, 0, 0
+            )
+        elif hasattr(self.f, "read"):
+            if self.chunksize == 0:
+                chunk = self.f.read()
+                if len(chunk) > 0:
+                    lib.uwsgi_response_write_body_do(
+                        self.wsgi_req, ffi.new("char[]", chunk), len(chunk)
+                    )
+                return
+            while True:
+                chunk = self.f.read(self.chunksize)
+                if chunk is None or len(chunk) == 0:
+                    break
+                lib.uwsgi_response_write_body_do(
+                    self.wsgi_req, ffi.new("char[]", chunk), len(chunk)
+                )
+
+
+class WSGIinput(object):
+    """
+    class implementing wsgi.input
+    """
+
+    def __init__(self, wsgi_req):
+        self.wsgi_req = wsgi_req
+
+    def read(self, size=0):
+        rlen = ffi.new("ssize_t*")
+        chunk = lib.uwsgi_request_body_read(self.wsgi_req, size, rlen)
+        if chunk != ffi.NULL:
+            return ffi.buffer(chunk, rlen[0])[:]
+        if rlen[0] < 0:
+            raise IOError("error reading wsgi.input")
+        raise IOError("error waiting for wsgi.input")
+
+    def getline(self, hint=0):
+        rlen = ffi.new("ssize_t*")
+        chunk = lib.uwsgi_request_body_readline(self.wsgi_req, hint, rlen)
+        if chunk != ffi.NULL:
+            return ffi.buffer(chunk, rlen[0])[:]
+        if rlen[0] < 0:
+            raise IOError("error reading line from wsgi.input")
+        raise IOError("error waiting for line on wsgi.input")
+
+    def readline(self, hint=0):
+        return self.getline(hint)
+
+    def readlines(self, hint=0):
+        lines = []
+        while True:
+            chunk = self.getline(hint)
+            if len(chunk) == 0:
+                break
+            lines.append(chunk)
+        return lines
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        chunk = self.getline()
+        if len(chunk) == 0:
+            raise StopIteration
+        return chunk
+
+
+def to_network(native):
+    return native.encode("latin1")
+
+
+@ffi.def_extern()
+def uwsgi_cffi_request(wsgi_req):
+    """
+    the WSGI request handler
+    """
+
+    # if (wsgi_req->async_force_again) {
+    # 	wi = &uwsgi_apps[wsgi_req->app_id];
+    # 	wsgi_req->async_force_again = 0;
+    # 	UWSGI_GET_GIL
+    # 	// get rid of timeout
+    # 	if (wsgi_req->async_timed_out) {
+    # 		PyDict_SetItemString(wsgi_req->async_environ, "x-wsgiorg.fdevent.timeout", Py_True);
+    # 		wsgi_req->async_timed_out = 0;
+    # 	}
+    # 	else {
+    # 		PyDict_SetItemString(wsgi_req->async_environ, "x-wsgiorg.fdevent.timeout", Py_None);
+    # 	}
+
+    # 	if (wsgi_req->async_ready_fd) {
+    # 		PyDict_SetItemString(wsgi_req->async_environ, "uwsgi.ready_fd", PyInt_FromLong(wsgi_req->async_last_ready_fd));
+    # 		wsgi_req->async_ready_fd = 0;
+    # 	}
+    # 	else {
+    # 		PyDict_SetItemString(wsgi_req->async_environ, "uwsgi.ready_fd", Py_None);
+    # 	}
+    # 	int ret = manage_python_response(wsgi_req);
+    # 	if (ret == UWSGI_OK) goto end;
+    # 	UWSGI_RELEASE_GIL
+    # 	if (ret == UWSGI_AGAIN) {
+    # 		wsgi_req->async_force_again = 1;
+    # 	}
+    # 	return ret;
+    # }
+
+    if wsgi_req.async_force_again:
+        print("force again")
+        wsgi_req.async_force_again = 0
+        # just close it
+        try:
+            ob_timeout = get_ob_timeout(wsgi_req)
+            ob_timeout.cancel()
+        except KeyError:
+            pass
+        asyncio.get_event_loop().remove_reader(wsgi_req.fd)
+        return lib.UWSGI_OK
+
+    def writer(data):
+        lib.uwsgi_response_write_body_do(wsgi_req, ffi.new("char[]", data), len(data))
+
+    def start_response(status, headers, exc_info=None):
+        if exc_info:
+            traceback.print_exception(*exc_info)
+        status = to_network(status)
+        lib.uwsgi_response_prepare_headers(
+            wsgi_req, ffi.new("char[]", status), len(status)
+        )
+        for hh in headers:
+            header, value = to_network(hh[0]), to_network(hh[1])
+            lib.uwsgi_response_add_header(
+                wsgi_req,
+                ffi.new("char[]", header),
+                len(hh[0]),
+                ffi.new("char[]", value),
+                len(hh[1]),
+            )
+        return writer
+
+    if lib.uwsgi_parse_vars(wsgi_req):
+        return -1
+
+    # check dynamic
+    # check app_id
+    app_id = lib.uwsgi_get_app_id(
+        wsgi_req, wsgi_req.appid, wsgi_req.appid_len, lib.cffi_plugin.modifier1
+    )
+    if app_id == -1 and not lib.uwsgi.no_default_app and lib.uwsgi.default_app > -1:
+        # and default app modifier1 == our modifier1
+        app_id = lib.uwsgi.default_app
+    wsgi_req.app_id = app_id
+    app_mount = ""
+    # app_mount can be something while app_id is -1
+    if wsgi_req.appid != ffi.NULL:
+        app_mount = ffi.string(wsgi_req.appid).decode("utf-8")
+    app = wsgi_apps.get(app_id)
+
+    # (see python wsgi_handlers.c)
+
+    environ = {}
+    iov = wsgi_req.hvec
+    for i in range(0, wsgi_req.var_cnt, 2):
+        environ[
+            ffi.string(ffi.cast("char*", iov[i].iov_base), iov[i].iov_len).decode(
+                "latin1"
+            )
+        ] = ffi.string(
+            ffi.cast("char*", iov[i + 1].iov_base), iov[i + 1].iov_len
+        ).decode(
+            "latin1"
+        )
+
+    # check bytes on environ...
+    environ["wsgi.version"] = (1, 0)
+    scheme = "http"
+    if "HTTPS" in environ:
+        if environ["HTTPS"] in ("on", "ON", "On", "1", "true", "TRUE", "True"):
+            scheme = "https"
+    environ["wsgi.url_scheme"] = environ.get("UWSGI_SCHEME", scheme)
+    environ["wsgi.input"] = WSGIinput(wsgi_req)
+    environ["wsgi.errors"] = sys.stderr
+    environ["wsgi.run_once"] = False
+    environ["wsgi.file_wrapper"] = lambda f, chunksize=0: WSGIfilewrapper(
+        wsgi_req, f, chunksize
+    )
+    environ["wsgi.multithread"] = True
+    environ["wsgi.multiprocess"] = True
+
+    environ["uwsgi.core"] = wsgi_req.async_id
+    environ["uwsgi.node"] = ffi.string(lib.uwsgi.hostname).decode("latin1")
+
+    try:
+        response = app(environ, start_response)
+    except:
+        print("app exception")
+        wsgi_req.async_force_again = 1
+        return lib.UWSGI_AGAIN
+
+    if type(response) is bytes:
+        writer(response)
+    else:
+        try:
+            if isinstance(response, WSGIfilewrapper):
+                response.sendfile()
+            else:
+                for chunk in response:
+                    if isinstance(chunk, WSGIfilewrapper):
+                        try:
+                            chunk.sendfile()
+                        finally:
+                            chunk.close()
+                    else:
+                        writer(chunk)
+        finally:
+            if hasattr(response, "close"):
+                response.close()
+
+    return lib.UWSGI_OK
 
 
 def async_init():

--- a/plugins/cffi/cffi_dyn_init.py
+++ b/plugins/cffi/cffi_dyn_init.py
@@ -1,0 +1,11 @@
+"""
+cffi init, not baked into .so
+"""
+
+from _uwsgi import ffi, lib
+
+
+@ffi.def_extern()
+def uwsgi_cffi_after_request(wsgi_req):
+    print("overridden callback!")
+    lib.log_request(wsgi_req)

--- a/plugins/cffi/cffi_greenlets.py
+++ b/plugins/cffi/cffi_greenlets.py
@@ -87,6 +87,8 @@ def uwsgi_pypy_greenlet_current_wsgi_req():
 def not_cffi(modifier1):
     """
     Is the request related to our plugin?
+
+    Used in some versions of the uwsgi loop. Not sure why.
     """
     return ffi.string(lib.uwsgi.p[modifier1].name) != b"cffi"
 

--- a/plugins/cffi/cffi_greenlets.py
+++ b/plugins/cffi/cffi_greenlets.py
@@ -1,0 +1,146 @@
+"""
+Greenlets and continulets support; pick one.
+"""
+
+from _uwsgi import ffi, lib
+
+# this is the dictionary of continulets (one per-core)
+uwsgi_pypy_continulets = {}
+
+
+def uwsgi_pypy_continulet_wrapper(cont):
+    lib.async_schedule_to_req_green()
+
+
+@ffi.def_extern()
+def uwsgi_pypy_continulet_schedule():
+    id = lib.uwsgi.wsgi_req.async_id
+    modifier1 = lib.uwsgi.wsgi_req.uh.modifier1
+
+    # generate a new continulet
+    if not lib.uwsgi.wsgi_req.suspended:
+        from _continuation import continulet
+
+        uwsgi_pypy_continulets[id] = continulet(uwsgi_pypy_continulet_wrapper)
+        lib.uwsgi.wsgi_req.suspended = 1
+
+    # this is called in the main stack
+    if lib.uwsgi.p[modifier1].suspend:
+        lib.uwsgi.p[modifier1].suspend(ffi.NULL)
+
+    # let's switch
+    uwsgi_pypy_continulets[id].switch()
+
+    # back to the main stack
+    if lib.uwsgi.p[modifier1].resume:
+        lib.uwsgi.p[modifier1].resume(ffi.NULL)
+
+
+@ffi.def_extern()
+def uwsgi_pypy_continulet_switch(wsgi_req):
+    id = wsgi_req.async_id
+    modifier1 = wsgi_req.uh.modifier1
+
+    # this is called in the current continulet
+    if lib.uwsgi.p[modifier1].suspend:
+        lib.uwsgi.p[modifier1].suspend(wsgi_req)
+
+    uwsgi_pypy_continulets[id].switch()
+
+    # back to the continulet
+    if lib.uwsgi.p[modifier1].resume:
+        lib.uwsgi.p[modifier1].resume(wsgi_req)
+
+    # update current running continulet
+    lib.uwsgi.wsgi_req = wsgi_req
+
+
+def uwsgi_pypy_setup_continulets():
+    if getattr(lib.uwsgi, "async") < 1:  # keyword
+        raise Exception("pypy continulets require async mode !!!")
+    lib.uwsgi.schedule_to_main = lib.uwsgi_pypy_continulet_switch
+    lib.uwsgi.schedule_to_req = lib.uwsgi_pypy_continulet_schedule
+    print("*** PyPy Continulets engine loaded ***")
+
+
+# Greenlets support
+# May prefer to continulets.
+# Built in to pypy (built on top of continulets)
+
+uwsgi_pypy_greenlets = {}
+
+
+def uwsgi_pypy_greenlet_wrapper():
+    lib.async_schedule_to_req_green()
+
+
+@ffi.def_extern()
+def uwsgi_pypy_greenlet_current_wsgi_req():
+    try:
+        return greenlet.getcurrent().uwsgi_wsgi_req
+    except AttributeError:
+        lib.uwsgi_log(b"[BUG] current_wsgi_req NOT FOUND!!!\n")
+        return lib.uwsgi.wsgi_req  # called early once?
+    return ffi.NULL
+
+
+def not_cffi(modifier1):
+    """
+    Is the request related to our plugin?
+    """
+    return ffi.string(lib.uwsgi.p[modifier1].name) != b"cffi"
+
+
+@ffi.def_extern()
+def uwsgi_pypy_greenlet_schedule_to_req():
+    id = lib.uwsgi.wsgi_req.async_id
+    modifier1 = lib.uwsgi.wsgi_req.uh.modifier1
+
+    # generate a new greenlet
+    if not lib.uwsgi.wsgi_req.suspended:
+        uwsgi_pypy_greenlets[id] = greenlet.greenlet(uwsgi_pypy_greenlet_wrapper)
+        uwsgi_pypy_greenlets[id].uwsgi_wsgi_req = lib.uwsgi.wsgi_req
+        lib.uwsgi.wsgi_req.suspended = 1
+
+    # this is called in the main stack
+    if not_cffi(modifier1) and lib.uwsgi.p[modifier1].suspend:
+        lib.uwsgi.p[modifier1].suspend(ffi.NULL)
+
+    # let's switch
+    uwsgi_pypy_greenlets[id].switch()
+
+    # back to the main stack
+    if not_cffi(modifier1) and lib.uwsgi.p[modifier1].resume:
+        lib.uwsgi.p[modifier1].resume(ffi.NULL)
+
+
+@ffi.def_extern()
+def uwsgi_pypy_greenlet_schedule_to_main(wsgi_req):
+    wsgi_req.async_id
+    modifier1 = wsgi_req.uh.modifier1
+
+    # this is called in the current greenlet
+    if not_cffi(modifier1) and lib.uwsgi.p[modifier1].suspend:
+        lib.uwsgi.p[modifier1].suspend(wsgi_req)
+
+    uwsgi_pypy_main_greenlet.switch()
+
+    # back to the greenlet
+    if not_cffi(modifier1) and lib.uwsgi.p[modifier1].resume:
+        lib.uwsgi.p[modifier1].resume(wsgi_req)
+
+    # update current running greenlet
+    lib.uwsgi.wsgi_req = wsgi_req
+
+
+def uwsgi_cffi_setup_greenlets():
+    global greenlet, uwsgi_pypy_main_greenlet
+    import greenlet
+
+    if getattr(lib.uwsgi, "async") < 1:
+        raise Exception("pypy greenlets require async mode !!!")
+
+    lib.uwsgi.schedule_to_main = lib.uwsgi_pypy_greenlet_schedule_to_main
+    lib.uwsgi.schedule_to_req = lib.uwsgi_pypy_greenlet_schedule_to_req
+    lib.uwsgi.current_wsgi_req = lib.uwsgi_pypy_greenlet_current_wsgi_req
+    uwsgi_pypy_main_greenlet = greenlet.getcurrent()

--- a/plugins/cffi/cffi_init.py
+++ b/plugins/cffi/cffi_init.py
@@ -1,0 +1,291 @@
+"""
+cffi embedding API based Python plugin, based on pypy plugin.
+
+Should work with both CPython and PyPy in theory.
+"""
+
+import importlib
+import sys
+import os
+
+import cffi_plugin
+
+from cffi_plugin import ffi, lib
+from cffi_plugin.lib import *
+
+# predictable name
+sys.modules["_uwsgi"] = cffi_plugin
+
+
+def to_network(native):
+    return native.encode("latin1")
+
+
+class WSGIfilewrapper(object):
+    """
+    class implementing wsgi.file_wrapper
+    """
+
+    def __init__(self, wsgi_req, f, chunksize=0):
+        self.wsgi_req = wsgi_req
+        self.f = f
+        self.chunksize = chunksize
+        if hasattr(f, "close"):
+            self.close = f.close
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        if self.chunksize:
+            data = self.f.read(self.chunksize)
+        else:
+            data = self.f.read()
+        if data:
+            return data
+        raise StopIteration()
+
+    next = __next__
+
+    def sendfile(self):
+        if hasattr(self.f, "fileno"):
+            lib.uwsgi_response_sendfile_do_can_close(
+                self.wsgi_req, self.f.fileno(), 0, 0, 0
+            )
+        elif hasattr(self.f, "read"):
+            if self.chunksize == 0:
+                chunk = self.f.read()
+                if len(chunk) > 0:
+                    lib.uwsgi_response_write_body_do(
+                        self.wsgi_req, ffi.new("char[]", chunk), len(chunk)
+                    )
+                return
+            while True:
+                chunk = self.f.read(self.chunksize)
+                if chunk is None or len(chunk) == 0:
+                    break
+                lib.uwsgi_response_write_body_do(
+                    self.wsgi_req, ffi.new("char[]", chunk), len(chunk)
+                )
+
+
+class WSGIinput(object):
+    """
+    class implementing wsgi.input
+    """
+
+    def __init__(self, wsgi_req):
+        self.wsgi_req = wsgi_req
+
+    def read(self, size=0):
+        rlen = ffi.new("ssize_t*")
+        chunk = lib.uwsgi_request_body_read(self.wsgi_req, size, rlen)
+        if chunk != ffi.NULL:
+            return ffi.buffer(chunk, rlen[0])[:]
+        if rlen[0] < 0:
+            raise IOError("error reading wsgi.input")
+        raise IOError("error waiting for wsgi.input")
+
+    def getline(self, hint=0):
+        rlen = ffi.new("ssize_t*")
+        chunk = lib.uwsgi_request_body_readline(self.wsgi_req, hint, rlen)
+        if chunk != ffi.NULL:
+            return ffi.buffer(chunk, rlen[0])[:]
+        if rlen[0] < 0:
+            raise IOError("error reading line from wsgi.input")
+        raise IOError("error waiting for line on wsgi.input")
+
+    def readline(self, hint=0):
+        return self.getline(hint)
+
+    def readlines(self, hint=0):
+        lines = []
+        while True:
+            chunk = self.getline(hint)
+            if len(chunk) == 0:
+                break
+            lines.append(chunk)
+        return lines
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        chunk = self.getline()
+        if len(chunk) == 0:
+            raise StopIteration
+        return chunk
+
+
+@ffi.def_extern()
+def uwsgi_cffi_init():
+    # doesn't seem to use PYTHONPATH automatically
+    # pypy will find environment from current working directory
+    # (uwsgi --chdir $VIRTUAL_ENV/bin)
+    if "PYTHONPATH" in os.environ:
+        sys.path[0:0] = os.environ["PYTHONPATH"].split(os.pathsep)
+
+    # define or override callbacks
+    if lib.ucffi.init:
+        init_name = ffi.string(lib.ucffi.init).decode("utf-8")
+        importlib.import_module(init_name)
+
+    return lib.UWSGI_OK
+
+
+@ffi.def_extern()
+def uwsgi_cffi_init_apps():
+    # one app is required or uWSGI quits
+    uwsgi_cffi_more_apps()
+    if lib.ucffi.wsgi:
+        uwsgi_pypy_loader(ffi.string(lib.ucffi.wsgi).decode("utf-8"))
+
+
+@ffi.def_extern()
+def uwsgi_cffi_request(wsgi_req):
+    """
+    the WSGI request handler
+    """
+    global wsgi_application
+
+    def writer(data):
+        lib.uwsgi_response_write_body_do(wsgi_req, ffi.new("char[]", data), len(data))
+
+    def start_response(status, headers, exc_info=None):
+        if exc_info:
+            traceback.print_exception(*exc_info)
+        status = to_network(status)
+        lib.uwsgi_response_prepare_headers(
+            wsgi_req, ffi.new("char[]", status), len(status)
+        )
+        for hh in headers:
+            header, value = to_network(hh[0]), to_network(hh[1])
+            lib.uwsgi_response_add_header(
+                wsgi_req,
+                ffi.new("char[]", header),
+                len(hh[0]),
+                ffi.new("char[]", value),
+                len(hh[1]),
+            )
+        return writer
+
+    if lib.uwsgi_parse_vars(wsgi_req):
+        return -1
+
+    # check dynamic
+    # check app_id
+    # (see python wsgi_handlers.c)
+
+    environ = {}
+    iov = wsgi_req.hvec
+    for i in range(0, wsgi_req.var_cnt, 2):
+        environ[
+            ffi.string(ffi.cast("char*", iov[i].iov_base), iov[i].iov_len).decode(
+                "latin1"
+            )
+        ] = ffi.string(
+            ffi.cast("char*", iov[i + 1].iov_base), iov[i + 1].iov_len
+        ).decode(
+            "latin1"
+        )
+
+    # check bytes on environ...
+    environ["wsgi.version"] = (1, 0)
+    scheme = "http"
+    if "HTTPS" in environ:
+        if environ["HTTPS"] in ("on", "ON", "On", "1", "true", "TRUE", "True"):
+            scheme = "https"
+    environ["wsgi.url_scheme"] = environ.get("UWSGI_SCHEME", scheme)
+    environ["wsgi.input"] = WSGIinput(wsgi_req)
+    environ["wsgi.errors"] = sys.stderr
+    environ["wsgi.run_once"] = False
+    environ["wsgi.file_wrapper"] = lambda f, chunksize=0: WSGIfilewrapper(
+        wsgi_req, f, chunksize
+    )
+    environ["wsgi.multithread"] = True
+    environ["wsgi.multiprocess"] = True
+
+    environ["uwsgi.core"] = wsgi_req.async_id
+    environ["uwsgi.node"] = ffi.string(lib.uwsgi.hostname).decode("latin1")
+
+    response = wsgi_application(environ, start_response)
+    if type(response) is str:
+        writer(response)
+    else:
+        try:
+            if isinstance(response, WSGIfilewrapper):
+                response.sendfile()
+            else:
+                for chunk in response:
+                    if isinstance(chunk, WSGIfilewrapper):
+                        try:
+                            chunk.sendfile()
+                        finally:
+                            chunk.close()
+                    else:
+                        writer(chunk)
+        finally:
+            if hasattr(response, "close"):
+                response.close()
+
+    return lib.UWSGI_OK
+
+
+@ffi.def_extern()
+def uwsgi_cffi_after_request(wsgi_req):
+    lib.log_request(wsgi_req)
+
+
+@ffi.def_extern()
+def uwsgi_cffi_preinit_apps():
+    pass
+
+
+@ffi.def_extern()
+def uwsgi_cffi_post_fork():
+    pass
+
+
+@ffi.def_extern()
+def uwsgi_cffi_enable_threads():
+    pass
+
+
+@ffi.def_extern()
+def uwsgi_cffi_init_thread():
+    pass
+
+
+@ffi.def_extern()
+def uwsgi_cffi_signal_handler(sig, handler):
+    ffi.from_handle(handler)(sig)
+    return 0
+
+
+@ffi.def_extern()
+def uwsgi_cffi_mule(opt):
+    opt = ffi.string(opt).decode("latin1")
+
+
+@ffi.def_extern()
+def uwsgi_cffi_rpc(func, argc, argv, argvs, buffer):
+    return ffi.from_handle(func)(argc, argv, argvs, buffer)
+
+
+#
+# Non-callback section
+#
+
+wsgi_application = None
+
+
+def uwsgi_pypy_loader(m):
+    """
+    load a wsgi module
+    """
+    global wsgi_application
+    c = "application"
+    if ":" in m:
+        m, c = m.split(":")
+    mod = importlib.import_module(m)
+    wsgi_application = getattr(mod, c)

--- a/plugins/cffi/cffi_plugin.py
+++ b/plugins/cffi/cffi_plugin.py
@@ -21,6 +21,11 @@ ffibuilder.cdef(
     plugin_data
     + """
 void uwsgi_cffi_more_apps();
+
+// libc functions
+ssize_t read (int, void *, size_t);
+ssize_t write (int, const void *, size_t);
+void free(void *);
 """
     # For cffi_asyncio.
     # Bound to Python code with @ffi.def_extern().
@@ -57,6 +62,7 @@ static void uwsgi_cffi_post_fork();
 static void uwsgi_cffi_enable_threads();
 static void uwsgi_cffi_init_thread();
 static int uwsgi_cffi_mule(char *opt);
+static int uwsgi_cffi_mule_msg(char *message, size_t len);
 static int uwsgi_cffi_signal_handler(uint8_t sig, void *handler);
 
 static int uwsgi_cffi_mount_app(char *, char *);
@@ -100,6 +106,7 @@ CFFI_DLLEXPORT struct uwsgi_plugin cffi_plugin = {
     .rpc = uwsgi_cffi_rpc,
     .post_fork = uwsgi_cffi_post_fork,
     .mule = uwsgi_cffi_mule,
+    .mule_msg = uwsgi_cffi_mule_msg,
 };
 """,
 )

--- a/plugins/cffi/cffi_plugin.py
+++ b/plugins/cffi/cffi_plugin.py
@@ -6,7 +6,7 @@ ffibuilder = cffi.FFI()
 
 # cdef() exposes uwsgi functions to Python
 ffibuilder.cdef(open("types.h").read())
-ffibuilder.cdef(open("constants.h").read())
+ffibuilder.cdef(open("_constants.h").read())
 ffibuilder.cdef(open("_uwsgi.h").read())
 
 plugin_data = """

--- a/plugins/cffi/cffi_plugin.py
+++ b/plugins/cffi/cffi_plugin.py
@@ -10,7 +10,7 @@ ffibuilder.cdef(open("constants.h").read())
 ffibuilder.cdef(open("_uwsgi.h").read())
 
 plugin_data = """
-struct uwsgi_cffi {
+static struct uwsgi_cffi {
 	char *wsgi;
     char *init;
 } ucffi;
@@ -43,6 +43,7 @@ extern "Python" static void asyncio_loop(void);
 # as well as our Python code:
 exposed_to_uwsgi = """
 extern struct uwsgi_server uwsgi;
+extern struct uwsgi_plugin cffi_plugin;
 
 static int uwsgi_cffi_init();
 static void uwsgi_cffi_preinit_apps();
@@ -57,6 +58,8 @@ static void uwsgi_cffi_enable_threads();
 static void uwsgi_cffi_init_thread();
 static int uwsgi_cffi_mule(char *opt);
 static int uwsgi_cffi_signal_handler(uint8_t sig, void *handler);
+
+static int uwsgi_cffi_mount_app(char *, char *);
 """
 ffibuilder.embedding_api(exposed_to_uwsgi)
 
@@ -92,10 +95,11 @@ CFFI_DLLEXPORT struct uwsgi_plugin cffi_plugin = {
     .init_apps = uwsgi_cffi_init_apps,
     .init_thread = uwsgi_cffi_init_thread,
     .signal_handler = uwsgi_cffi_signal_handler,
+    .mount_app = uwsgi_cffi_mount_app,
     .enable_threads = uwsgi_cffi_enable_threads,
     .rpc = uwsgi_cffi_rpc,
     .post_fork = uwsgi_cffi_post_fork,
-    .mule = uwsgi_cffi_mule
+    .mule = uwsgi_cffi_mule,
 };
 """,
 )

--- a/plugins/cffi/cffi_plugin.py
+++ b/plugins/cffi/cffi_plugin.py
@@ -1,0 +1,104 @@
+# based on the example and pypy plugins
+
+import cffi
+
+ffibuilder = cffi.FFI()
+
+# cdef() exposes uwsgi functions to Python
+ffibuilder.cdef(open("types.h").read())
+ffibuilder.cdef(open("constants.h").read())
+ffibuilder.cdef(open("_uwsgi.h").read())
+
+plugin_data = """
+struct uwsgi_cffi {
+	char *wsgi;
+    char *init;
+} ucffi;
+"""
+
+# defined by our plugin
+ffibuilder.cdef(
+    plugin_data
+    + """
+void uwsgi_cffi_more_apps();
+"""
+    # For cffi_asyncio.
+    # Bound to Python code with @ffi.def_extern().
+    # Also OK to leave unbound & uncalled.
+    + """
+extern "Python" static void uwsgi_pypy_continulet_schedule(void);
+extern "Python" static void uwsgi_pypy_continulet_switch(struct wsgi_request *);
+extern "Python" static void uwsgi_pypy_greenlet_schedule_to_req(void);
+extern "Python" static void uwsgi_pypy_greenlet_schedule_to_main(struct wsgi_request *);
+extern "Python" static struct wsgi_request * uwsgi_pypy_greenlet_current_wsgi_req();
+extern "Python" static int uwsgi_asyncio_wait_read_hook(int fd, int timeout);
+extern "Python" static int uwsgi_asyncio_wait_write_hook(int fd, int timeout);
+extern "Python" static void uwsgi_asyncio_schedule_fix(struct wsgi_request *);
+extern "Python" static void asyncio_loop(void);
+"""
+)
+
+# embedding_api() exposes Python functions to uwsgi.
+# Similar to extern "Python", but referenced by our own C set_source()
+# as well as our Python code:
+exposed_to_uwsgi = """
+extern struct uwsgi_server uwsgi;
+
+static int uwsgi_cffi_init();
+static void uwsgi_cffi_preinit_apps();
+static void uwsgi_cffi_init_apps();
+static int uwsgi_cffi_request(struct wsgi_request *wsgi_req);
+static void uwsgi_cffi_after_request(struct wsgi_request *wsgi_req);
+static void uwsgi_cffi_onload();
+
+static uint64_t uwsgi_cffi_rpc(void *, uint8_t,  char **, uint16_t *, char **);
+static void uwsgi_cffi_post_fork();
+static void uwsgi_cffi_enable_threads();
+static void uwsgi_cffi_init_thread();
+static int uwsgi_cffi_mule(char *opt);
+static int uwsgi_cffi_signal_handler(uint8_t sig, void *handler);
+"""
+ffibuilder.embedding_api(exposed_to_uwsgi)
+
+ffibuilder.embedding_init_code(open("cffi_init.py", "r").read())
+
+ffibuilder.set_source(
+    "cffi_plugin",
+    """
+#include <uwsgi.h>
+"""
+    + plugin_data
+    + exposed_to_uwsgi
+    + """
+
+extern void uwsgi_cffi_more_apps() {
+    uwsgi_apps_cnt++;
+}
+
+static struct uwsgi_option uwsgi_cffi_options[] = {
+    {"cffi-wsgi", required_argument, 0, "load a WSGI module", uwsgi_opt_set_str, &ucffi.wsgi, 0},
+    {"cffi-init", required_argument, 0, "load a module during init (define or override callbacks)", uwsgi_opt_set_str, &ucffi.init, 0},
+	{0, 0, 0, 0, 0, 0, 0},
+};
+
+CFFI_DLLEXPORT struct uwsgi_plugin cffi_plugin = {
+    .name = "cffi",
+    .modifier1 = 0,
+    .init = uwsgi_cffi_init,
+    .request = uwsgi_cffi_request,
+    .after_request = uwsgi_cffi_after_request,
+    .options = uwsgi_cffi_options,
+    .preinit_apps = uwsgi_cffi_preinit_apps,
+    .init_apps = uwsgi_cffi_init_apps,
+    .init_thread = uwsgi_cffi_init_thread,
+    .signal_handler = uwsgi_cffi_signal_handler,
+    .enable_threads = uwsgi_cffi_enable_threads,
+    .rpc = uwsgi_cffi_rpc,
+    .post_fork = uwsgi_cffi_post_fork,
+    .mule = uwsgi_cffi_mule
+};
+""",
+)
+
+if __name__ == "__main__":
+    ffibuilder.emit_c_code("cffi_plugin.c")

--- a/plugins/cffi/cffi_setup_asyncio.py
+++ b/plugins/cffi/cffi_setup_asyncio.py
@@ -1,9 +1,6 @@
-
 import cffi_greenlets
-
-cffi_greenlets.uwsgi_cffi_setup_greenlets()
-
 import cffi_asyncio
 
-cffi_asyncio.async_init()
 cffi_asyncio.setup_asyncio(32)  # is this the same as the --async option?
+cffi_greenlets.uwsgi_cffi_setup_greenlets()
+cffi_asyncio.async_init()  # should this happen in a postfork hook or at a different phase of config?

--- a/plugins/cffi/cffi_setup_asyncio.py
+++ b/plugins/cffi/cffi_setup_asyncio.py
@@ -1,0 +1,9 @@
+
+import cffi_greenlets
+
+cffi_greenlets.uwsgi_cffi_setup_greenlets()
+
+import cffi_asyncio
+
+cffi_asyncio.async_init()
+cffi_asyncio.setup_asyncio(32)  # is this the same as the --async option?

--- a/plugins/cffi/cffitest.sh
+++ b/plugins/cffi/cffitest.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+# Run from base uwsgi directory
+set -e
+# export C_INCLUDE_PATH=/usr/local/opt/openssl\@1.1/include
+python ./uwsgiconfig.py -p plugins/cffi nolang
+./uwsgi --plugin cffi -T \
+    --http-socket 0.0.0.0:8080 \
+    --env=PYTHONPATH=$HOME/prog/uwsgi:$HOME/prog/uwsgi/plugins/cffi \
+    --cffi-init=cffi_dyn_init \
+    --cffi-wsgi=helloworld \
+    --chdir=$VIRTUAL_ENV/bin \
+    --master \
+    --touch-reload=$HOME/prog/uwsgi/helloworld.py

--- a/plugins/cffi/cffitest.sh
+++ b/plugins/cffi/cffitest.sh
@@ -8,6 +8,7 @@ python ./uwsgiconfig.py -p plugins/cffi nolang
     --single-interpreter \
     --env=PYTHONPATH=$HOME/prog/uwsgi:$HOME/prog/uwsgi/plugins/cffi \
     --cffi-init=cffi_dyn_init \
+    --cffi-wsgi=$PWD/helloworld.py \
     --manage-script-name \
     --mount=/app=helloworld:application \
     --mount=/app2=$PWD/helloworld.py \

--- a/plugins/cffi/cffitest.sh
+++ b/plugins/cffi/cffitest.sh
@@ -5,9 +5,12 @@ set -e
 python ./uwsgiconfig.py -p plugins/cffi nolang
 ./uwsgi --plugin cffi -T \
     --http-socket 0.0.0.0:8080 \
+    --single-interpreter \
     --env=PYTHONPATH=$HOME/prog/uwsgi:$HOME/prog/uwsgi/plugins/cffi \
     --cffi-init=cffi_dyn_init \
-    --cffi-wsgi=helloworld \
+    --manage-script-name \
+    --mount=/app=helloworld:application \
+    --mount=/app2=$PWD/helloworld.py \
     --chdir=$VIRTUAL_ENV/bin \
     --master \
     --touch-reload=$HOME/prog/uwsgi/helloworld.py

--- a/plugins/cffi/chattest.sh
+++ b/plugins/cffi/chattest.sh
@@ -11,6 +11,7 @@ python ./uwsgiconfig.py -p plugins/cffi nolang
   --cffi-init=cffi_setup_asyncio \
   --async=32 \
   --http-socket=:8080 \
+  --manage-script-name \
   --mount=/wsgi=helloworld \
   --mount=/=starlettetest:app \
   --chdir=$VIRTUAL_ENV/bin \

--- a/plugins/cffi/chattest.sh
+++ b/plugins/cffi/chattest.sh
@@ -10,7 +10,7 @@ python ./uwsgiconfig.py -p plugins/cffi nolang
   --plugin=cffi \
   --cffi-init=cffi_setup_asyncio \
   --async=32 \
-  --http-socket=:8080 \
+  --http-socket=[::]:8080 \
   --manage-script-name \
   --mount=/=starlettetest:app \
   --mount=/wsgi=$PWD/examples/welcome3.py \

--- a/plugins/cffi/chattest.sh
+++ b/plugins/cffi/chattest.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+# Run from base uwsgi directory
+set -e
+export C_INCLUDE_PATH=/usr/local/opt/openssl\@1.1/include
+python ./uwsgiconfig.py -p plugins/cffi nolang
+./uwsgi --plugin cffi -T --async 32 --http-socket :8080 --mount=/=websockets_chat_asyncio --chdir $VIRTUAL_ENV/bin --touch-reload $PWD/tests/websockets_chat_asyncio.py --master

--- a/plugins/cffi/chattest.sh
+++ b/plugins/cffi/chattest.sh
@@ -1,6 +1,18 @@
 #!/bin/sh
 # Run from base uwsgi directory
 set -e
+export PYTHONPATH=$PWD:$PWD/plugins/cffi
 export C_INCLUDE_PATH=/usr/local/opt/openssl\@1.1/include
 python ./uwsgiconfig.py -p plugins/cffi nolang
-./uwsgi --plugin cffi -T --async 32 --http-socket :8080 --mount=/=websockets_chat_asyncio --chdir $VIRTUAL_ENV/bin --touch-reload $PWD/tests/websockets_chat_asyncio.py --master
+./uwsgi \
+  --master \
+  --enable-threads \
+  --plugin=cffi \
+  --cffi-init=cffi_setup_asyncio \
+  --async=32 \
+  --http-socket=:8080 \
+  --mount=/wsgi=helloworld \
+  --mount=/=starlettetest:app \
+  --chdir=$VIRTUAL_ENV/bin \
+  --touch-reload $PWD/starlettetest.py \
+  --touch-reload $PWD/plugins/cffi/cffi_asyncio.py

--- a/plugins/cffi/chattest.sh
+++ b/plugins/cffi/chattest.sh
@@ -12,8 +12,8 @@ python ./uwsgiconfig.py -p plugins/cffi nolang
   --async=32 \
   --http-socket=:8080 \
   --manage-script-name \
-  --mount=/wsgi=helloworld \
   --mount=/=starlettetest:app \
+  --mount=/wsgi=$PWD/examples/welcome3.py \
   --chdir=$VIRTUAL_ENV/bin \
   --touch-reload $PWD/starlettetest.py \
   --touch-reload $PWD/plugins/cffi/cffi_asyncio.py

--- a/plugins/cffi/constants.py
+++ b/plugins/cffi/constants.py
@@ -29,7 +29,7 @@ for cflag in uwsgi_cflags:
 
 uwsgi_dot_h = open("../../uwsgi.h").read()
 
-with open("constants.h", "w+") as defines:
+with open("_constants.h", "w+") as defines:
     defines.write("\n".join(uwsgi_cdef))
     defines.write("\n\n")
     for line in uwsgi_dot_h.splitlines():

--- a/plugins/cffi/constants.py
+++ b/plugins/cffi/constants.py
@@ -1,0 +1,38 @@
+"""
+Process uwsgi cflags, dot-h into something cffi can use.
+"""
+
+import re
+import subprocess
+
+# or could run the preprocessor to omit this on unsupported platforms
+skip = set(("MSG_FASTOPEN", "UWSGI_DEBUG"))
+
+define_re = re.compile(".*#define\s+(\w+)\s+\d+")
+
+try:
+    uwsgi_cflags = subprocess.check_output(["../../uwsgi", "--cflags"]).decode("utf-8")
+except subprocess.CalledProcessError:
+    uwsgi_cflags = ""
+
+uwsgi_cdef = []
+uwsgi_defines = []
+uwsgi_cflags = uwsgi_cflags.split()
+
+for cflag in uwsgi_cflags:
+    if cflag.startswith("-D"):
+        line = cflag[2:]
+        if "=" in line or line in skip:
+            continue
+        else:
+            uwsgi_cdef.append("#define %s ..." % line)
+
+uwsgi_dot_h = open("../../uwsgi.h").read()
+
+with open("constants.h", "w+") as defines:
+    defines.write("\n".join(uwsgi_cdef))
+    defines.write("\n\n")
+    for line in uwsgi_dot_h.splitlines():
+        match = define_re.match(line)
+        if match and not match.group(1).startswith("__") and not match.group(1) in skip:
+            defines.write("#define %s ...\n" % match.group(1))

--- a/plugins/cffi/filtercdefs.py
+++ b/plugins/cffi/filtercdefs.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python
+# Filter out only matching files from preprocessor output
+# Omit blank lines
+
+DEBUG = False
+
+import re, sys
+
+comment = re.compile(r'^# (?P<lineno>\d+) "(?P<filename>[^\"]+)"')
+
+# include stdint.h also?
+allowed_filenames = re.compile(".*(<stdin>)$")
+
+
+def filter_by_file(input):
+    filename = ""
+    allowed = True
+    for line in input:
+        match = comment.match(line)
+        if match:
+            filename = match.group("filename")
+            allowed = bool(allowed_filenames.match(filename))
+        if not line.strip():
+            continue
+        if not allowed:
+            continue
+        if line[0] == "#":
+            continue
+        yield line
+
+
+struct = re.compile(r"\s*(?P<kind>\w+)\s+(?P<name>\w+)\s*{")
+declaration = re.compile(r"\s*(?P<kind>(struct )?\w+)\s+(?P<name>\w+)\s*")
+matchers = {
+    None: struct,
+    "struct": declaration,
+    "enum": None,
+    "union": None,
+    "skip": None,
+}
+end = re.compile(".*}.*;")
+
+# types that for whatever reason we don't want to deal with
+avoid_types = set(
+    (
+        "pthread_key_t",
+        "pthread_mutex_t",
+        "pthread_attr_t",
+        "pthread_t",
+        "ino_t",
+        "off_t",
+        "mode_t",
+        "struct msghdr",
+        "struct termios",
+        "struct rlimit",
+        "struct timeval",
+        "struct sockaddr_un",
+    )
+)
+
+# skip lines containing these strings:
+avoid_names = set(("mode_t", "uwsgi_recv_cred"))
+
+# declared in uwsgi.h but not included in the base profile:
+avoid_names.update(
+    (
+        "uwsgi_amqp_consume",
+        "uwsgi_hooks_setns_run",
+        "uwsgi_legion_i_am_the_lord",
+        "uwsgi_legion_lord_scroll",
+        "uwsgi_legion_scrolls",
+    )
+)
+
+
+def output(string):
+    if not DEBUG:
+        return
+    sys.stderr.write(string)
+
+
+# well-formatted uwsgi.h admits semi-simple parsing.
+def filter_structs(lines):
+    stack = [None]
+    for line in lines:
+        skipline = False
+        state = stack[-1]
+        matcher = matchers[state]
+        if any(name in line for name in avoid_names):
+            skipline = True
+        if end.match(line):
+            if state == "struct":
+                yield "...;\n"
+            if state:
+                stack.pop()
+        elif matcher:
+            match = matcher.match(line)
+            if match:
+                output(str(match.groups()) + "\n")
+                if state == None:
+                    kind = match.group("kind")
+                    if kind == "union":
+                        skipline = True
+                        if not line.strip().endswith(";"):
+                            stack.append("skip")
+                    else:
+                        stack.append(match.group("kind"))
+                elif state == "struct":
+                    kind = match.group("kind")
+                    output(str(match.groupdict()) + "\n")
+                    if kind in avoid_types:
+                        skipline = True
+                    if kind == "union":  # sockaddr_t?
+                        skipline = True
+                        if not line.strip().endswith(";"):
+                            stack.append("skip")
+
+        if skipline or state == "skip":
+            yield "//" + line.strip() + "\n"
+        else:
+            yield line.strip() + "\n"
+
+
+if __name__ == "__main__":
+    pipeline = filter_structs(filter_by_file(open(sys.argv[1])))
+    sys.stdout.writelines(pipeline)

--- a/plugins/cffi/types.h
+++ b/plugins/cffi/types.h
@@ -1,0 +1,14 @@
+// these may not be portable...
+typedef int32_t pid_t;
+typedef int32_t uid_t;
+typedef int32_t gid_t;
+typedef long time_t;
+typedef unsigned int socklen_t;
+typedef long off_t;
+typedef uint64_t rlim_t;
+
+struct iovec {
+  void *iov_base;
+  size_t iov_len;
+  ...;
+};

--- a/plugins/cffi/uwsgi.py
+++ b/plugins/cffi/uwsgi.py
@@ -1,37 +1,34 @@
 """
 Implement the uwsgi module.
+
+Based on plugins/pypy/pypy_setup.py
 """
 
-from cffi_plugin import ffi, lib
+from _uwsgi import ffi, lib
 
-# version = ... # parse from uwsgi_get_cflags()?
-hostname = ffi.string(lib.uwsgi.hostname)
+# latin1 might be better
+hostname = ffi.string(lib.uwsgi.hostname, lib.uwsgi.hostname_len).decode("utf-8")
+numproc = lib.uwsgi.numproc
+buffer_size = lib.uwsgi.buffer_size
+if lib.uwsgi.mode:
+    mode = ffi.string(lib.uwsgi.mode).decode("utf-8")
+if lib.uwsgi.pidfile:
+    pidfile = ffi.string(lib.uwsgi.pidfile).decode("utf-8")
 
+# parse version from cflags
+_version = {}
+for _flag in ffi.string(lib.uwsgi_get_cflags()).decode("utf-8").split():
+    if _flag.startswith("-DUWSGI_VERSION"):
+        _k, _v = _flag.split("=", 1)
+        _version[_k] = _v.replace('"', "").replace("\\", "")
 
-def masterpid():
-    if lib.uwsgi.master_process:
-        return lib.uwsgi.workers[0].pid
-    return 0
+print(_version)
 
-
-def signal_registered(signum):
-    return lib.uwsgi_signal_registered(signum)
-
-
-def worker_id():
-    return lib.uwsgi.mywid
-
-
-def mule_id():
-    return lib.uwsgi.muleid
-
-
-def logsize():
-    return lib.uwsgi.shared.logsize
-
-
-def mule_msg_recv_size():
-    return lib.uwsgi.mule_msg_recv_size
+version = _version["-DUWSGI_VERSION"]
+version_info = tuple(
+    int(_version["-DUWSGI_VERSION_" + _k])
+    for _k in ("BASE", "MAJOR", "MINOR", "REVISION")
+) + (_version["-DUWSGI_VERSION_CUSTOM"],)
 
 
 def _current_wsgi_req():
@@ -51,30 +48,278 @@ def async_id():
     return wsgi_req.async_id
 
 
-def connection_fd():
-    fd = _current_wsgi_req().fd
-    print("request_id", request_id(), "connection_fd", fd)
-    return fd
+def register_signal(signum, kind, handler):
+    cb = ffi.callback("void(int)", handler)
+    uwsgi_gc.append(cb)
+    if (
+        lib.uwsgi_register_signal(
+            signum, ffi.new("char[]", kind), cb, lib.pypy_plugin.modifier1
+        )
+        < 0
+    ):
+        raise Exception("unable to register signal %d" % signum)
 
 
-def uwsgi_pypy_current_wsgi_req():
-    return lib.uwsgi.current_wsgi_req()
+class uwsgi_pypy_RPC(object):
+    def __init__(self, func):
+        self.func = func
+
+    def __call__(self, argc, argv, argvs, buf):
+        pargs = []
+        for i in range(0, argc):
+            pargs.append(ffi.buffer(argv[i], argvs[i])[:])
+        response = self.func(*pargs)
+        if len(response) > 0:
+            buf[0] = lib.uwsgi_malloc(len(response))
+            dst = ffi.buffer(buf[0], len(response))
+            dst[: len(response)] = response
+        return len(response)
+
+
+def register_rpc(name, func, argc=0):
+    rpc_func = uwsgi_pypy_RPC(func)
+    cb = ffi.callback("int(int, char*[], int[], char**)", rpc_func)
+    uwsgi_gc.append(cb)
+    if (
+        lib.uwsgi_register_rpc(
+            ffi.new("char[]", name), ffi.addressof(lib.pypy_plugin), argc, cb
+        )
+        < 0
+    ):
+        raise Exception("unable to register rpc func %s" % name)
+
+
+def rpc(node, func, *args):
+    argc = 0
+    argv = ffi.new("char*[256]")
+    argvs = ffi.new("uint16_t[256]")
+    rsize = ffi.new("uint64_t*")
+
+    for arg in args:
+        if argc >= 255:
+            raise Exception("invalid number of rpc arguments")
+        if len(arg) >= 65535:
+            raise Exception("invalid rpc argument size (must be < 65535)")
+        argv[argc] = ffi.new("char[]", arg)
+        argvs[argc] = len(arg)
+        argc += 1
+
+    if node:
+        c_node = ffi.new("char[]", node)
+    else:
+        c_node = ffi.NULL
+
+    response = lib.uwsgi_do_rpc(
+        c_node, ffi.new("char[]", func), argc, argv, argvs, rsize
+    )
+    if response:
+        ret = ffi.buffer(response, rsize[0])[:]
+        lib.free(response)
+        return ret
+    return None
+
+
+def call(func, *args):
+    node = None
+    if "@" in func:
+        (func, node) = func.split("@")
+    return uwsgi_pypy_rpc(node, func, *args)
+
+
+signal = lambda x: lib.uwsgi_signal_send(lib.uwsgi.signal_socket, x)
+
+metric_get = lambda x: lib.uwsgi_metric_get(x, ffi.NULL)
+metric_set = lambda x, y: lib.uwsgi_metric_set(x, ffi.NULL, y)
+metric_inc = lambda x, y=1: lib.uwsgi_metric_inc(x, ffi.NULL, y)
+metric_dec = lambda x, y=1: lib.uwsgi_metric_dec(x, ffi.NULL, y)
+metric_mul = lambda x, y=1: lib.uwsgi_metric_mul(x, ffi.NULL, y)
+metric_div = lambda x, y=1: lib.uwsgi_metric_div(x, ffi.NULL, y)
+
+
+def cache_get(key, cache=ffi.NULL):
+    vallen = ffi.new("uint64_t*")
+    value = lib.uwsgi_cache_magic_get(key, len(key), vallen, ffi.NULL, cache)
+    if value == ffi.NULL:
+        return None
+    ret = ffi.buffer(value, vallen[0])[:]
+    libc.free(value)
+    return ret
+
+
+def cache_set(key, value, expires=0, cache=ffi.NULL):
+    if (
+        lib.uwsgi_cache_magic_set(key, len(key), value, len(value), expires, 0, cache)
+        < 0
+    ):
+        raise Exception("unable to store item in the cache")
+
+
+def cache_update(key, value, expires=0, cache=ffi.NULL):
+    if (
+        lib.uwsgi_cache_magic_set(
+            key, len(key), value, len(value), expires, 1 << 1, cache
+        )
+        < 0
+    ):
+        raise Exception("unable to store item in the cache")
+
+
+def cache_del(key, cache=ffi.NULL):
+    if lib.uwsgi_cache_magic_del(key, len(key), cache) < 0:
+        raise Exception("unable to delete item from the cache")
+
+
+def cache_keys(cache=ffi.NULL):
+    uc = lib.uwsgi_cache_by_name(cache)
+    if uc == ffi.NULL:
+        raise Exception("no local uWSGI cache available")
+    l = []
+    lib.uwsgi_cache_rlock(uc)
+    pos = ffi.new("uint64_t *")
+    uci = ffi.new("struct uwsgi_cache_item **")
+    while True:
+        uci[0] = lib.uwsgi_cache_keys(uc, pos, uci)
+        if uci[0] == ffi.NULL:
+            break
+        l.append(ffi.buffer(lib.uwsgi_cache_item_key(uci[0]), uci[0].keysize)[:])
+    lib.uwsgi_cache_rwunlock(uc)
+    return l
+
+
+def add_timer(signum, secs):
+    if lib.uwsgi_add_timer(signum, secs) < 0:
+        raise Exception("unable to register timer")
+
+
+def add_rb_timer(signum, secs):
+    if lib.uwsgi_signal_add_rb_timer(signum, secs, 0) < 0:
+        raise Exception("unable to register redblack timer")
+
+
+def add_file_monitor(signum, filename):
+    if lib.uwsgi_add_file_monitor(signum, ffi.new("char[]", filename)) < 0:
+        raise Exception("unable to register file monitor")
+
+
+def lock(num=0):
+    if lib.uwsgi_user_lock(num) < 0:
+        raise Exception("invalid lock")
+
+
+def unlock(num=0):
+    if lib.uwsgi_user_unlock(num) < 0:
+        raise Exception("invalid lock")
+
+
+def masterpid():
+    if lib.uwsgi.master_process:
+        return lib.uwsgi.workers[0].pid
+    return 0
+
+
+def worker_id():
+    return lib.uwsgi.mywid
+
+
+def mule_id():
+    return lib.uwsgi.muleid
+
+
+def mule_msg_recv_size():
+    return lib.uwsgi.mule_msg_recv_size
+
+
+def logsize():
+    return lib.uwsgi.shared.logsize
+
+
+def signal_registered(signum):
+    if lib.uwsgi_signal_registered(signum) > 0:
+        return True
+    return False
+
+
+def alarm(alarm, msg):
+    lib.uwsgi_alarm_trigger(ffi.new("char[]", alarm), ffi.new("char[]", msg), len(msg))
+
+
+setprocname = lambda name: lib.uwsgi_set_processname(ffi.new("char[]", name))
+
+
+def add_cron(signum, minute, hour, day, month, week):
+    if lib.uwsgi_signal_add_cron(signum, minute, hour, day, month, week) < 0:
+        raise Exception("unable to register cron")
 
 
 def suspend():
     """
     uwsgi.suspend()
     """
-    wsgi_req = uwsgi_pypy_current_wsgi_req()
+    wsgi_req = _current_wsgi_req()
     if lib.uwsgi.schedule_to_main:
         lib.uwsgi.schedule_to_main(wsgi_req)
+
+
+def workers():
+    """
+    uwsgi.workers()
+    """
+    workers = []
+    for i in range(1, lib.uwsgi.numproc + 1):
+        worker = {}
+        worker["id"] = lib.uwsgi.workers[i].id
+        worker["pid"] = lib.uwsgi.workers[i].pid
+        worker["requests"] = lib.uwsgi.workers[i].requests
+        worker["delta_requests"] = lib.uwsgi.workers[i].delta_requests
+        worker["signals"] = lib.uwsgi.workers[i].signals
+        worker["exceptions"] = lib.uwsgi_worker_exceptions(i)
+        worker["apps"] = []
+        if lib.uwsgi.workers[i].cheaped:
+            worker["status"] == "cheap"
+        elif lib.uwsgi.workers[i].suspended and not lib.uwsgi_worker_is_busy(i):
+            worker["status"] == "pause"
+        else:
+            if lib.uwsgi.workers[i].sig:
+                worker["status"] = "sig%d" % lib.uwsgi.workers[i].signum
+            elif lib.uwsgi_worker_is_busy(i):
+                worker["status"] = "busy"
+            else:
+                worker["status"] = "idle"
+        worker["running_time"] = lib.uwsgi.workers[i].running_time
+        worker["avg_rt"] = lib.uwsgi.workers[i].avg_response_time
+        worker["tx"] = lib.uwsgi.workers[i].tx
+
+        workers.append(worker)
+    return workers
+
+
+def async_sleep(timeout):
+    """
+    uwsgi.async_sleep(timeout)
+    """
+    if timeout > 0:
+        wsgi_req = _current_wsgi_req()
+        lib.async_add_timeout(wsgi_req, timeout)
+
+
+def async_connect(addr):
+    """
+    uwsgi.async_connect(addr)
+    """
+    fd = lib.uwsgi_connect(ffi.new("char[]", addr), 0, 1)
+    if fd < 0:
+        raise Exception("unable to connect to %s" % addr)
+    return fd
+
+
+connection_fd = lambda: _current_wsgi_req().fd
 
 
 def wait_fd_read(fd, timeout=0):
     """
     uwsgi.wait_fd_read(fd, timeout=0)
     """
-    wsgi_req = uwsgi_pypy_current_wsgi_req()
+    wsgi_req = _current_wsgi_req()
     if lib.async_add_fd_read(wsgi_req, fd, timeout) < 0:
         raise Exception("unable to add fd %d to the event queue" % fd)
 
@@ -83,7 +328,7 @@ def wait_fd_write(fd, timeout=0):
     """
     uwsgi.wait_fd_write(fd, timeout=0)
     """
-    wsgi_req = uwsgi_pypy_current_wsgi_req()
+    wsgi_req = _current_wsgi_req()
     if lib.async_add_fd_write(wsgi_req, fd, timeout) < 0:
         raise Exception("unable to add fd %d to the event queue" % fd)
 
@@ -92,8 +337,58 @@ def ready_fd():
     """
     uwsgi.ready_fd()
     """
-    wsgi_req = uwsgi_pypy_current_wsgi_req()
+    wsgi_req = _current_wsgi_req()
     return lib.uwsgi_ready_fd(wsgi_req)
+
+
+def send(*args):
+    """
+    uwsgi.send(fd=None,data)
+    """
+    if len(args) == 0:
+        raise ValueError("uwsgi.send() takes at least 1 argument")
+    elif len(args) == 1:
+        wsgi_req = _current_wsgi_req()
+        fd = wsgi_req.fd
+        data = args[0]
+    else:
+        fd = args[0]
+        data = args[1]
+    rlen = libc.write(fd, data, len(data))
+    if rlen <= 0:
+        raise IOError("unable to send data")
+    return rlen
+
+
+def recv(*args):
+    """
+    uwsgi.recv(fd=None,len)
+    """
+    if len(args) == 0:
+        raise ValueError("uwsgi.recv() takes at least 1 argument")
+    elif len(args) == 1:
+        wsgi_req = _current_wsgi_req()
+        fd = wsgi_req.fd
+        l = args[0]
+    else:
+        fd = args[0]
+        l = args[1]
+    data = ffi.new("char[%d]" % l)
+    rlen = libc.read(fd, data, l)
+    if rlen <= 0:
+        raise IOError("unable to receive data")
+    return ffi.string(data[0:rlen])
+
+
+"""
+uwsgi.close(fd)
+"""
+close = lambda fd: lib.close(fd)
+
+"""
+uwsgi.disconnect()
+"""
+disconnect = lambda: lib.uwsgi_disconnect(_current_wsgi_req())
 
 
 def websocket_recv():
@@ -146,3 +441,101 @@ def websocket_send(msg):
     wsgi_req = lib.uwsgi.current_wsgi_req()
     if lib.uwsgi_websocket_send(wsgi_req, ffi.new("char[]", msg), len(msg)) < 0:
         raise IOError("unable to send websocket message")
+
+
+def chunked_read(timeout=0):
+    """
+    uwsgi.chunked_read(timeout=0)
+    """
+    wsgi_req = _current_wsgi_req()
+    rlen = ffi.new("size_t*")
+    chunk = lib.uwsgi_chunked_read(wsgi_req, rlen, timeout, 0)
+    if chunk == ffi.NULL:
+        raise IOError("unable to receive chunked part")
+    return ffi.buffer(chunk, rlen[0])[:]
+
+
+def chunked_read_nb():
+    """
+    uwsgi.chunked_read_nb()
+    """
+    wsgi_req = _current_wsgi_req()
+    rlen = ffi.new("size_t*")
+    chunk = lib.uwsgi_chunked_read(wsgi_req, rlen, 0, 1)
+    if chunk == ffi.NULL:
+        if lib.uwsgi_is_again() > 0:
+            return None
+        raise IOError("unable to receive chunked part")
+
+    return ffi.buffer(chunk, rlen[0])[:]
+
+
+def set_user_harakiri(x):
+    """
+    uwsgi.set_user_harakiri(sec)
+    """
+    wsgi_req = _current_wsgi_req()
+    lib.set_user_harakiri(wsgi_req, x)
+
+
+def get_logvar(key):
+    """
+    uwsgi.get_logvar(key)
+    """
+    wsgi_req = _current_wsgi_req()
+    c_key = ffi.new("char[]", key)
+    lv = lib.uwsgi_logvar_get(wsgi_req, c_key, len(key))
+    if lv:
+        return ffi.string(lv.val[0 : lv.vallen])
+    return None
+
+
+def set_logvar(key, val):
+    """
+    uwsgi.set_logvar(key, value)
+    """
+    wsgi_req = _current_wsgi_req()
+    c_key = ffi.new("char[]", key)
+    c_val = ffi.new("char[]", val)
+    lib.uwsgi_logvar_add(wsgi_req, c_key, len(key), c_val, len(val))
+
+
+def _init():
+    """
+    Create uwsgi module, with properties.
+    """
+    import sys
+    import types
+
+    class UwsgiModule(types.ModuleType):
+        pass
+
+    module = UwsgiModule("uwsgi")
+    module.__dict__.update(
+        (k, v) for (k, v) in globals().items() if not k.startswith("_")
+    )
+
+    """
+    populate uwsgi.opt
+    """
+    opt = {}
+    for i in range(0, lib.uwsgi.exported_opts_cnt):
+        uo = lib.uwsgi.exported_opts[i]
+        k = ffi.string(uo.key)
+        if uo.value == ffi.NULL:
+            v = True
+        else:
+            v = ffi.string(uo.value)
+        if k in opt:
+            if type(opt[k]) is list:
+                opt[k].append(v)
+            else:
+                opt[k] = [opt[k], v]
+        else:
+            opt[k] = v
+    module.opt = opt
+
+    sys.modules["uwsgi"] = module
+
+
+_init()

--- a/plugins/cffi/uwsgi.py
+++ b/plugins/cffi/uwsgi.py
@@ -61,7 +61,7 @@ def register_signal(signum, kind, handler):
     uwsgi_gc.append(cb)
     if (
         lib.uwsgi_register_signal(
-            signum, ffi.new("char[]", kind), cb, lib.cffi_plugin.modifier1,
+            signum, ffi.new("char[]", kind), cb, lib.cffi_plugin.modifier1
         )
         < 0
     ):
@@ -486,6 +486,15 @@ def websocket_send(msg):
     wsgi_req = lib.uwsgi.current_wsgi_req()
     if lib.uwsgi_websocket_send(wsgi_req, ffi.new("char[]", msg), len(msg)) < 0:
         raise IOError("unable to send websocket message")
+
+
+def websocket_send_binary(msg):
+    """
+    uwsgi.websocket_send_binary(msg)
+    """
+    wsgi_req = lib.uwsgi.current_wsgi_req()
+    if lib.uwsgi_websocket_send_binary(wsgi_req, ffi.new("char[]", msg), len(msg)) < 0:
+        raise IOError("unable to send binary websocket message")
 
 
 def chunked_read(timeout=0):

--- a/plugins/cffi/uwsgi.py
+++ b/plugins/cffi/uwsgi.py
@@ -22,8 +22,6 @@ for _flag in ffi.string(lib.uwsgi_get_cflags()).decode("utf-8").split():
         _k, _v = _flag.split("=", 1)
         _version[_k] = _v.replace('"', "").replace("\\", "")
 
-print(_version)
-
 version = _version["-DUWSGI_VERSION"]
 version_info = tuple(
     int(_version["-DUWSGI_VERSION_" + _k])

--- a/plugins/cffi/uwsgi.py
+++ b/plugins/cffi/uwsgi.py
@@ -1,0 +1,148 @@
+"""
+Implement the uwsgi module.
+"""
+
+from cffi_plugin import ffi, lib
+
+# version = ... # parse from uwsgi_get_cflags()?
+hostname = ffi.string(lib.uwsgi.hostname)
+
+
+def masterpid():
+    if lib.uwsgi.master_process:
+        return lib.uwsgi.workers[0].pid
+    return 0
+
+
+def signal_registered(signum):
+    return lib.uwsgi_signal_registered(signum)
+
+
+def worker_id():
+    return lib.uwsgi.mywid
+
+
+def mule_id():
+    return lib.uwsgi.muleid
+
+
+def logsize():
+    return lib.uwsgi.shared.logsize
+
+
+def mule_msg_recv_size():
+    return lib.uwsgi.mule_msg_recv_size
+
+
+def _current_wsgi_req():
+    wsgi_req = lib.uwsgi.current_wsgi_req()
+    if wsgi_req == ffi.NULL:
+        raise SystemError("you can call uwsgi api function only from the main callable")
+    return wsgi_req
+
+
+def request_id():
+    wsgi_req = _current_wsgi_req()
+    return lib.uwsgi.workers[lib.uwsgi.mywid].cores[wsgi_req.async_id].requests
+
+
+def async_id():
+    wsgi_req = _current_wsgi_req()
+    return wsgi_req.async_id
+
+
+def connection_fd():
+    fd = _current_wsgi_req().fd
+    print("request_id", request_id(), "connection_fd", fd)
+    return fd
+
+
+def uwsgi_pypy_current_wsgi_req():
+    return lib.uwsgi.current_wsgi_req()
+
+
+def suspend():
+    """
+    uwsgi.suspend()
+    """
+    wsgi_req = uwsgi_pypy_current_wsgi_req()
+    if lib.uwsgi.schedule_to_main:
+        lib.uwsgi.schedule_to_main(wsgi_req)
+
+
+def wait_fd_read(fd, timeout=0):
+    """
+    uwsgi.wait_fd_read(fd, timeout=0)
+    """
+    wsgi_req = uwsgi_pypy_current_wsgi_req()
+    if lib.async_add_fd_read(wsgi_req, fd, timeout) < 0:
+        raise Exception("unable to add fd %d to the event queue" % fd)
+
+
+def wait_fd_write(fd, timeout=0):
+    """
+    uwsgi.wait_fd_write(fd, timeout=0)
+    """
+    wsgi_req = uwsgi_pypy_current_wsgi_req()
+    if lib.async_add_fd_write(wsgi_req, fd, timeout) < 0:
+        raise Exception("unable to add fd %d to the event queue" % fd)
+
+
+def ready_fd():
+    """
+    uwsgi.ready_fd()
+    """
+    wsgi_req = uwsgi_pypy_current_wsgi_req()
+    return lib.uwsgi_ready_fd(wsgi_req)
+
+
+def websocket_recv():
+    """
+    uwsgi.websocket_recv()
+    """
+    wsgi_req = lib.uwsgi.current_wsgi_req()
+    ub = lib.uwsgi_websocket_recv(wsgi_req)
+    if ub == ffi.NULL:
+        raise IOError("unable to receive websocket message")
+    ret = ffi.buffer(ub.buf, ub.pos)[:]
+    lib.uwsgi_buffer_destroy(ub)
+    return ret
+
+
+def websocket_recv_nb():
+    """
+    uwsgi.websocket_recv_nb()
+    """
+    wsgi_req = lib.uwsgi.current_wsgi_req()
+    ub = lib.uwsgi_websocket_recv_nb(wsgi_req)
+    if ub == ffi.NULL:
+        raise IOError("unable to receive websocket message")
+    ret = ffi.buffer(ub.buf, ub.pos)[:]
+    lib.uwsgi_buffer_destroy(ub)
+    return ret
+
+
+def websocket_handshake(key="", origin="", proto=""):
+    """
+    uwsgi.websocket_handshake(key, origin)
+    """
+    wsgi_req = _current_wsgi_req()
+    c_key = ffi.new("char[]", key.encode("latin1"))  # correct encoding?
+    c_origin = ffi.new("char[]", origin.encode("latin1"))
+    c_proto = ffi.new("char[]", proto.encode("latin1"))
+    if (
+        lib.uwsgi_websocket_handshake(
+            wsgi_req, c_key, len(key), c_origin, len(origin), c_proto, len(proto)
+        )
+        < 0
+    ):
+        raise IOError("unable to complete websocket handshake")
+
+
+def websocket_send(msg):
+    """
+    uwsgi.websocket_send(msg)
+    """
+    wsgi_req = lib.uwsgi.current_wsgi_req()
+    if lib.uwsgi_websocket_send(wsgi_req, ffi.new("char[]", msg), len(msg)) < 0:
+        raise IOError("unable to send websocket message")

--- a/plugins/cffi/uwsgiplugin.py
+++ b/plugins/cffi/uwsgiplugin.py
@@ -1,0 +1,110 @@
+NAME = "cffi"
+
+import os.path
+import sys
+from distutils import sysconfig
+import subprocess
+
+subprocess.check_call(["make"], cwd="plugins/cffi")
+
+
+def get_python_version():
+    version = sysconfig.get_config_var("VERSION")
+    try:
+        version = version + sys.abiflags
+    except Exception:
+        pass
+    return version
+
+
+GCC_LIST = ["cffi_plugin"]
+
+if sys.implementation.name == "pypy":
+
+    CFLAGS = [
+        "-pthread",
+        "-DNDEBUG",
+        f"-I{sys.base_exec_prefix}/include",
+        f"-I{sys.prefix}/include",
+        "-fvisibility=hidden",
+    ]
+
+    if sys.platform == "linux":
+        LDFLAGS = [f"-L{sys.prefix}/bin/", f"-Wl,-rpath={sys.prefix}/bin/", "-lpypy3-c"]
+    else:
+        LDFLAGS = [f"-L{sys.prefix}/bin/", "-lpypy3-c"]
+    LIBS = []
+
+    def post_build(config):
+        # How to detect embedded or shared object?
+        # find pypy3-c on osx
+        if sys.platform == "darwin":
+            rpath = os.path.dirname(sys.executable)
+            subprocess.check_call(
+                ["install_name_tool", "-add_rpath", rpath, "cffi_plugin.so"]
+            )
+
+
+else:
+    # copied from plugins/python
+
+    CFLAGS = [
+        "-I" + sysconfig.get_python_inc(),
+        "-I" + sysconfig.get_python_inc(plat_specific=True),
+    ]
+    LDFLAGS = []
+
+    if "UWSGI_PYTHON_NOLIB" not in os.environ:
+        LIBS = (
+            sysconfig.get_config_var("LIBS").split()
+            + sysconfig.get_config_var("SYSLIBS").split()
+        )
+        # check if it is a non-shared build (but please, add --enable-shared to your python's ./configure script)
+        if not sysconfig.get_config_var("Py_ENABLE_SHARED"):
+            libdir = sysconfig.get_config_var("LIBPL")
+            # libdir does not exists, try to get it from the venv
+            version = get_python_version()
+            if not os.path.exists(libdir):
+                libdir = "%s/lib/python%s/config" % (sys.prefix, version)
+            # try skipping abiflag
+            if not os.path.exists(libdir) and version.endswith("m"):
+                version = version[:-1]
+                libdir = "%s/lib/python%s/config" % (sys.prefix, version)
+            # try 3.x style config dir
+            if not os.path.exists(libdir):
+                libdir = "%s/lib/python%s/config-%s" % (
+                    sys.prefix,
+                    version,
+                    get_python_version(),
+                )
+
+            # get cpu type
+            uname = os.uname()
+            if uname[4].startswith("arm"):
+                libpath = "%s/%s" % (libdir, sysconfig.get_config_var("LIBRARY"))
+                if not os.path.exists(libpath):
+                    libpath = "%s/%s" % (libdir, sysconfig.get_config_var("LDLIBRARY"))
+            else:
+                libpath = "%s/%s" % (libdir, sysconfig.get_config_var("LDLIBRARY"))
+                if not os.path.exists(libpath):
+                    libpath = "%s/%s" % (libdir, sysconfig.get_config_var("LIBRARY"))
+            if not os.path.exists(libpath):
+                libpath = "%s/libpython%s.a" % (libdir, version)
+            LIBS.append(libpath)
+            # hack for messy linkers/compilers
+            if "-lutil" in LIBS:
+                LIBS.append("-lutil")
+        else:
+            try:
+                libdir = sysconfig.get_config_var("LIBDIR")
+            except Exception:
+                libdir = "%s/lib" % sysconfig.PREFIX
+
+            LDFLAGS.append("-L%s" % libdir)
+            LDFLAGS.append("-Wl,-rpath,%s" % libdir)
+
+            os.environ["LD_RUN_PATH"] = "%s" % libdir
+
+            LIBS.append("-lpython%s" % get_python_version())
+    else:
+        LIBS = []

--- a/starlettetest.html
+++ b/starlettetest.html
@@ -1,17 +1,52 @@
+<!doctype html>
 <html>
 
 <head>
+  <meta charset="utf-8">
+  <meta content="width=device-width,initial-scale=1,minimal-ui" name="viewport">
+  <link rel="stylesheet"
+    href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700,400italic|Material+Icons">
+  <link rel="stylesheet" href="https://unpkg.com/vue-material/dist/vue-material.min.css">
+  <link rel="stylesheet" href="https://unpkg.com/vue-material/dist/theme/default.css">
+</head>
+
+<body>
+  <div id="app">
+    <md-card class="md-layout-item md-size-50 md-small-size-100">
+      <md-card-header>
+        <div class="md-title">WebSocket Chat (asgi)</div>
+      </md-card-header>
+
+      <md-card-content>
+        <form novalidate class="md-layout" @submit.prevent="send">
+          <md-field>
+            <label>Chat</label>
+            <md-input v-model="textarea">
+              </md-textarea>
+          </md-field>
+
+          <md-field>
+            <label>Messages</label>
+            <md-textarea v-model="autogrow" disabled md-autogrow></md-textarea>
+          </md-field>
+        </form>
+      </md-card-content>
+  </div>
+
+  <script src="http://unpkg.com/vue"></script>
+  <script src="https://unpkg.com/vue-material"></script>
   <script>
-    function post(data) {
-      var bb = document.getElementById('blackboard')
-      var html = bb.innerHTML;
-      bb.innerHTML = html + '<br/>' + data;
-    }
     var s = new WebSocket("%s://%s/foobar/");
+
+    function post(message) {
+      app.messages.splice(0, 0, message);
+    }
+
     s.onopen = function () {
       post("connected !!!");
       s.send("ciao");
     };
+
     s.onmessage = function (e) {
       post(e.data);
     };
@@ -24,22 +59,27 @@
       post("connection closed");
     }
 
-    function invia() {
-      var value = document.getElementById('testo').value;
-      s.send(value);
-    }
-  </script>
-</head>
+    Vue.use(VueMaterial.default);
 
-<body>
-  <h1>WebSocket (asgi)</h1>
-  <form onsubmit="event.preventDefault(); return false;">
-    <input type="text" id="testo" />
-    <input type="submit" value="invia" onclick="invia();" />
-  </form>
-  <div id="blackboard"
-    style="width:640px;height:480px;background-color:black;color:white;border: solid 2px red;overflow:auto">
-  </div>
+    var app = new Vue({
+      el: '#app',
+      data: () => ({
+        messages: [],
+        textarea: "",
+      }),
+      computed: {
+        autogrow() {
+          return this.messages.join("\n");
+        }
+      },
+      methods: {
+        send() {
+          s.send(this.textarea);
+          this.textarea = "";
+        }
+      }
+    })
+  </script>
 </body>
 
 </html>

--- a/starlettetest.html
+++ b/starlettetest.html
@@ -1,0 +1,45 @@
+<html>
+
+<head>
+  <script>
+    function post(data) {
+      var bb = document.getElementById('blackboard')
+      var html = bb.innerHTML;
+      bb.innerHTML = html + '<br/>' + data;
+    }
+    var s = new WebSocket("%s://%s/foobar/");
+    s.onopen = function () {
+      post("connected !!!");
+      s.send("ciao");
+    };
+    s.onmessage = function (e) {
+      post(e.data);
+    };
+
+    s.onerror = function (e) {
+      post(e.toString());
+    }
+
+    s.onclose = function (e) {
+      post("connection closed");
+    }
+
+    function invia() {
+      var value = document.getElementById('testo').value;
+      s.send(value);
+    }
+  </script>
+</head>
+
+<body>
+  <h1>WebSocket (asgi)</h1>
+  <form onsubmit="event.preventDefault(); return false;">
+    <input type="text" id="testo" />
+    <input type="submit" value="invia" onclick="invia();" />
+  </form>
+  <div id="blackboard"
+    style="width:640px;height:480px;background-color:black;color:white;border: solid 2px red;overflow:auto">
+  </div>
+</body>
+
+</html>

--- a/starlettetest.py
+++ b/starlettetest.py
@@ -1,0 +1,12 @@
+from starlette.applications import Starlette
+from starlette.responses import JSONResponse
+from starlette.routing import Route
+
+
+async def homepage(request):
+    return JSONResponse({'hello': 'world'})
+
+
+app = Starlette(debug=True, routes=[
+    Route('/', homepage),
+])

--- a/starlettetest.py
+++ b/starlettetest.py
@@ -7,8 +7,11 @@ import os
 import asyncio
 import asyncio_redis
 
-with open(os.path.join(os.path.dirname(__file__), "starlettetest.html")) as tf:
-    template = tf.read()
+
+def get_template():
+    with open(os.path.join(os.path.dirname(__file__), "starlettetest.html")) as tf:
+        template = tf.read()
+    return template
 
 
 REDIS_CHANNEL = "foobar"
@@ -18,7 +21,7 @@ async def homepage(request):
     ws_scheme = "wss"
     if request["scheme"] == "http":
         ws_scheme = "ws"
-    return HTMLResponse(template % (ws_scheme, request.headers["host"]))
+    return HTMLResponse(get_template() % (ws_scheme, request.headers["host"]))
 
 
 async def websocket_endpoint(websocket: WebSocket):

--- a/starlettetest.py
+++ b/starlettetest.py
@@ -1,13 +1,90 @@
 from starlette.applications import Starlette
-from starlette.responses import JSONResponse
-from starlette.routing import Route
+from starlette.responses import JSONResponse, HTMLResponse
+from starlette.websockets import WebSocket
+from starlette.routing import Route, Mount, WebSocketRoute
+
+import os
+import asyncio
+import asyncio_redis
+
+with open(os.path.join(os.path.dirname(__file__), "starlettetest.html")) as tf:
+    template = tf.read()
+
+
+REDIS_CHANNEL = "foobar"
 
 
 async def homepage(request):
-    return JSONResponse({"hello": "world"})
+    ws_scheme = "wss"
+    if request["scheme"] == "http":
+        ws_scheme = "ws"
+    return HTMLResponse(template % (ws_scheme, request.headers["host"]))
 
 
-app = Starlette(debug=True, routes=[Route("/", homepage)])
+async def websocket_endpoint(websocket: WebSocket):
+    print("websocket_endpoint")
+    try:
+        await websocket.accept()
+        while True:
+            event = await websocket.receive()
+            msg = event["text"]
+            await websocket.send_text(msg.upper())
+            if msg == "bye":
+                break
+        await websocket.close()
+    except:
+        import traceback
+
+        traceback.print_exc()
+
+
+async def chat_endpoint(websocket: WebSocket):
+    """
+    Relay websocket messages to redis channel and vice versa.
+    """
+    await websocket.accept()
+
+    connection = await redis_connect()
+    subscriber = await redis_subscribe()
+    await subscriber.subscribe([REDIS_CHANNEL])
+
+    async def left():
+        while True:
+            event = await websocket.receive()
+            msg = event["text"]
+            await connection.publish(REDIS_CHANNEL, msg)
+
+    async def right():
+        while True:
+            print("getting a redis message")
+            msg = await subscriber.next_published()
+            print("redis msg", msg)
+            if msg:
+                await websocket.send_text(msg.value)
+
+    try:
+        await asyncio.gather(right(), left())
+    except:
+        import traceback
+
+        traceback.print_exc()
+        # cancel other task...
+
+
+async def redis_connect():
+    return await asyncio_redis.Connection.create(host="localhost", port=6379)
+
+
+async def redis_subscribe():
+    connection = await redis_connect()
+    subscriber = await connection.start_subscribe()
+    return subscriber
+
+
+app = Starlette(
+    debug=True,
+    routes=[Route("/", homepage), WebSocketRoute("/foobar/", chat_endpoint)],
+)
 
 import sys
 
@@ -23,7 +100,10 @@ def trace_calls_and_returns(frame, event, arg):
         return
     line_no = frame.f_lineno
     filename = co.co_filename
-    if not filename.startswith("/Users/daniel/prog/uwsgi/plugins/cffi/"):
+    if not (
+        "starlette" in filename
+        or filename.startswith("/Users/daniel/prog/uwsgi/plugins/cffi/")
+    ):
         return
     if event == "call":
         print("Call to %s on line %s of %s" % (func_name, line_no, filename))

--- a/starlettetest.py
+++ b/starlettetest.py
@@ -4,9 +4,37 @@ from starlette.routing import Route
 
 
 async def homepage(request):
-    return JSONResponse({'hello': 'world'})
+    return JSONResponse({"hello": "world"})
 
 
-app = Starlette(debug=True, routes=[
-    Route('/', homepage),
-])
+app = Starlette(debug=True, routes=[Route("/", homepage)])
+
+import sys
+
+
+UNINTERESTING_FUNCS = set(("asgi_scope_http",))
+
+
+def trace_calls_and_returns(frame, event, arg):
+    co = frame.f_code
+    func_name = co.co_name
+    if func_name == "write":
+        # Ignore write() calls from print statements
+        return
+    line_no = frame.f_lineno
+    filename = co.co_filename
+    if not filename.startswith("/Users/daniel/prog/uwsgi/plugins/cffi/"):
+        return
+    if event == "call":
+        print("Call to %s on line %s of %s" % (func_name, line_no, filename))
+        return trace_calls_and_returns
+    elif event == "return":
+        print("%s => %s" % (func_name, arg))
+    elif event == "line" and func_name not in UNINTERESTING_FUNCS:
+        print("%s:%s of %s" % (func_name, line_no, filename))
+    # else:
+    #     print(event)
+    return
+
+
+# sys.settrace(trace_calls_and_returns)

--- a/tests/asgitest.py
+++ b/tests/asgitest.py
@@ -54,8 +54,6 @@ def trace_calls_and_returns(frame, event, arg):
     return
 
 
-# sys.settrace(trace_calls_and_returns)
-
 from starlettetest import app
 
 
@@ -92,7 +90,7 @@ def application(env, sr):
         "asgi": {"spec_version": "2.1"},
         "http_version": environ["SERVER_PROTOCOL"][len("HTTP/") :].decode("utf-8"),
         "method": environ["REQUEST_METHOD"].decode("utf-8"),
-        "scheme": env["wsgi.url_scheme"],  #
+        "scheme": environ.get("UWSGI_SCHEME", "http"),
         "path": environ["PATH_INFO"].decode("utf-8"),
         "raw_path": environ["REQUEST_URI"],
         "query_string": environ["QUERY_STRING"],
@@ -134,5 +132,3 @@ def application(env, sr):
             if not event.get("more_body"):
                 break
 
-
-# if inspect.iscoroutinefunction(foo) or inspect.iscoroutinefunction(foo.__call__) assume asgi

--- a/tests/asgitest.py
+++ b/tests/asgitest.py
@@ -1,0 +1,138 @@
+
+
+async def asgifoo(scope, receive, send):
+    try:
+        pprint.pprint("in asgifoo")
+        event = await receive()
+        pprint.pprint("asgifoo got")
+        pprint.pprint(event)
+        await send(
+            {
+                "type": "http.response.start",
+                "status": 200,
+                "headers": [
+                    (b"X-Header", b"Amazing Value"),
+                    (b"Content-Type", b"text/plain; charset=UTF-8"),
+                ],
+            }
+        )
+        for i in range(32):
+            await send(
+                {
+                    "type": "http.response.body",
+                    "body": b"Hello from asgifoo %d\n" % i,
+                    "more_body": True,
+                }
+            )
+            await asyncio.sleep(1)
+        await send({"type": "http.response.body", "body": b"Goodbye from asgifoo"})
+    except:
+        # critical debug info
+        import traceback
+
+        traceback.print_exc()
+
+
+import sys
+
+
+def trace_calls_and_returns(frame, event, arg):
+    co = frame.f_code
+    func_name = co.co_name
+    if func_name == "write":
+        # Ignore write() calls from print statements
+        return
+    line_no = frame.f_lineno
+    filename = co.co_filename
+    if event == "call":
+        print("Call to %s on line %s of %s" % (func_name, line_no, filename))
+        return trace_calls_and_returns
+    elif event == "return":
+        print("%s => %s" % (func_name, arg))
+    # else:
+    #     print(event)
+    return
+
+
+# sys.settrace(trace_calls_and_returns)
+
+from starlettetest import app
+
+
+def application(env, sr):
+    """
+    Adapt uwsgi + greenlets to asgi + asyncio
+    """
+
+    # skip extra request
+    if env["PATH_INFO"] == "/favicon.ico":
+        sr("200 OK", [("Content-Type", "image/x-icon")])
+        return [b""]
+
+    import _uwsgi
+    from _uwsgi import ffi, lib
+
+    wsgi_req = _uwsgi.lib.uwsgi.current_wsgi_req()
+
+    environ = {}
+    headers = []
+    iov = wsgi_req.hvec
+    for i in range(0, wsgi_req.var_cnt, 2):
+        key, value = (
+            ffi.string(ffi.cast("char*", iov[i].iov_base), iov[i].iov_len),
+            ffi.string(ffi.cast("char*", iov[i + 1].iov_base), iov[i + 1].iov_len),
+        )
+        if key.startswith(b"HTTP_"):
+            headers.append((key[5:].lower(), value))
+        else:
+            environ[key.decode("ascii")] = value
+
+    scope = {
+        "type": "http",
+        "asgi": {"spec_version": "2.1"},
+        "http_version": environ["SERVER_PROTOCOL"][len("HTTP/") :].decode("utf-8"),
+        "method": environ["REQUEST_METHOD"].decode("utf-8"),
+        "scheme": env["wsgi.url_scheme"],  #
+        "path": environ["PATH_INFO"].decode("utf-8"),
+        "raw_path": environ["REQUEST_URI"],
+        "query_string": environ["QUERY_STRING"],
+        "root_path": environ["SCRIPT_NAME"].decode("utf-8"),
+        "headers": headers,
+        # some references to REMOTE_PORT but not always in environ
+        "client": (environ["REMOTE_ADDR"].decode("utf-8"), 0),
+        "server": (environ["SERVER_NAME"].decode("utf-8"), environ["SERVER_PORT"]),
+    }
+
+    gc = greenlet.getcurrent()
+
+    async def send(event):
+        gc.switch(event)
+        # do we need to do anything else to avoid pausing asyncio? or to give
+        # backpressure to the asgi app by waiting a bit longer?
+        # uwsgi probably switches to main greenlet / event loop for us.
+
+    async def receive():
+        print("can we rx something?")
+        return {"type": "http.request"}
+
+    asyncio.get_event_loop().create_task(app(scope, receive, send))
+
+    while True:
+        event = gc.parent.switch()
+        print("got", event, "in adapter")
+        if event["type"] == "http.response.start":
+            # raw uwsgi function accepts bytes
+            sr(
+                str(event["status"]),
+                [
+                    [key.decode("latin1"), value.decode("latin1")]
+                    for (key, value) in event["headers"]
+                ],
+            )
+        elif event["type"] == "http.response.body":
+            yield event["body"]
+            if not event.get("more_body"):
+                break
+
+
+# if inspect.iscoroutinefunction(foo) or inspect.iscoroutinefunction(foo.__call__) assume asgi

--- a/tests/websockets_chat_async.py
+++ b/tests/websockets_chat_async.py
@@ -10,12 +10,12 @@ import sys
 
 def application(env, sr):
 
-    ws_scheme = 'ws'
-    if 'HTTPS' in env or env['wsgi.url_scheme'] == 'https':
-        ws_scheme = 'wss'
+    ws_scheme = "ws"
+    if "HTTPS" in env or env["wsgi.url_scheme"] == "https":
+        ws_scheme = "wss"
 
-    if env['PATH_INFO'] == '/':
-        sr('200 OK', [('Content-Type', 'text/html')])
+    if env["PATH_INFO"] == "/":
+        sr("200 OK", [("Content-Type", "text/html")])
         output = """
     <html>
       <head>
@@ -47,24 +47,31 @@ def application(env, sr):
      </head>
     <body>
         <h1>WebSocket</h1>
+        <form onsubmit="event.preventDefault(); return false;">
         <input type="text" id="testo"/>
-        <input type="button" value="invia" onClick="invia();"/>
+        <input type="submit" value="invia" onclick="invia();" />
+        </form>
         <div id="blackboard" style="width:640px;height:480px;background-color:black;color:white;border: solid 2px red;overflow:auto">
         </div>
     </body>
     </html>
-        """ % (ws_scheme, env['HTTP_HOST'])
+        """ % (
+            ws_scheme,
+            env["HTTP_HOST"],
+        )
         if sys.version_info[0] > 2:
-            return output.encode('latin1')
-        return output
-    elif env['PATH_INFO'] == '/favicon.ico':
-        return ""
-    elif env['PATH_INFO'] == '/foobar/':
-        uwsgi.websocket_handshake(env['HTTP_SEC_WEBSOCKET_KEY'], env.get('HTTP_ORIGIN', ''))
+            return [output.encode("latin1")]
+        return [output]
+    elif env["PATH_INFO"] == "/favicon.ico":
+        return [""]
+    elif env["PATH_INFO"] == "/foobar/":
+        uwsgi.websocket_handshake(
+            env["HTTP_SEC_WEBSOCKET_KEY"], env.get("HTTP_ORIGIN", "")
+        )
         print("websockets...")
-        r = redis.StrictRedis(host='localhost', port=6379, db=0)
+        r = redis.StrictRedis(host="localhost", port=6379, db=0)
         channel = r.pubsub()
-        channel.subscribe('foobar')
+        channel.subscribe("foobar")
 
         websocket_fd = uwsgi.connection_fd()
         redis_fd = channel.connection._sock.fileno()
@@ -78,18 +85,23 @@ def application(env, sr):
                 if fd == websocket_fd:
                     msg = uwsgi.websocket_recv_nb()
                     if msg:
-                        r.publish('foobar', msg)
+                        r.publish("foobar", msg.decode("utf-8"))
                 elif fd == redis_fd:
                     msg = channel.parse_response()
                     print(msg)
                     # only interested in user messages
-                    t = 'message'
+                    t = "message"
                     if sys.version_info[0] > 2:
-                        t = b'message'
+                        t = b"message"
                     if msg[0] == t:
-                        uwsgi.websocket_send("[%s] %s" % (time.time(), msg))
+                        uwsgi.websocket_send(
+                            (
+                                "[%s] %s"
+                                % (time.time(), [m.decode("utf-8") for m in msg])
+                            ).encode("utf-8")
+                        )
             else:
                 # on timeout call websocket_recv_nb again to manage ping/pong
                 msg = uwsgi.websocket_recv_nb()
                 if msg:
-                    r.publish('foobar', msg)
+                    r.publish("foobar", msg.decode("utf-8"))

--- a/tests/websockets_chat_asyncio.py
+++ b/tests/websockets_chat_asyncio.py
@@ -113,7 +113,7 @@ def application(env, sr):
           </script>
      </head>
     <body>
-        <h1>WebSocket</h1>
+        <h1>WebSocket (asyncio)</h1>
         <form onsubmit="event.preventDefault(); return false;">
         <input type="text" id="testo"/>
         <input type="submit" value="invia" onclick="invia();" />


### PR DESCRIPTION
This adds asgi with an asyncio event loop to uWSGI. ASGI is a new way to do http + websockets from asyncio Python. The websockets chat example works. However it continues to be very difficult to get the uWSGI internals right, to figure out the right control flow when perhaps the old Python plugin was written against an older version of uWSGI's internals and the more maintained event loops seem to make greater use of the `wsgi_req->async_*` values. For example the websockets seem to close okay but are not logged.

I thought the tornado event loop was the easiest to read but I'm not sure if its approach would work with asyncio.

The coolest thing about this IMO is that it can detect WSGI and ASGI applications and just host them, both natively, wherever you decide they should be mounted. Perfectly fine if you have a normal "quick requests" WSGI app.