### PR TITLE
Graceful Harakiri

### DIFF
--- a/core/init.c
+++ b/core/init.c
@@ -188,6 +188,8 @@ void uwsgi_init_default() {
 	uwsgi_master_fifo_prepare();
 
 	uwsgi.notify_socket_fd = -1;
+
+	uwsgi.harakiri_options.delay = 0;
 }
 
 void uwsgi_setup_reload() {

--- a/core/master_checks.c
+++ b/core/master_checks.c
@@ -186,9 +186,13 @@ int uwsgi_master_check_workers_deadline() {
 	for (i = 1; i <= uwsgi.numproc; i++) {
 		/* first check for harakiri */
 		if (uwsgi.workers[i].harakiri > 0) {
-			if (uwsgi.workers[i].harakiri < (time_t) uwsgi.current_time) {
+			if (uwsgi.workers[i].harakiri < (time_t) uwsgi.current_time &&
+				uwsgi.workers[i].harakiri_delayed_at + uwsgi.harakiri_options.delay < (time_t) uwsgi.current_time
+			) {
 				trigger_harakiri(i);
-				ret = 1;
+				if (!uwsgi.workers[i].harakiri_delayed_at) {
+					ret = 1;
+				}
 			}
 		}
 		/* then user-defined harakiri */

--- a/core/uwsgi.c
+++ b/core/uwsgi.c
@@ -80,6 +80,7 @@ static struct uwsgi_option uwsgi_base_options[] = {
 	{"workers", required_argument, 'p', "spawn the specified number of workers/processes", uwsgi_opt_set_int, &uwsgi.numproc, 0},
 	{"thunder-lock", no_argument, 0, "serialize accept() usage (if possible)", uwsgi_opt_true, &uwsgi.use_thunder_lock, 0},
 	{"harakiri", required_argument, 't', "set harakiri timeout", uwsgi_opt_set_int, &uwsgi.harakiri_options.workers, 0},
+	{"harakiri-delay", required_argument, 0, "set harakiri delay time", uwsgi_opt_set_int, &uwsgi.harakiri_options.delay, 0},
 	{"harakiri-verbose", no_argument, 0, "enable verbose mode for harakiri", uwsgi_opt_true, &uwsgi.harakiri_verbose, 0},
 	{"harakiri-no-arh", no_argument, 0, "do not enable harakiri during after-request-hook", uwsgi_opt_true, &uwsgi.harakiri_no_arh, 0},
 	{"no-harakiri-arh", no_argument, 0, "do not enable harakiri during after-request-hook", uwsgi_opt_true, &uwsgi.harakiri_no_arh, 0},

--- a/plugins/psgi/psgi.h
+++ b/plugins/psgi/psgi.h
@@ -66,6 +66,8 @@ struct uwsgi_perl {
 
 	CV *spooler;
 
+	struct uwsgi_string_list *exec_pre_harakiri;
+
 	int no_plack;
 };
 

--- a/uwsgi.h
+++ b/uwsgi.h
@@ -1740,6 +1740,7 @@ struct uwsgi_harakiri_options {
 	int workers;
 	int spoolers;
 	int mules;
+	int delay;
 };
 
 struct uwsgi_fsmon {
@@ -3018,6 +3019,7 @@ struct uwsgi_worker {
 
 	time_t harakiri;
 	time_t user_harakiri;
+	time_t harakiri_delayed_at;
 	uint64_t harakiri_count;
 	int pending_harakiri;
 


### PR DESCRIPTION
There two commits for this new features, one in core, which contains the infrastructure for supporting graceful-harakiri. Another is psgi, which makes use of the new feature. Currently, the harakiri delay is only useful if plugins wants to do some special operations on the worker (like dumping stacktrace).

Bellow are the commit messages:

## core: introduce a harakiri graceful period mechanism

Usually when a harakiri timeout is triggered, uwsgi master fires an SIGKILL to
the worker immediately. There is no time for the app to perform some operations
on the worker like triggering a stacktrace dump or generates a notification.
This commit introduces a harakiri delay time to make it easy and possible. It is
up to plugins like psgi to set a harakiri_delayed_at timestamp to tell the
master if it wants to give some time for the plugin to perform some special
operations like dumping stacktraces before the worker is killed.œ

The new delay time is controlled by a new option: harakiri-delay. By default,
no harakiri delay is applied.

## plugins/psgi: add a harakiri handler and a pre-harakiri command

This commits makes use of the new harakiri graceful period mechanism. If a user
specifies the psgi-exec-pre-harakiri option, which is a separate program, then
psgi will trigger the program before harakiri and sets the harakiri_delayed_at,
which stops master from killing the worker immediately and delayed it after
harakiri-delay time (default is 0s).

There two environment variables is set for the `psgi-exec-pre-harakiri` command:

	UWSGI_HARAKIRI_WORKER_PID
	UWSGI_HARAKIRI_REQUEST_URI

A config example:

	harakiri-delay = 3
	psgi-exec-pre-harakiri = /bin/send_harakiri_event_with_stacktrace
