### PR TITLE
allow 'iteration' option to uwsgi::add_rb_timer

### DIFF
--- a/plugins/psgi/uwsgi_plmodule.c
+++ b/plugins/psgi/uwsgi_plmodule.c
@@ -659,8 +659,13 @@ XS(XS_add_rb_timer) {
 
         uint8_t uwsgi_signal = SvIV(ST(0));
         int seconds = SvIV(ST(1));
+        int iterations = 0;
 
-        if (uwsgi_signal_add_rb_timer(uwsgi_signal, seconds, 0)) {
+        if (items > 2) {
+                iterations = SvIV(ST(2));
+        }
+
+        if (uwsgi_signal_add_rb_timer(uwsgi_signal, seconds, iterations)) {
                 croak("unable to register rb timer");
                 XSRETURN_UNDEF;
         }


### PR DESCRIPTION
The caller can now specify a custom iteration value when setting an
rb_timer.

The default is still zero if no third parameter is passed, i.e.:
   uwsgi::add_rb_timer($signal, $interval);

Is the same as:
   uwsgi::add_rb_timer($signal, $interval, 0);