### PR TITLE
python: Use new Py_SET_SIZE API introduced in Python 3.9

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -38,3 +38,4 @@ Alexandre Bonnetain
 Darvame Hleran
 Sokolov Yura <funny.falcon@gmail.com>
 Marcin Lulek <info@webreactor.eu>
+Derzsi Dániel <daniel@tohka.us>

--- a/plugins/python/uwsgi_pymodule.c
+++ b/plugins/python/uwsgi_pymodule.c
@@ -2039,7 +2039,7 @@ PyObject *py_uwsgi_sharedarea_read(PyObject * self, PyObject * args) {
         }
 
 	// HACK: we are safe as rlen can only be lower or equal to len
-	Py_SIZE(ret) = rlen;
+	Py_SET_SIZE((PyVarObject *) ret, rlen);
 
 	return ret;
 }

--- a/plugins/python/uwsgi_python.h
+++ b/plugins/python/uwsgi_python.h
@@ -42,9 +42,9 @@
 #define PYTHREE
 #endif
 
-#if (PY_VERSION_HEX < 0x02060000)
-#ifndef Py_SIZE
-#define Py_SIZE(ob)             (((PyVarObject*)(ob))->ob_size)
+#if (PY_VERSION_HEX < 0x03090000)
+#ifndef Py_SET_SIZE
+#define Py_SET_SIZE(o, size) ((o)->ob_size = (size))
 #endif
 #endif
 


### PR DESCRIPTION
Python 3.9 implements a new API method: `Py_SET_SIZE` which is used for setting a PyVarObject's type: https://docs.python.org/3.9/c-api/structures.html#c.Py_SET_SIZE

In Python 3.10, `Py_SIZE` was changed from a macro to a function, which changes its fundamental syntax: https://docs.python.org/3.10/c-api/structures.html#c.Py_SIZE

This causes a compile error using Python 3.10:

```
plugins/python/uwsgi_pymodule.c:1825:15: error: expression is not assignable
          Py_SIZE(ret) = rlen;
           ~~~~~~~~~~~~ ^
```

Therefore, we should migrate the usage of Py_SIZE to set the object size to the new Py_SET_SIZE API, which was specifically made for this purpose.

For all versions below Python 3.9, `Py_SET_SIZE` is implemented by a macro with the old functionality. This even allows us to remove an old Python 2.6 compatibility macro.