### PR TITLE
Change errror code to 404 if no app is found

### DIFF
--- a/plugins/python/wsgi_handlers.c
+++ b/plugins/python/wsgi_handlers.c
@@ -384,7 +384,7 @@ int uwsgi_request_wsgi(struct wsgi_request *wsgi_req) {
 
 
 	if (wsgi_req->app_id == -1) {
-		uwsgi_500(wsgi_req);
+		uwsgi_404(wsgi_req);
 		uwsgi_log("--- no python application found, check your startup logs for errors ---\n");
 		goto clear2;
 	}


### PR DESCRIPTION
Currently an error code of 500 is returned when no app is found for a route, but this changes it to a 404 which seems more appropriate. See this issue for more context:

https://github.com/unbit/uwsgi/issues/1935

Honestly I'm not sure if this change is really possible since maybe the currently functionality is required for compatibility. I tried running tests, but I had some issues. At the very least this appears to fix the problems for me so I figured I would open up a PR to solicit feedback.