### PR TITLE
uwsgiconfig: Fix call to __builtin__['compile']

### DIFF
--- a/uwsgiconfig.py
+++ b/uwsgiconfig.py
@@ -1396,7 +1396,7 @@ try:
 except NameError:
     def execfile(path, up):
         with open(path) as py:
-            code = __builtins__.compile(py.read(), path, 'exec')
+            code = __builtins__["compile"](py.read(), path, 'exec')
         exec(code, up)
 
 


### PR DESCRIPTION
running `pip install` on a local checkout of uwsgi fails:

```
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/Users/stargirl/workspace/third_party/uwsgi/setup.py", line 127, in <module>
        setup(
      File "/Users/stargirl/workspace/web/beedle/venv/lib/python3.10/site-packages/setuptools/__init__.py", line 159, in setup
        return distutils.core.setup(**attrs)
      File "/Users/stargirl/.pyenv/versions/3.10.0/lib/python3.10/distutils/core.py", line 148, in setup
        dist.run_commands()
      File "/Users/stargirl/.pyenv/versions/3.10.0/lib/python3.10/distutils/dist.py", line 966, in run_commands
        self.run_command(cmd)
      File "/Users/stargirl/.pyenv/versions/3.10.0/lib/python3.10/distutils/dist.py", line 985, in run_command
        cmd_obj.run()
      File "/Users/stargirl/workspace/third_party/uwsgi/setup.py", line 78, in run
        uc.build_uwsgi(conf)
      File "/Users/stargirl/workspace/third_party/uwsgi/uwsgiconfig.py", line 463, in build_uwsgi
        path, up = get_plugin_up(path)
      File "/Users/stargirl/workspace/third_party/uwsgi/uwsgiconfig.py", line 1414, in get_plugin_up
        execfile('%s/uwsgiplugin.py' % path, up)
      File "/Users/stargirl/workspace/third_party/uwsgi/uwsgiconfig.py", line 1399, in execfile
        code = __builtins__.compile(py.read(), path, 'exec')
    AttributeError: 'dict' object has no attribute 'compile'
```

This is because `__builtins__` is a `dict`, not an object - this fixes `uwsgiconfig.py` to properly find the `compile` built-in.