### PR TITLE
RFC: Async client disconnect

### DIFF
--- a/plugins/python/uwsgi_python.h
+++ b/plugins/python/uwsgi_python.h
@@ -62,6 +62,8 @@
 #define uwsgi_py_write_set_exception(x) if (!uwsgi.disable_write_exception) { PyErr_SetString(PyExc_IOError, "write error"); };
 #define uwsgi_py_write_exception(x) uwsgi_py_write_set_exception(x); uwsgi_manage_exception(x, 0);
 
+#define uwsgi_py_closed_set_exception(x)  };
+#define uwsgi_py_closed_exception(x) PyErr_SetString(PyExc_IOError, "Connection reset by peer"); uwsgi_manage_exception(x, 0);
 
 #define uwsgi_py_check_write_errors if (wsgi_req->write_errors > 0 && uwsgi.write_errors_exception_only) {\
                         uwsgi_py_write_set_exception(wsgi_req);\

--- a/plugins/python/wsgi_subhandler.c
+++ b/plugins/python/wsgi_subhandler.c
@@ -268,6 +268,11 @@ int uwsgi_response_subhandler_wsgi(struct wsgi_request *wsgi_req) {
 
 	PyObject *pychunk;
 
+	if (wsgi_req->async_closed) {
+		uwsgi_py_closed_exception(wsgi_req);
+		goto clear;
+	}
+
 	// return or yield ?
 	// in strict mode we do not optimize apps directly returning strings (or bytes)
 	if (!up.wsgi_strict) {

--- a/uwsgi.h
+++ b/uwsgi.h
@@ -3407,6 +3407,7 @@ int event_queue_init(void);
 void *event_queue_alloc(int);
 int event_queue_add_fd_read(int, int);
 int event_queue_add_fd_write(int, int);
+int event_queue_idle_fd(int, int);
 int event_queue_del_fd(int, int, int);
 int event_queue_wait(int, int, int *);
 int event_queue_wait_multi(int, int, void *, int);
@@ -3420,6 +3421,7 @@ int event_queue_fd_read_to_readwrite(int, int);
 int event_queue_fd_write_to_readwrite(int, int);
 int event_queue_interesting_fd_is_read(void *, int);
 int event_queue_interesting_fd_is_write(void *, int);
+int event_queue_interesting_fd_is_closed(void *, int);
 
 int event_queue_add_timer(int, int *, int);
 int event_queue_add_timer_hr(int, int *, int, long);

--- a/uwsgi.h
+++ b/uwsgi.h
@@ -1498,6 +1498,7 @@ struct wsgi_request {
 
 	int async_id;
 	int async_status;
+	int async_closed;
 
 	int switches;
 	size_t write_pos;
@@ -2366,6 +2367,7 @@ struct uwsgi_server {
 	// async commodity
 	struct wsgi_request **async_waiting_fd_table;
 	struct wsgi_request **async_proto_fd_table;
+	struct wsgi_request **async_idle_fd_table;
 	struct uwsgi_async_request *async_runqueue;
 	struct uwsgi_async_request *async_runqueue_last;
 


### PR DESCRIPTION
I'm scratching my own itch here.

I'm implementing log-file streaming over HTTP using the usual `Client - NGINX - uWSGI - Flask` stack. When clients requests the stream, they receive the full log, and then new lines added to logs are streamed as they come. Those new lines might occur with several minutes in between. If the client disconnects in such an interval, the handler is blocked waiting for new log messages, and doesn't detect the closed connection. This effectively exhausts the "worker" pool if many such disconnects happen. Writing "dummy" data to the socket regularly isn't an option, as the dummy data would appear in the streamed log contents.

To fix this, the async core can detect the disconnected clients by keeping the protocol sockets in the event queue, and enable `EPOLLRDHUP` events. (I haven't checked similar flags for other event queue implementations.) The python plugin then checks a flag to detect closed connections in the response handler.