### PR TITLE
fix(python-plugin): update internal interpreter state immediately upon forking 

### DIFF
--- a/plugins/python/uwsgi_python.h
+++ b/plugins/python/uwsgi_python.h
@@ -1,5 +1,6 @@
 #include <uwsgi.h>
 #include <Python.h>
+#include <pythread.h>
 
 #include <frameobject.h>
 
@@ -238,6 +239,8 @@ struct uwsgi_python {
 	int master_check_signals;
 	
 	char *executable;
+
+	int call_uwsgi_fork_hooks;
 };
 
 

--- a/tests/deadlocks/main.py
+++ b/tests/deadlocks/main.py
@@ -1,0 +1,4 @@
+def application(env, start_response):
+    start_response("200 OK", [("Content-Type", "text/plain")])
+    message = "Hello World"
+    return [message.encode("utf-8")]

--- a/tests/deadlocks/master-nothreads.ini
+++ b/tests/deadlocks/master-nothreads.ini
@@ -3,3 +3,4 @@ show-config = true
 master = true
 enable-threads = false
 workers = 1
+py-call-uwsgi-fork-hooks = true

--- a/tests/deadlocks/master-nothreads.ini
+++ b/tests/deadlocks/master-nothreads.ini
@@ -1,0 +1,5 @@
+[uwsgi]
+show-config = true
+master = true
+enable-threads = false
+workers = 1

--- a/tests/deadlocks/master-singleinterpreter-threads-10workers.ini
+++ b/tests/deadlocks/master-singleinterpreter-threads-10workers.ini
@@ -1,0 +1,6 @@
+[uwsgi]
+show-config = true
+master = true
+enable-threads = true
+workers = 10
+single-interpreter = true

--- a/tests/deadlocks/master-singleinterpreter-threads-10workers.ini
+++ b/tests/deadlocks/master-singleinterpreter-threads-10workers.ini
@@ -4,3 +4,4 @@ master = true
 enable-threads = true
 workers = 10
 single-interpreter = true
+py-call-uwsgi-fork-hooks = true

--- a/tests/deadlocks/master-singleinterpreter-threads-1worker.ini
+++ b/tests/deadlocks/master-singleinterpreter-threads-1worker.ini
@@ -1,0 +1,6 @@
+[uwsgi]
+show-config = true
+master = true
+enable-threads = true
+workers = 1
+single-interpreter = true

--- a/tests/deadlocks/master-singleinterpreter-threads-1worker.ini
+++ b/tests/deadlocks/master-singleinterpreter-threads-1worker.ini
@@ -4,3 +4,4 @@ master = true
 enable-threads = true
 workers = 1
 single-interpreter = true
+py-call-uwsgi-fork-hooks = true

--- a/tests/deadlocks/master-threads-10workers.ini
+++ b/tests/deadlocks/master-threads-10workers.ini
@@ -1,0 +1,5 @@
+[uwsgi]
+show-config = true
+master = true
+enable-threads = true
+workers = 10

--- a/tests/deadlocks/master-threads-10workers.ini
+++ b/tests/deadlocks/master-threads-10workers.ini
@@ -3,3 +3,4 @@ show-config = true
 master = true
 enable-threads = true
 workers = 10
+py-call-uwsgi-fork-hooks = true

--- a/tests/deadlocks/master-threads-1worker.ini
+++ b/tests/deadlocks/master-threads-1worker.ini
@@ -3,3 +3,4 @@ show-config = true
 master = true
 enable-threads = true
 workers = 1
+py-call-uwsgi-fork-hooks = true

--- a/tests/deadlocks/master-threads-1worker.ini
+++ b/tests/deadlocks/master-threads-1worker.ini
@@ -1,0 +1,5 @@
+[uwsgi]
+show-config = true
+master = true
+enable-threads = true
+workers = 1

--- a/tests/deadlocks/nomaster-threads-10workers.ini
+++ b/tests/deadlocks/nomaster-threads-10workers.ini
@@ -3,3 +3,4 @@ show-config = true
 master = false
 enable-threads = true
 workers = 10
+py-call-uwsgi-fork-hooks = true

--- a/tests/deadlocks/nomaster-threads-10workers.ini
+++ b/tests/deadlocks/nomaster-threads-10workers.ini
@@ -1,0 +1,5 @@
+[uwsgi]
+show-config = true
+master = false
+enable-threads = true
+workers = 10

--- a/tests/deadlocks/nomaster-threads-1worker.ini
+++ b/tests/deadlocks/nomaster-threads-1worker.ini
@@ -1,0 +1,5 @@
+[uwsgi]
+show-config = true
+master = false
+enable-threads = true
+workers = 1

--- a/tests/deadlocks/nomaster-threads-1worker.ini
+++ b/tests/deadlocks/nomaster-threads-1worker.ini
@@ -3,3 +3,4 @@ show-config = true
 master = false
 enable-threads = true
 workers = 1
+py-call-uwsgi-fork-hooks = true

--- a/tests/deadlocks/sitecustomize.py
+++ b/tests/deadlocks/sitecustomize.py
@@ -1,0 +1,14 @@
+import threading
+import time
+
+
+def run():
+    print("[DEADLOCKS] started run")
+    st = time.time()
+    while time.time() < st + 5:
+        pass
+    print("[DEADLOCKS] finished run")
+
+t = threading.Thread(target=run)
+t.daemon = True
+t.start()

--- a/uwsgi.h
+++ b/uwsgi.h
@@ -1095,6 +1095,9 @@ struct uwsgi_plugin {
 	int (*worker)(void);
 
 	void (*early_post_jail) (void);
+
+	void (*pre_uwsgi_fork) (void);
+	void (*post_uwsgi_fork) (int);
 };
 
 #ifdef UWSGI_PCRE


### PR DESCRIPTION
Fixes #2387

This PR adds `pre_uwsgi_fork` and `post_uwsgi_fork` hooks to `uwsgi_plugin` in order to update the internal interpreter state of CPython immediately before and immediately after the call to `uwsgi_fork`. This follows the implementation of the standard library `os.fork()` in CPython. 

While these two hooks effectively replace existing code to update the internal interpreter state during the lifecycle of master and worker processes, we preserve the current behavior for uWSGI LTS. We instead provide a new option `py-call-uwsgi-fork-hooks` to enable the new feature.

We add test coverage for the issue of deadlocked workers raised in #2387 parameterized for relevant configurations options.