### PR TITLE
Remove stray license headers

### DIFF
--- a/apache2/mod_Ruwsgi.c
+++ b/apache2/mod_Ruwsgi.c
@@ -1,27 +1,3 @@
-/*
-
- *** uWSGI/mod_Ruwsgi ***
-
- Copyright 2009-2010 Roger Florkowski <rflorkowski@mypublisher.com>
- Copyright 2009-2010 Unbit S.a.s. <info@unbit.it>
-
- This program is free software; you can redistribute it and/or
- modify it under the terms of the GNU General Public License
- as published by the Free Software Foundation; either version 2
- of the License, or (at your option) any later version.
-
- This program is distributed in the hope that it will be useful,
- but WITHOUT ANY WARRANTY; without even the implied warranty of
- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- GNU General Public License for more details.
-
- You should have received a copy of the GNU General Public License
- along with this program; if not, write to the Free Software
- Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
-
-
-*/
-
 #define MOD_UWSGI_VERSION "1.0"
 
 #include "ap_config.h"

--- a/apache2/mod_proxy_uwsgi.c
+++ b/apache2/mod_proxy_uwsgi.c
@@ -1,20 +1,6 @@
 /*
-        
+
 *** mod_proxy_uwsgi ***
-
-Copyright 2009-2017 Unbit S.a.s. <info@unbit.it>
-     
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    https://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
 
 To build:
 

--- a/apache2/mod_uwsgi.c
+++ b/apache2/mod_uwsgi.c
@@ -2,23 +2,6 @@
         
 *** uWSGI/mod_uwsgi ***
 
-Copyright 2009-2014 Unbit S.a.s. <info@unbit.it>
-     
-This program is free software; you can redistribute it and/or
-modify it under the terms of the GNU General Public License
-as published by the Free Software Foundation; either version 2
-of the License, or (at your option) any later version.
-
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this program; if not, write to the Free Software
-Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
-
-
 To compile:
 (Linux)
 	apxs2 -i -c mod_uwsgi.c

--- a/core/uwsgi.c
+++ b/core/uwsgi.c
@@ -1,26 +1,3 @@
-/*
-
- *** uWSGI ***
-
- Copyright (C) 2009-2017 Unbit S.a.s. <info@unbit.it>
-
- This program is free software; you can redistribute it and/or
- modify it under the terms of the GNU General Public License
- as published by the Free Software Foundation; either version 2
- of the License, or (at your option) any later version.
-
- This program is distributed in the hope that it will be useful,
- but WITHOUT ANY WARRANTY; without even the implied warranty of
- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- GNU General Public License for more details.
-
- You should have received a copy of the GNU General Public License
- along with this program; if not, write to the Free Software
- Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
-
-*/
-
-
 #include "uwsgi.h"
 
 struct uwsgi_server uwsgi;

--- a/plugins/router_xmldir/router_xmldir.c
+++ b/plugins/router_xmldir/router_xmldir.c
@@ -1,23 +1,3 @@
-/*
- * Copyright (C) 2013 Unbit S.a.s. <info@unbit.it>
- * Copyright (C) 2013 Guido Berhoerster <guido+uwsgi@berhoerster.name>
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * as published by the Free Software Foundation; either version 2
- * of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,  USA.
- *
- */
-
 #include <uwsgi.h>
 #include <locale.h>
 #include <iconv.h>


### PR DESCRIPTION
Remove stray license headers that don't comply with the global GPL2 + linking exception licensing model adopted with version 2.

Fixes #2401