### PR TITLE
uwsgiconfig: Drop Homebrew-specific workaround

### DIFF
--- a/uwsgiconfig.py
+++ b/uwsgiconfig.py
@@ -1253,8 +1253,6 @@ class uConf(object):
                 else:
                     jsonconf = spcall("pkg-config --cflags yajl")
                     if jsonconf:
-                        if jsonconf.endswith('include/yajl'):
-                            jsonconf = jsonconf.rstrip('yajl')
                         self.cflags.append(jsonconf)
                         self.cflags.append("-DUWSGI_JSON")
                         self.gcc_list.append('core/json')


### PR DESCRIPTION
This is a tentative pull request because the necessary changes to Homebrew haven't been accepted yet.

In https://github.com/Homebrew/homebrew-core/pull/74516, the libvirt developers have been attempting to get the yajl issues that https://github.com/unbit/uwsgi/commit/80c3d6528b257ab9e173fda130b55141e7697f3c was intended to work around addressed in Homebrew. We have our own, similar workaround already in place, but we believe that the issue would be better fixed once and for all in Homebrew rather than worked around separately in each project that uses yajl and wants to support macOS.

The Homebrew maintainers have, quite understandably, been reluctant to introduce and carry a downstream-only patch. In [a recent comment](https://github.com/Homebrew/homebrew-core/pull/74516#issuecomment-843698702) however, the maintainers declared themselves willing to consider incorporating the fix under the condition that at least one more project in addition to libvirt would ask for that to happen.

Would uwsgi developers be willing to join the libvirt developers in asking for this bug in yajl to be addressed in Homebrew instead of being worked around in each project that uses the library?

Thank you for your consideration!