### PR TITLE
fix(tests/deadlock): sleep before checking uwsgi process

### DIFF
--- a/tests/travis.sh
+++ b/tests/travis.sh
@@ -77,6 +77,7 @@ test_python_deadlocks() {
     echo -en "${bldred}"
     # initialize with tests/deadlocks/sitecustomize.py
     PYTHONPATH=tests/deadlocks ./uwsgi --plugin 0:$1 --http :8080 --exit-on-reload --touch-reload reload.txt --wsgi-file tests/deadlocks/main.py --ini $2 --daemonize uwsgi.log
+    sleep 1
     echo -en "${txtrst}"
     http_test "http://localhost:8080/"
     echo -e "${bldyel}===================== DONE $1 $2 =====================${txtrst}\n\n"


### PR DESCRIPTION
Fixes #2416 

Added 2s sleep to after uwsgi process is started and before pid is checked.