### PR TITLE
Replace all os.system usage with subprocess.call

### DIFF
--- a/examples/mjpeg_stream.py
+++ b/examples/mjpeg_stream.py
@@ -1,4 +1,5 @@
 import os
+import subprocess
 
 
 def application(env, start_response):
@@ -16,8 +17,8 @@ def application(env, start_response):
 
     while 1:
         yield "Content-Type: image/jpeg\r\n\r\n"
-        print os.system('screencapture -t jpg -m -T 1 screenshot.jpg')
+        print subprocess.call('screencapture -t jpg -m -T 1 screenshot.jpg', shell=True)
         f = open('screenshot.jpg')
         yield env['wsgi.file_wrapper'](f)
         yield "\r\n--%s\r\n" % boundary
-        # os.system('./isightcapture -w 640 -h 480 screenshot.jpg')
+        # subprocess.call('./isightcapture -w 640 -h 480 screenshot.jpg', shell=True)

--- a/plugins/gccgo/uwsgiplugin.py
+++ b/plugins/gccgo/uwsgiplugin.py
@@ -1,4 +1,5 @@
 import os
+import subprocess
 
 NAME = 'gccgo'
 
@@ -10,6 +11,6 @@ GCC_LIST = ['gccgo_plugin', 'uwsgi.go']
 
 def post_build(config):
     if os.path.exists('plugins/gccgo/uwsgi.go.o'):
-        if os.system("objcopy -j .go_export plugins/gccgo/uwsgi.go.o plugins/gccgo/uwsgi.gox") != 0:
+        if subprocess.call("objcopy -j .go_export plugins/gccgo/uwsgi.go.o plugins/gccgo/uwsgi.gox", shell=True) != 0:
             os._exit(1)
         print("*** uwsgi.gox available in %s/plugins/gccgo ***" % os.getcwd())

--- a/plugins/jvm/uwsgiplugin.py
+++ b/plugins/jvm/uwsgiplugin.py
@@ -1,5 +1,6 @@
 import os
 import shutil
+import subprocess
 
 NAME = 'jvm'
 
@@ -72,9 +73,9 @@ else:
 
 
 def post_build(config):
-    if os.system("javac %s/plugins/jvm/uwsgi.java" % os.getcwd()) != 0:
+    if subprocess.call("javac %s/plugins/jvm/uwsgi.java" % os.getcwd(), shell=True) != 0:
         os._exit(1)
-    if os.system("cd %s/plugins/jvm ; jar cvf uwsgi.jar *.class" % os.getcwd()) != 0:
+    if subprocess.call("cd %s/plugins/jvm ; jar cvf uwsgi.jar *.class" % os.getcwd(), shell=True) != 0:
         os._exit(1)
     print("*** uwsgi.jar available in %s/plugins/jvm/uwsgi.jar ***" % os.getcwd())
 

--- a/plugins/mono/uwsgiplugin.py
+++ b/plugins/mono/uwsgiplugin.py
@@ -1,4 +1,5 @@
 import os
+import subprocess
 
 NAME = 'mono'
 
@@ -12,8 +13,8 @@ if os.uname()[0] == 'Darwin':
 
 
 def post_build(config):
-    if os.system("sn -k plugins/mono/uwsgi.key") != 0:
+    if subprocess.call("sn -k plugins/mono/uwsgi.key", shell=True) != 0:
         os._exit(1)
-    if os.system("mcs /target:library /r:System.Configuration.dll /r:System.Web.dll /keyfile:plugins/mono/uwsgi.key plugins/mono/uwsgi.cs") != 0:
+    if subprocess.call("mcs /target:library /r:System.Configuration.dll /r:System.Web.dll /keyfile:plugins/mono/uwsgi.key plugins/mono/uwsgi.cs", shell=True) != 0:
         os._exit(1)
     print("*** uwsgi.dll available in %s/plugins/mono/uwsgi.dll ***" % os.getcwd())

--- a/uwsgiconfig.py
+++ b/uwsgiconfig.py
@@ -1383,10 +1383,10 @@ def get_remote_plugin(path):
     if git_dir.endswith('.git'):
         git_dir = git_dir[:-4]
     if not os.path.isdir(git_dir):
-        if subprocess.call('git clone %s' % path, shell=True) != 0:
+        if subprocess.call(['git', 'clone', path]) != 0:
             sys.exit(1)
     else:
-        if subprocess.call('cd %s ; git pull' % git_dir, shell=True) != 0:
+        if subprocess.call(['git', 'pull'], cwd=git_dir) != 0:
             sys.exit(1)
     return git_dir
 

--- a/uwsgiconfig.py
+++ b/uwsgiconfig.py
@@ -118,7 +118,7 @@ def thread_compiler(num):
             print_lock.acquire()
             print_compilation_output("[thread %d][%s] %s" % (num, GCC, objfile), "[thread %d] %s" % (num, cmdline))
             print_lock.release()
-            ret = os.system(cmdline)
+            ret = subprocess.call(cmdline, shell=True)
             if ret != 0:
                 os._exit(1)
         elif cmdline:
@@ -249,7 +249,7 @@ def push_print(msg):
 def push_command(objfile, cmdline):
     if not compile_queue:
         print_compilation_output("[%s] %s" % (GCC, objfile), cmdline)
-        ret = os.system(cmdline)
+        ret = subprocess.call(cmdline, shell=True)
         if ret != 0:
             sys.exit(1)
     else:
@@ -515,12 +515,12 @@ def build_uwsgi(uc, print_only=False, gcll=None):
                     try:
                         binary_link_cmd = "ld -r -b binary -o %s/%s.o %s/%s" % (path, bfile[1], path, bfile[1])
                         print(binary_link_cmd)
-                        if os.system(binary_link_cmd) != 0:
+                        if subprocess.call(binary_link_cmd, shell=True) != 0:
                             raise Exception('unable to link binary file')
                         for kind in ('start', 'end'):
                             objcopy_cmd = "objcopy --redefine-sym _binary_%s_%s=%s_%s %s/%s.o" % (binarize('%s/%s' % (path, bfile[1])), kind, bfile[0], kind, path, bfile[1])
                             print(objcopy_cmd)
-                            if os.system(objcopy_cmd) != 0:
+                            if subprocess.call(objcopy_cmd, shell=True) != 0:
                                 raise Exception('unable to link binary file')
                         gcc_list.append('%s/%s.o' % (path, bfile[1]))
                     except Exception:
@@ -583,7 +583,7 @@ def build_uwsgi(uc, print_only=False, gcll=None):
             ' '.join(uniq_warnings(libs))
         )
     print(ldline)
-    ret = os.system(ldline)
+    ret = subprocess.call(ldline, shell=True)
     if ret != 0:
         print("*** error linking uWSGI ***")
         sys.exit(1)
@@ -1163,7 +1163,7 @@ class uConf(object):
             if self.embed_config:
                 binary_link_cmd = "ld -r -b binary -o %s.o %s" % (binarize(self.embed_config), self.embed_config)
                 print(binary_link_cmd)
-                os.system(binary_link_cmd)
+                subprocess.call(binary_link_cmd, shell=True)
                 self.cflags.append("-DUWSGI_EMBED_CONFIG=_binary_%s_start" % binarize(self.embed_config))
                 self.cflags.append("-DUWSGI_EMBED_CONFIG_END=_binary_%s_end" % binarize(self.embed_config))
             embed_files = os.environ.get('UWSGI_EMBED_FILES')
@@ -1182,23 +1182,23 @@ class uConf(object):
                                 fname = "%s/%s" % (directory, f)
                                 binary_link_cmd = "ld -r -b binary -o %s.o %s" % (binarize(fname), fname)
                                 print(binary_link_cmd)
-                                os.system(binary_link_cmd)
+                                subprocess.call(binary_link_cmd, shell=True)
                                 if symbase:
                                     for kind in ('start', 'end'):
                                         objcopy_cmd = "objcopy --redefine-sym _binary_%s_%s=_binary_%s%s_%s build/%s.o" % (binarize(fname), kind, binarize(symbase), binarize(fname[len(ef):]), kind, binarize(fname))
                                         print(objcopy_cmd)
-                                        os.system(objcopy_cmd)
+                                        subprocess.call(objcopy_cmd, shell=True)
                                 binary_list.append(binarize(fname))
                     else:
                         binary_link_cmd = "ld -r -b binary -o %s.o %s" % (binarize(ef), ef)
                         print(binary_link_cmd)
-                        os.system(binary_link_cmd)
+                        subprocess.call(binary_link_cmd, shell=True)
                         binary_list.append(binarize(ef))
                         if symbase:
                             for kind in ('start', 'end'):
                                 objcopy_cmd = "objcopy --redefine-sym _binary_%s_%s=_binary_%s_%s build/%s.o" % (binarize(ef), kind, binarize(symbase), kind, binarize(ef))
                                 print(objcopy_cmd)
-                                os.system(objcopy_cmd)
+                                subprocess.call(objcopy_cmd, shell=True)
 
         self.cflags.append('-DUWSGI_VERSION="\\"' + uwsgi_version + '\\""')
 
@@ -1383,10 +1383,10 @@ def get_remote_plugin(path):
     if git_dir.endswith('.git'):
         git_dir = git_dir[:-4]
     if not os.path.isdir(git_dir):
-        if os.system('git clone %s' % path) != 0:
+        if subprocess.call('git clone %s' % path, shell=True) != 0:
             sys.exit(1)
     else:
-        if os.system('cd %s ; git pull' % git_dir) != 0:
+        if subprocess.call('cd %s ; git pull' % git_dir, shell=True) != 0:
             sys.exit(1)
     return git_dir
 
@@ -1496,7 +1496,7 @@ def build_plugin(path, uc, cflags, ldflags, libs, name=None):
         try:
             binary_link_cmd = "ld -r -b binary -o %s/%s.o %s/%s" % (path, bfile[1], path, bfile[1])
             print(binary_link_cmd)
-            if os.system(binary_link_cmd) != 0:
+            if subprocess.call(binary_link_cmd, shell=True) != 0:
                 raise Exception('unable to link binary file')
             for kind in ('start', 'end'):
                 objcopy_cmd = "objcopy --redefine-sym _binary_%s_%s=%s_%s %s/%s.o" % (
@@ -1508,7 +1508,7 @@ def build_plugin(path, uc, cflags, ldflags, libs, name=None):
                     bfile[1]
                 )
                 print(objcopy_cmd)
-                if os.system(objcopy_cmd) != 0:
+                if subprocess.call(objcopy_cmd, shell=True) != 0:
                     raise Exception('unable to link binary file')
             gcc_list.append('%s/%s.o' % (path, bfile[1]))
         except Exception:
@@ -1567,7 +1567,7 @@ def build_plugin(path, uc, cflags, ldflags, libs, name=None):
     )
     print_compilation_output("[%s] %s.so" % (GCC, plugin_dest), gccline)
 
-    ret = os.system(gccline)
+    ret = subprocess.call(gccline, shell=True)
     if ret != 0:
         print("*** unable to build %s plugin ***" % name)
         sys.exit(1)
@@ -1580,7 +1580,7 @@ def build_plugin(path, uc, cflags, ldflags, libs, name=None):
             f.close()
             objline = "objcopy %s.so --add-section uwsgi=.uwsgi_plugin_section %s.so" % (plugin_dest, plugin_dest)
             print_compilation_output(None, objline)
-            os.system(objline)
+            subprocess.call(objline, shell=True)
             os.unlink('.uwsgi_plugin_section')
     except Exception:
         pass
@@ -1692,15 +1692,15 @@ if __name__ == "__main__":
             pass
         build_plugin(options.extra_plugin[0], None, cflags, ldflags, None, name)
     elif options.clean:
-        os.system("rm -f core/*.o")
-        os.system("rm -f proto/*.o")
-        os.system("rm -f lib/*.o")
-        os.system("rm -f plugins/*/*.o")
-        os.system("rm -f build/*.o")
-        os.system("rm -f core/dot_h.c")
-        os.system("rm -f core/config_py.c")
+        subprocess.call("rm -f core/*.o", shell=True)
+        subprocess.call("rm -f proto/*.o", shell=True)
+        subprocess.call("rm -f lib/*.o", shell=True)
+        subprocess.call("rm -f plugins/*/*.o", shell=True)
+        subprocess.call("rm -f build/*.o", shell=True)
+        subprocess.call("rm -f core/dot_h.c", shell=True)
+        subprocess.call("rm -f core/config_py.c", shell=True)
     elif options.check:
-        os.system("cppcheck --max-configs=1000 --enable=all -q core/ plugins/ proto/ lib/ apache2/")
+        subprocess.call("cppcheck --max-configs=1000 --enable=all -q core/ plugins/ proto/ lib/ apache2/", shell=True)
     else:
         parser.print_help()
         sys.exit(1)


### PR DESCRIPTION
This aims to fix intermittent build failures on some platforms (most notably Debian Bullseye) which appear to be due to the use of `os.system` from background threads. The exact nature of the issue is unclear, however moving to `subprocess.call` appears to fix it.

Fixes https://github.com/unbit/uwsgi/issues/2447.

While there's more that could be done here to modernise these calls, this aims to be a minimal change which introduces subprocess without much intrusion.

This PR goes further than https://github.com/unbit/uwsgi/pull/2373 as a measure of future-proofing the change and as it's unclear to me which of these calls actually could happen in threaded contexts. Since `subprocess` is the preferred mechanism for this in Python anyway this feels like a reasonable set of changes.