### PR TITLE
Replace os.system by subprocess.call in `thread_compile`

### DIFF
--- a/uwsgiconfig.py
+++ b/uwsgiconfig.py
@@ -118,7 +118,7 @@ def thread_compiler(num):
             print_lock.acquire()
             print_compilation_output("[thread %d][%s] %s" % (num, GCC, objfile), "[thread %d] %s" % (num, cmdline))
             print_lock.release()
-            ret = os.system(cmdline)
+            ret = subprocess.call(cmdline, shell=True)
             if ret != 0:
                 os._exit(1)
         elif cmdline:


### PR DESCRIPTION
Please don't ask me why, but unintrusive one-liner seems to circumvent a nondeterministic bug in building the wheel (see [this comment](https://github.com/agdsn/pycroft/pull/508#issuecomment-975101269)).

It's probably a good idea anyway because the subprocess module is considered to be the replacement of `os.system`.

The relevant log portion looks as follows:
```
[…]
   [thread 1][gcc -pthread] core/regexp.o
  [thread 0][gcc -pthread] core/routing.o
  [thread 1][gcc -pthread] core/yaml.o
  [thread 1][gcc -pthread] core/ssl.o
  [thread 1][gcc -pthread] core/legion.o
  [thread 0][gcc -pthread] core/xmlconf.o
  [thread 0][gcc -pthread] core/dot_h.o
  ----------------------------------------
  ERROR: Failed building wheel for uwsgi
```

…without any further stacktrace or error message. Modifying the lines below to print the return code taught me that `os.system` returned `-1`, but I didn't quite understand the docs concerning whether this meant „terminated by signal“ or „terminated regularly with error code -1“.