### PR TITLE
core, proto: replace uwsgi.h system includes

### DIFF
--- a/core/async.c
+++ b/core/async.c
@@ -1,4 +1,4 @@
-#include <uwsgi.h>
+#include "uwsgi.h"
 
 extern struct uwsgi_server uwsgi;
 

--- a/core/cache.c
+++ b/core/cache.c
@@ -1,4 +1,4 @@
-#include <uwsgi.h>
+#include "uwsgi.h"
 
 extern struct uwsgi_server uwsgi;
 #define cache_item(x) (struct uwsgi_cache_item *) (((char *)uc->items) + ((sizeof(struct uwsgi_cache_item)+uc->keysize) * x))

--- a/core/chunked.c
+++ b/core/chunked.c
@@ -1,4 +1,4 @@
-#include <uwsgi.h>
+#include "uwsgi.h"
 
 extern struct uwsgi_server uwsgi;
 

--- a/core/config.c
+++ b/core/config.c
@@ -1,4 +1,4 @@
-#include <uwsgi.h>
+#include "uwsgi.h"
 
 /*
 

--- a/core/cookie.c
+++ b/core/cookie.c
@@ -1,4 +1,4 @@
-#include <uwsgi.h>
+#include "uwsgi.h"
 
 /*
 

--- a/core/cron.c
+++ b/core/cron.c
@@ -1,4 +1,4 @@
-#include <uwsgi.h>
+#include "uwsgi.h"
 
 extern struct uwsgi_server uwsgi;
 

--- a/core/daemons.c
+++ b/core/daemons.c
@@ -1,4 +1,4 @@
-#include <uwsgi.h>
+#include "uwsgi.h"
 
 extern struct uwsgi_server uwsgi;
 

--- a/core/emperor.c
+++ b/core/emperor.c
@@ -3,7 +3,7 @@
 The uWSGI Emperor
 
 */
-#include <uwsgi.h>
+#include "uwsgi.h"
 
 extern struct uwsgi_server uwsgi;
 extern char **environ;

--- a/core/errors.c
+++ b/core/errors.c
@@ -1,4 +1,4 @@
-#include <uwsgi.h>
+#include "uwsgi.h"
 
 extern struct uwsgi_server uwsgi;
 

--- a/core/exceptions.c
+++ b/core/exceptions.c
@@ -1,4 +1,4 @@
-#include <uwsgi.h>
+#include "uwsgi.h"
 
 extern struct uwsgi_server uwsgi;
 

--- a/core/fifo.c
+++ b/core/fifo.c
@@ -1,4 +1,4 @@
-#include <uwsgi.h>
+#include "uwsgi.h"
 
 extern struct uwsgi_server uwsgi;
 

--- a/core/fork_server.c
+++ b/core/fork_server.c
@@ -1,4 +1,4 @@
-#include <uwsgi.h>
+#include "uwsgi.h"
 
 extern struct uwsgi_server uwsgi;
 

--- a/core/fsmon.c
+++ b/core/fsmon.c
@@ -1,4 +1,4 @@
-#include <uwsgi.h>
+#include "uwsgi.h"
 
 extern struct uwsgi_server uwsgi;
 

--- a/core/hash.c
+++ b/core/hash.c
@@ -1,4 +1,4 @@
-#include <uwsgi.h>
+#include "uwsgi.h"
 
 extern struct uwsgi_server uwsgi;
 

--- a/core/hooks.c
+++ b/core/hooks.c
@@ -1,4 +1,4 @@
-#include <uwsgi.h>
+#include "uwsgi.h"
 
 extern struct uwsgi_server uwsgi;
 

--- a/core/ini.c
+++ b/core/ini.c
@@ -1,4 +1,4 @@
-#include <uwsgi.h>
+#include "uwsgi.h"
 
 extern struct uwsgi_server uwsgi;
 

--- a/core/logging.c
+++ b/core/logging.c
@@ -1,5 +1,5 @@
 #ifndef __DragonFly__
-#include <uwsgi.h>
+#include "uwsgi.h"
 #endif
 #if defined(__FreeBSD__) || defined(__NetBSD__) || defined(__DragonFly__) || defined(__OpenBSD__)
 #include <sys/user.h>
@@ -15,7 +15,7 @@
 #endif
 
 #ifdef __DragonFly__
-#include <uwsgi.h>
+#include "uwsgi.h"
 #endif
 
 extern struct uwsgi_server uwsgi;

--- a/core/master_checks.c
+++ b/core/master_checks.c
@@ -1,4 +1,4 @@
-#include <uwsgi.h>
+#include "uwsgi.h"
 
 extern struct uwsgi_server uwsgi;
 

--- a/core/master_events.c
+++ b/core/master_events.c
@@ -1,4 +1,4 @@
-#include <uwsgi.h>
+#include "uwsgi.h"
 
 extern struct uwsgi_server uwsgi;
 

--- a/core/metrics.c
+++ b/core/metrics.c
@@ -1,4 +1,4 @@
-#include <uwsgi.h>
+#include "uwsgi.h"
 
 extern struct uwsgi_server uwsgi;
 

--- a/core/mount.c
+++ b/core/mount.c
@@ -1,4 +1,4 @@
-#include <uwsgi.h>
+#include "uwsgi.h"
 
 /*
 

--- a/core/notify.c
+++ b/core/notify.c
@@ -1,4 +1,4 @@
-#include <uwsgi.h>
+#include "uwsgi.h"
 
 extern struct uwsgi_server uwsgi;
 

--- a/core/plugins_builder.c
+++ b/core/plugins_builder.c
@@ -1,4 +1,4 @@
-#include <uwsgi.h>
+#include "uwsgi.h"
 
 #define UWSGI_BUILD_DIR ".uwsgi_plugins_builder"
 

--- a/core/progress.c
+++ b/core/progress.c
@@ -1,4 +1,4 @@
-#include <uwsgi.h>
+#include "uwsgi.h"
 
 /*
 

--- a/core/querystring.c
+++ b/core/querystring.c
@@ -1,4 +1,4 @@
-#include <uwsgi.h>
+#include "uwsgi.h"
 
 /*
 

--- a/core/rb_timers.c
+++ b/core/rb_timers.c
@@ -10,7 +10,7 @@
         the "Introduction to Algorithms" by Cormen, Leiserson and Rivest.
 */
 
-#include <uwsgi.h>
+#include "uwsgi.h"
 
 #define uwsgi_rbt_red(node)               ((node)->color = 1)
 #define uwsgi_rbt_black(node)             ((node)->color = 0)

--- a/core/reader.c
+++ b/core/reader.c
@@ -1,4 +1,4 @@
-#include <uwsgi.h>
+#include "uwsgi.h"
 
 extern struct uwsgi_server uwsgi;
 

--- a/core/routing.c
+++ b/core/routing.c
@@ -1,5 +1,5 @@
 #ifdef UWSGI_ROUTING
-#include <uwsgi.h>
+#include "uwsgi.h"
 
 extern struct uwsgi_server uwsgi;
 

--- a/core/rpc.c
+++ b/core/rpc.c
@@ -1,4 +1,4 @@
-#include <uwsgi.h>
+#include "uwsgi.h"
 
 extern struct uwsgi_server uwsgi;
 

--- a/core/sharedarea.c
+++ b/core/sharedarea.c
@@ -1,4 +1,4 @@
-#include <uwsgi.h>
+#include "uwsgi.h"
 
 extern struct uwsgi_server uwsgi;
 

--- a/core/snmp.c
+++ b/core/snmp.c
@@ -1,4 +1,4 @@
-#include <uwsgi.h>
+#include "uwsgi.h"
 
 extern struct uwsgi_server uwsgi;
 

--- a/core/ssl.c
+++ b/core/ssl.c
@@ -1,4 +1,4 @@
-#include <uwsgi.h>
+#include "uwsgi.h"
 #include <openssl/rand.h>
 #include <openssl/sha.h>
 #include <openssl/md5.h>

--- a/core/strings.c
+++ b/core/strings.c
@@ -1,4 +1,4 @@
-#include <uwsgi.h>
+#include "uwsgi.h"
 
 char *uwsgi_str_split_nget(char *str, size_t len, char what, size_t pos, size_t *rlen) {
 	size_t i;

--- a/core/timebomb.c
+++ b/core/timebomb.c
@@ -1,4 +1,4 @@
-#include <uwsgi.h>
+#include "uwsgi.h"
 
 /*
 

--- a/core/transformations.c
+++ b/core/transformations.c
@@ -1,4 +1,4 @@
-#include <uwsgi.h>
+#include "uwsgi.h"
 
 /*
 

--- a/core/utils.c
+++ b/core/utils.c
@@ -1,4 +1,4 @@
-#include <uwsgi.h>
+#include "uwsgi.h"
 
 
 extern struct uwsgi_server uwsgi;

--- a/core/uwsgi.c
+++ b/core/uwsgi.c
@@ -21,7 +21,7 @@
 */
 
 
-#include <uwsgi.h>
+#include "uwsgi.h"
 
 struct uwsgi_server uwsgi;
 pid_t masterpid;

--- a/core/webdav.c
+++ b/core/webdav.c
@@ -1,4 +1,4 @@
-#include <uwsgi.h>
+#include "uwsgi.h"
 
 extern struct uwsgi_server uwsgi;
 

--- a/core/websockets.c
+++ b/core/websockets.c
@@ -1,4 +1,4 @@
-#include <uwsgi.h>
+#include "uwsgi.h"
 
 /*
 

--- a/core/zeus.c
+++ b/core/zeus.c
@@ -1,4 +1,4 @@
-#include <uwsgi.h>
+#include "uwsgi.h"
 
 /*
 

--- a/core/zlib.c
+++ b/core/zlib.c
@@ -1,4 +1,4 @@
-#include <uwsgi.h>
+#include "uwsgi.h"
 
 char gzheader[10] = { 0x1f, 0x8b, Z_DEFLATED, 0, 0, 0, 0, 0, 0, 3 };
 

--- a/proto/BUILD
+++ b/proto/BUILD
@@ -1,0 +1,1 @@
+exports_files(glob(["*.c"]))

--- a/proto/base.c
+++ b/proto/base.c
@@ -1,4 +1,4 @@
-#include <uwsgi.h>
+#include "uwsgi.h"
 
 extern struct uwsgi_server uwsgi;
 

--- a/proto/fastcgi.c
+++ b/proto/fastcgi.c
@@ -1,6 +1,6 @@
 /* async fastcgi protocol parser */
 
-#include <uwsgi.h>
+#include "uwsgi.h"
 
 extern struct uwsgi_server uwsgi;
 

--- a/proto/http.c
+++ b/proto/http.c
@@ -1,6 +1,6 @@
 /* async http protocol parser */
 
-#include <uwsgi.h>
+#include "uwsgi.h"
 
 extern struct uwsgi_server uwsgi;
 

--- a/proto/puwsgi.c
+++ b/proto/puwsgi.c
@@ -1,6 +1,6 @@
 /* async uwsgi protocol parser */
 
-#include <uwsgi.h>
+#include "uwsgi.h"
 
 extern struct uwsgi_server uwsgi;
 

--- a/proto/scgi.c
+++ b/proto/scgi.c
@@ -1,6 +1,6 @@
 /* async SCGI protocol parser */
 
-#include <uwsgi.h>
+#include "uwsgi.h"
 
 extern struct uwsgi_server uwsgi;
 

--- a/proto/uwsgi.c
+++ b/proto/uwsgi.c
@@ -1,6 +1,6 @@
 /* async uwsgi protocol parser */
 
-#include <uwsgi.h>
+#include "uwsgi.h"
 
 extern struct uwsgi_server uwsgi;
 


### PR DESCRIPTION
This replaces all `#include <uwsgi.h>` in core/ and proto/ with `#include "uwsgi.h"`.

This is to make it easier to build uWSGI with build systems that are more opinonated about local-vs-system include directories (eg. Bazel), and is without detriment to uWSGI itself (at least as far as I can tell).