### PR TITLE
Fix compilation with clang11 on FreeBSD 13.0

### DIFF
--- a/plugins/gevent/gevent.c
+++ b/plugins/gevent/gevent.c
@@ -389,7 +389,7 @@ static void gil_gevent_get() {
 }
 
 static void gil_gevent_release() {
-	PyGILState_Release((PyGILState_STATE) pthread_getspecific(up.upt_gil_key));
+	PyGILState_Release((long) pthread_getspecific(up.upt_gil_key));
 }
 
 static void monkey_patch() {

--- a/plugins/gevent/gevent.c
+++ b/plugins/gevent/gevent.c
@@ -389,7 +389,7 @@ static void gil_gevent_get() {
 }
 
 static void gil_gevent_release() {
-	PyGILState_Release((long) pthread_getspecific(up.upt_gil_key));
+	PyGILState_Release((PyGILState_STATE)(long) pthread_getspecific(up.upt_gil_key));
 }
 
 static void monkey_patch() {


### PR DESCRIPTION
This fixes the compilation error mentioned in https://github.com/unbit/uwsgi/issues/2238#issuecomment-819929450.