### PR TITLE
plugins/python: Properly call `.close()` as mandated by WSGI specs.

### DIFF
--- a/tests/travis.sh
+++ b/tests/travis.sh
@@ -63,6 +63,7 @@ test_python() {
     echo -e "${bldyel}>>> Spawning uWSGI python app${txtrst}"
     echo -en "${bldred}"
     ./uwsgi --master --plugin 0:$1 --http :8080 --exit-on-reload --touch-reload reload.txt --wsgi-file $2 --daemonize uwsgi.log
+    sleep 1
     echo -en "${txtrst}"
     http_test "http://localhost:8080/"
     echo -e "${bldyel}===================== DONE $1 $2 =====================${txtrst}\n\n"


### PR DESCRIPTION
uWSGI did not call `.close()` on objects returned by
`wsgi.file_wrapper`. This resulted on `.close()` beeing called when the
gc managed to clean up the object (which apparently did not happen with
refcounting due to cyclic references) resulting in hard to debug errors.

@unbit as promised the PR, I have no idea how to write tests in uWSGI and given that it is in maintenance mode and I am not using it myself I am not sure I want to dig in that deep.

Fixes #2422