### PR TITLE
Add PY_SSIZE_T_CLEAN define for Python 3.10 support

### DIFF
--- a/plugins/python/uwsgi_python.h
+++ b/plugins/python/uwsgi_python.h
@@ -1,4 +1,6 @@
 #include <uwsgi.h>
+/* See https://docs.python.org/3.10/whatsnew/3.10.html#id2 */
+#define PY_SSIZE_T_CLEAN
 #include <Python.h>
 
 #include <frameobject.h>


### PR DESCRIPTION
Python 3.10 started requiring `PY_SSIZE_T_CLEAN` to be defined when using `PyArg_ParseTuple` with formats that deal with object sizes (see [release notes](https://docs.python.org/3.10/whatsnew/3.10.html#id2)). Without this, invoking a Python extension module method that hits that code path (like `uwsgi.mule_msg`) causes a SystemError:

```
Traceback (most recent call last):
  ...
  File "./venv/lib/python3.10/site-packages/uwsgidecorators.py", line 191, in __call__
    return self.real_call(*args, **kwargs)
  File "./venv/lib/python3.10/site-packages/uwsgidecorators.py", line 183, in real_call
    uwsgi.mule_msg(data, self.mule)
SystemError: PY_SSIZE_T_CLEAN macro must be defined for '#' formats
```

This just defines the macro, since the Python module itself has already been updated to use `Py_ssize_t` instead of `int`. The define tells Python that none of your invocations are using an `int`.