### PR TITLE
Add distutils MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,5 @@
+include proto/* apache2/* attach.py buildconf/* core/* lib/* proto/* valgrind/* vassals/*
+recursive-include plugins *
+include INSTALL install.sh LICENSE Makefile
+include setup.cpyext.py setup.py setup.pyuwsgi.py
+include uwsgiconfig.py uwsgidecorators.py uwsgi.h uwsgi_main.c

--- a/setup.py
+++ b/setup.py
@@ -125,6 +125,7 @@ setup(
     url='https://uwsgi-docs.readthedocs.io/en/latest/',
     py_modules=['uwsgidecorators'],
     distclass=uWSGIDistribution,
+    include_package_data=True,
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'License :: OSI Approved :: GNU General Public License v2 or later (GPLv2+)',


### PR DESCRIPTION
I was trying to use sdist to generate the package locally and noticed it did not include the dependencies. This adds the `MANIFEST.in` to pull all the C files required for installation.

Not sure if this is needed or if there's a separate build process - if so I can close this PR

tested with `python setup.py sdist` and then `pip install ...`