### PR TITLE
Add Python 3.11 support

### DIFF
--- a/plugins/python/python_plugin.c
+++ b/plugins/python/python_plugin.c
@@ -1185,8 +1185,12 @@ void uwsgi_python_init_apps() {
 
 	// prepare for stack suspend/resume
 	if (uwsgi.async > 0) {
+#ifdef UWSGI_PY311
+		up.current_recursion_remaining = uwsgi_malloc(sizeof(int)*uwsgi.async);
+#else
 		up.current_recursion_depth = uwsgi_malloc(sizeof(int)*uwsgi.async);
-        	up.current_frame = uwsgi_malloc(sizeof(struct _frame)*uwsgi.async);
+#endif
+		up.current_frame = uwsgi_malloc(sizeof(up.current_frame[0])*uwsgi.async);
 	}
 
 	struct uwsgi_string_list *upli = up.import_list;
@@ -1581,12 +1585,22 @@ void uwsgi_python_suspend(struct wsgi_request *wsgi_req) {
 	PyGILState_Release(pgst);
 
 	if (wsgi_req) {
+#ifdef UWSGI_PY311
+		up.current_recursion_remaining[wsgi_req->async_id] = tstate->recursion_remaining;
+		up.current_frame[wsgi_req->async_id] = tstate->cframe;
+#else
 		up.current_recursion_depth[wsgi_req->async_id] = tstate->recursion_depth;
 		up.current_frame[wsgi_req->async_id] = tstate->frame;
+#endif
 	}
 	else {
+#ifdef UWSGI_PY311
+		up.current_main_recursion_remaining = tstate->recursion_remaining;
+		up.current_main_frame = tstate->cframe;
+#else
 		up.current_main_recursion_depth = tstate->recursion_depth;
 		up.current_main_frame = tstate->frame;
+#endif
 	}
 
 }
@@ -1814,12 +1828,22 @@ void uwsgi_python_resume(struct wsgi_request *wsgi_req) {
 	PyGILState_Release(pgst);
 
 	if (wsgi_req) {
+#ifdef UWSGI_PY311
+		tstate->recursion_remaining = up.current_recursion_remaining[wsgi_req->async_id];
+		tstate->cframe = up.current_frame[wsgi_req->async_id];
+#else
 		tstate->recursion_depth = up.current_recursion_depth[wsgi_req->async_id];
 		tstate->frame = up.current_frame[wsgi_req->async_id];
+#endif
 	}
 	else {
+#ifdef UWSGI_PY311
+		tstate->recursion_remaining = up.current_main_recursion_remaining;
+		tstate->cframe = up.current_main_frame;
+#else
 		tstate->recursion_depth = up.current_main_recursion_depth;
 		tstate->frame = up.current_main_frame;
+#endif
 	}
 
 }

--- a/plugins/python/uwsgi_python.h
+++ b/plugins/python/uwsgi_python.h
@@ -16,6 +16,10 @@
 #define UWSGI_PYTHON_OLD
 #endif
 
+#if (PY_VERSION_HEX >= 0x030b0000)
+#  define UWSGI_PY311
+#endif
+
 #if PY_MAJOR_VERSION == 2 && PY_MINOR_VERSION < 7
 #define HAS_NOT_PyMemoryView_FromBuffer
 #endif
@@ -177,11 +181,19 @@ struct uwsgi_python {
 
 	char *callable;
 
+#ifdef UWSGI_PY311
+	int *current_recursion_remaining;
+	_PyCFrame **current_frame;
+
+	int current_main_recursion_remaining;
+	_PyCFrame *current_main_frame;
+#else
 	int *current_recursion_depth;
 	struct _frame **current_frame;
 
 	int current_main_recursion_depth;
 	struct _frame *current_main_frame;
+#endif
 
 	void (*swap_ts)(struct wsgi_request *, struct uwsgi_app *);
 	void (*reset_ts)(struct wsgi_request *, struct uwsgi_app *);


### PR DESCRIPTION
* Use PyFrame_GetCode().
* Add PyFrame_GetCode() for Python 3.8 and older.
* Add UWSGI_PY311 macro: defined on Python 3.11 and newer.
* struct uwsgi_python: "current_recursion_depth" becomes
  "current_recursion_remaining" and current_frame type becomes
  _PyCFrame** on Python 3.11.

Related Python 3.11 changes:

* https://docs.python.org/dev/whatsnew/3.11.html#id6
* The PyFrameObject structure became opaque.
* PyThreadState.frame (PyFrameObject) became PyThreadState.cframe
  (_PyCFrame) in Python 3.11.
* PyThreadState: recursion_depth was replaced with
  recursion_remaining + recursion_limit.