### PR TITLE
Request Transfer-Encoding

### DIFF
--- a/plugins/http/http.c
+++ b/plugins/http/http.c
@@ -1224,8 +1224,9 @@ ssize_t http_parse(struct corerouter_peer *main_peer) {
 			}
 
 			if (hr->remains > 0) {
-				if (hr->content_length < hr->remains) { 
-					hr->remains = hr->content_length;
+				if (hr->content_length < hr->remains) {
+					if (hr->content_length > 0 || !hr->raw_body)
+						hr->remains = hr->content_length;
 					hr->content_length = 0;
 					// we need to avoid problems with pipelined requests
 					hr->session.can_keepalive = 0;

--- a/plugins/python/wsgi_handlers.c
+++ b/plugins/python/wsgi_handlers.c
@@ -65,6 +65,7 @@ static PyObject *uwsgi_Input_read(uwsgi_Input *self, PyObject *args) {
 	char *buf = NULL;
 	if (wsgi_req->body_is_chunked && up.wsgi_manage_chunked_input) {
 		struct uwsgi_buffer *ubuf = uwsgi_chunked_read_smart(wsgi_req, arg_len, uwsgi.socket_timeout);
+		UWSGI_GET_GIL
 		if (!ubuf) {
        			return PyErr_Format(PyExc_IOError, "error during chunked read(%ld) on wsgi.input", arg_len);
 		}


### PR DESCRIPTION
2 bug fixes to Transfer-Encoding requests:
1. In raw mode (with no Content-Length), don't overwrite `hr->remains` and lose data
1. Make sure to grab the GIL before calling any Python methods