### PR TITLE
Use threading.current_thread, has existed since Python 2.6

### DIFF
--- a/plugins/python/python_plugin.c
+++ b/plugins/python/python_plugin.c
@@ -1423,16 +1423,12 @@ void uwsgi_python_enable_threads() {
 }
 
 void uwsgi_python_set_thread_name(int core_id) {
-	// call threading.currentThread (taken from mod_wsgi, but removes DECREFs as thread in uWSGI are fixed)
+	// call threading.current_thread (taken from mod_wsgi, but removes DECREFs as thread in uWSGI are fixed)
 	PyObject *threading_module = PyImport_ImportModule("threading");
         if (threading_module) {
                 PyObject *threading_module_dict = PyModule_GetDict(threading_module);
                 if (threading_module_dict) {
-#ifdef PYTHREE
                         PyObject *threading_current = PyDict_GetItemString(threading_module_dict, "current_thread");
-#else
-                        PyObject *threading_current = PyDict_GetItemString(threading_module_dict, "currentThread");
-#endif
                         if (threading_current) {
                                 PyObject *current_thread = PyObject_CallObject(threading_current, (PyObject *)NULL);
                                 if (!current_thread) {
@@ -1516,11 +1512,7 @@ PyObject *uwsgi_python_setup_thread(char *name, PyInterpreterState *interpreter)
         if (threading_module) {
                 PyObject *threading_module_dict = PyModule_GetDict(threading_module);
                 if (threading_module_dict) {
-#ifdef PYTHREE
                         PyObject *threading_current = PyDict_GetItemString(threading_module_dict, "current_thread");
-#else
-                        PyObject *threading_current = PyDict_GetItemString(threading_module_dict, "currentThread");
-#endif
                         if (threading_current) {
                                 PyObject *current_thread = PyObject_CallObject(threading_current, (PyObject *)NULL);
                                 if (!current_thread) {


### PR DESCRIPTION
`threading.currentThread` is deprecated since Python 3.10 and scheduled for removal in Python 3.12 (October 2023).

* https://github.com/python/cpython/pull/25174

We have an `ifdef` guard, but the `current_thread` version has existed since Python 2.6, the [oldest version supported here](https://github.com/unbit/uwsgi/blob/ca8bc6acc98b2c062b5b00668acd851e210fcbca/setup.py#L141), so we can simplify things.

* https://docs.python.org/2.6/library/threading.html#threading.current_thread
