### PR TITLE
use strrchr to get port

### DIFF
--- a/plugins/corerouter/cr_common.c
+++ b/plugins/corerouter/cr_common.c
@@ -62,7 +62,7 @@ void uwsgi_corerouter_setup_sockets(struct uwsgi_corerouter *ucr) {
 
 				// fix SERVER_PORT
 				if (!ugs->port || !ugs->port_len) {
-					ugs->port = strchr(ugs->name, ':');
+					ugs->port = strrchr(ugs->name, ':');
 					if (ugs->port) {
 						ugs->port++;
 						ugs->port_len = strlen(ugs->port);


### PR DESCRIPTION
Noticed an ipv6 --http-socket=[::]:80 had a bad port in the SERVER_PORT variable