### PR TITLE
Log SIGINT/SIGTERM triggered kill_them_all

### DIFF
--- a/core/uwsgi.c
+++ b/core/uwsgi.c
@@ -1375,7 +1375,7 @@ void kill_them_all(int signum) {
 	// unsubscribe if needed
 	uwsgi_unsubscribe_all();
 
-	uwsgi_log("SIGINT/SIGQUIT received...killing workers...\n");
+	uwsgi_log("SIGINT/SIGTERM received...killing workers...\n");
 
 	int i;
 	for (i = 1; i <= uwsgi.numproc; i++) {


### PR DESCRIPTION
Log `SIGINT/SIGTERM` instead of `SIGTERM/SIGQUIT` in `kill_them_all` because `SIGINT` and `SIGTERM` are the two signals that will run that function:

https://github.com/unbit/uwsgi/blob/d58a832c81c2c96ae0f6e72614e1cc47f4b5d332/core/master.c#L374-L378


