### PR TITLE
Ssl socket activation

### DIFF
--- a/core/setup_utils.c
+++ b/core/setup_utils.c
@@ -14,7 +14,7 @@ void uwsgi_setup_systemd() {
 			if (listen_fds) {
 				int systemd_fds = atoi(listen_fds);
 				if (systemd_fds > 0) {
-					uwsgi_log("- SystemD socket activation detected -\n");
+					uwsgi_log("- systemd socket activation detected -\n");
 					for (i = 3; i < 3 + systemd_fds; i++) {
 						uwsgi_sock = uwsgi_new_socket(NULL);
 						uwsgi_add_socket_from_fd(uwsgi_sock, i);

--- a/core/socket.c
+++ b/core/socket.c
@@ -1160,6 +1160,21 @@ void uwsgi_add_socket_from_fd(struct uwsgi_socket *uwsgi_sock, int fd) {
 							uwsgi_log("uwsgi zerg socket %d attached to INET address %s fd %d\n", uwsgi_get_socket_num(uwsgi_sock), computed_addr, uwsgi_sock->fd);
 						}
 						else {
+							struct uwsgi_socket *us = uwsgi.sockets;
+							while (us) {
+								/*
+								 * Apply SSL configuration for https-socket
+								 * under the same name to the the socket received form
+								 * systemd or upstart.
+								 */
+								if (!strcmp(us->name, computed_addr)) {
+									uwsgi_sock->proto_name = uwsgi_concat2(us->proto_name, "");
+									uwsgi_sock->ssl_ctx = us->ssl_ctx;
+									us->ssl_ctx = NULL;
+									break;
+								}
+								us = us->next;
+							}
 							uwsgi_log("uwsgi socket %d attached to INET address %s fd %d\n", uwsgi_get_socket_num(uwsgi_sock), computed_addr, uwsgi_sock->fd);
 						}
 						free(computed_addr);
@@ -1228,6 +1243,21 @@ void uwsgi_add_socket_from_fd(struct uwsgi_socket *uwsgi_sock, int fd) {
 							uwsgi_log("uwsgi zerg socket %d attached to INET6 address %s fd %d\n", uwsgi_get_socket_num(uwsgi_sock), computed_addr, uwsgi_sock->fd);
 						}
 						else {
+							struct uwsgi_socket *us = uwsgi.sockets;
+							while (us) {
+								/*
+								 * Apply SSL configuration for https-socket
+								 * under the same name to the the socket received form
+								 * systemd or upstart.
+								 */
+								if (!strcmp(us->name, computed_addr)) {
+									uwsgi_sock->proto_name = uwsgi_concat2(us->proto_name, "");
+									uwsgi_sock->ssl_ctx = us->ssl_ctx;
+									us->ssl_ctx = NULL;
+									break;
+								}
+								us = us->next;
+							}
 							uwsgi_log("uwsgi socket %d attached to INET6 address %s fd %d\n", uwsgi_get_socket_num(uwsgi_sock), computed_addr, uwsgi_sock->fd);
 						}
 						free(computed_addr);

--- a/core/socket.c
+++ b/core/socket.c
@@ -1155,6 +1155,7 @@ void uwsgi_add_socket_from_fd(struct uwsgi_socket *uwsgi_sock, int fd) {
 						uwsgi_sock->family = AF_INET;
 						uwsgi_sock->bound = 1;
 						uwsgi_sock->name = uwsgi_concat2(computed_addr, "");
+						uwsgi_sock->name_len = strlen(uwsgi_sock->name);
 						if (uwsgi.zerg) {
 							uwsgi_log("uwsgi zerg socket %d attached to INET address %s fd %d\n", uwsgi_get_socket_num(uwsgi_sock), computed_addr, uwsgi_sock->fd);
 						}
@@ -1222,6 +1223,7 @@ void uwsgi_add_socket_from_fd(struct uwsgi_socket *uwsgi_sock, int fd) {
 						uwsgi_sock->family = AF_INET6;
 						uwsgi_sock->bound = 1;
 						uwsgi_sock->name = uwsgi_concat2(computed_addr, "");
+						uwsgi_sock->name_len = strlen(uwsgi_sock->name);
 						if (uwsgi.zerg) {
 							uwsgi_log("uwsgi zerg socket %d attached to INET6 address %s fd %d\n", uwsgi_get_socket_num(uwsgi_sock), computed_addr, uwsgi_sock->fd);
 						}


### PR DESCRIPTION
If I am not mistaken, it isn't possible at the moment to configure uWSGI to receive sockets from systemd **and** use them as SSL sockets. These patches (actually the last one) makes uWSGI grab SSL context from `uwsgi_socket` configured in a config file and apply it to a socket received from systemd (while detaching it from the original structure).

For an SSL configuration to be applied to a socket received from systemd its computed name must match the name configured with `https-socket`.

**WARNING!** Although I have tested it for both IPv4 and IPv6 and it works for me, I am not entirely sure this is the right way to do it. Please, review the patches carefully.