### PR TITLE
Enable the py-tracebacker for mules

### DIFF
--- a/plugins/python/python_plugin.c
+++ b/plugins/python/python_plugin.c
@@ -169,6 +169,7 @@ struct uwsgi_option uwsgi_python_options[] = {
 	{"pyrun", required_argument, 0, "run a python script in the uWSGI environment", uwsgi_opt_pyrun, NULL, 0},
 
 	{"py-tracebacker", required_argument, 0, "enable the uWSGI python tracebacker", uwsgi_opt_set_str, &up.tracebacker, UWSGI_OPT_THREADS|UWSGI_OPT_MASTER},
+	{"py-tracebacker-mule", required_argument, 0, "enable the uWSGI python tracebacker for mules", uwsgi_opt_set_str, &up.mule_tracebacker, UWSGI_OPT_THREADS|UWSGI_OPT_MASTER},
 
 	{"py-auto-reload", required_argument, 0, "monitor python modules mtime to trigger reload (use only in development)", uwsgi_opt_set_int, &up.auto_reload, UWSGI_OPT_THREADS|UWSGI_OPT_MASTER},
 	{"py-autoreload", required_argument, 0, "monitor python modules mtime to trigger reload (use only in development)", uwsgi_opt_set_int, &up.auto_reload, UWSGI_OPT_THREADS|UWSGI_OPT_MASTER},
@@ -467,7 +468,7 @@ void uwsgi_python_post_fork() {
 		}
 	}
 	if (uwsgi.muleid > 0) {
-		if (up.tracebacker) {
+		if (up.mule_tracebacker) {
 			// spawn the tracebacker thread
 			pthread_t ptb_tid;
 			pthread_create(&ptb_tid, NULL, uwsgi_python_tracebacker_thread, NULL);

--- a/plugins/python/python_plugin.c
+++ b/plugins/python/python_plugin.c
@@ -466,6 +466,13 @@ void uwsgi_python_post_fork() {
 			pthread_create(&ptb_tid, NULL, uwsgi_python_tracebacker_thread, NULL);
 		}
 	}
+	if (uwsgi.muleid > 0) {
+		if (up.tracebacker) {
+			// spawn the tracebacker thread
+			pthread_t ptb_tid;
+			pthread_create(&ptb_tid, NULL, uwsgi_python_tracebacker_thread, NULL);
+		}
+	}
 
 UWSGI_RELEASE_GIL
 

--- a/plugins/python/tracebacker.c
+++ b/plugins/python/tracebacker.c
@@ -65,8 +65,16 @@ void *uwsgi_python_tracebacker_thread(void *foobar) {
 	struct sockaddr_un so_sun;
 	socklen_t so_sun_len = 0;
 
-	char *str_wid = uwsgi_num2str(uwsgi.mywid);
-	char *sock_path = uwsgi_concat2(up.tracebacker, str_wid);
+	char *str_wid = NULL;
+	char *sock_path = NULL;
+	if (uwsgi.muleid > 0) {
+		str_wid = uwsgi_num2str(uwsgi.muleid);
+		sock_path = uwsgi_concat3(up.tracebacker, "-mule-", str_wid);
+	}
+	else {
+		str_wid = uwsgi_num2str(uwsgi.mywid);
+		sock_path = uwsgi_concat2(up.tracebacker, str_wid);
+	}
 
 	int current_defer_accept = uwsgi.no_defer_accept;
         uwsgi.no_defer_accept = 1;
@@ -94,7 +102,12 @@ void *uwsgi_python_tracebacker_thread(void *foobar) {
 
 	PyObject *_current_frames = PyDict_GetItemString(sys_dict, "_current_frames");
 
-	uwsgi_log("python tracebacker for worker %d available on %s\n", uwsgi.mywid, sock_path);
+	if (uwsgi.muleid > 0) {
+		uwsgi_log("python tracebacker for mule %d available on %s\n", uwsgi.mywid, sock_path);
+	}
+	else {
+		uwsgi_log("python tracebacker for worker %d available on %s\n", uwsgi.muleid, sock_path);
+	}
 
 	for(;;) {
 		UWSGI_RELEASE_GIL;

--- a/plugins/python/tracebacker.c
+++ b/plugins/python/tracebacker.c
@@ -69,7 +69,7 @@ void *uwsgi_python_tracebacker_thread(void *foobar) {
 	char *sock_path = NULL;
 	if (uwsgi.muleid > 0) {
 		str_wid = uwsgi_num2str(uwsgi.muleid);
-		sock_path = uwsgi_concat3(up.tracebacker, "-mule-", str_wid);
+		sock_path = uwsgi_concat2(up.mule_tracebacker, str_wid);
 	}
 	else {
 		str_wid = uwsgi_num2str(uwsgi.mywid);
@@ -103,10 +103,10 @@ void *uwsgi_python_tracebacker_thread(void *foobar) {
 	PyObject *_current_frames = PyDict_GetItemString(sys_dict, "_current_frames");
 
 	if (uwsgi.muleid > 0) {
-		uwsgi_log("python tracebacker for mule %d available on %s\n", uwsgi.mywid, sock_path);
+		uwsgi_log("python tracebacker for mule %d available on %s\n", uwsgi.muleid, sock_path);
 	}
 	else {
-		uwsgi_log("python tracebacker for worker %d available on %s\n", uwsgi.muleid, sock_path);
+		uwsgi_log("python tracebacker for worker %d available on %s\n", uwsgi.mywid, sock_path);
 	}
 
 	for(;;) {

--- a/plugins/python/uwsgi_python.h
+++ b/plugins/python/uwsgi_python.h
@@ -187,6 +187,7 @@ struct uwsgi_python {
 	void (*gil_release) (void);
 	int auto_reload;
 	char *tracebacker;
+	char *mule_tracebacker;
 	struct uwsgi_string_list *auto_reload_ignore;
 
 	PyObject *workers_tuple;


### PR DESCRIPTION
The current traceback system is great for giving visibility into the callstacks for serving requests, but when you use mules you don't get to see the same data.

This adds a new configuration option, --py-tracebacker-mule, which works the same way as --py-tracebacker. I added a new option because I didn't want to break anyone who was using the old behavior (although an earlier version of this change simply uses the same base path and adds -mule as a suffix between the path and the number). This results in in the same sockets being created as before and you can then read the stacks from them.

This is really useful in my usage, and I hoped others might find it useful enough that it should be a core feature.