### PR TITLE
plugins/gevent: fix compilation with clang11

### DIFF
--- a/plugins/gevent/gevent.c
+++ b/plugins/gevent/gevent.c
@@ -389,7 +389,7 @@ static void gil_gevent_get() {
 }
 
 static void gil_gevent_release() {
-	PyGILState_Release((PyGILState_STATE) pthread_getspecific(up.upt_gil_key));
+	PyGILState_Release((PyGILState_STATE)(long) pthread_getspecific(up.upt_gil_key));
 }
 
 static void monkey_patch() {


### PR DESCRIPTION
plugins/gevent/gevent.c[thread 11]:
392:21: error: cast to smaller integer type 'PyGILState_STATE' from 'void *' [-Werror,-Wvoid-pointer-to-enum-cast]
        PyGILState_Release((PyGILState_STATE) pthread_getspecific(up.upt_gil_key));
                           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

Fix #2238