### PR TITLE
Fixed compilation issue on macOS + Clang.

### DIFF
--- a/core/mount.c
+++ b/core/mount.c
@@ -106,6 +106,7 @@ uint64_t uwsgi_mount_flag(char *mflag) {
 }
 
 int uwsgi_mount(char *fs, char *what, char *where, char *flags, char *data) {
+#if defined(__linux__) || defined(__FreeBSD__) || defined(__GNU_kFreeBSD__)
 #if defined(__FreeBSD__) || defined(__GNU_kFreeBSD__)
 	struct iovec iov[6];
 #endif
@@ -146,10 +147,12 @@ parsed:
 
 	return nmount(iov, 6, (int) mountflags);
 #endif
+#endif
 	return -1;
 }
 
 int uwsgi_umount(char *where, char *flags) {
+#if defined(__linux__) || defined(__FreeBSD__) || defined(__GNU_kFreeBSD__)
 	unsigned long mountflags = 0;
         if (!flags) goto parsed;
         char *mflags = uwsgi_str(flags);
@@ -198,6 +201,7 @@ unmountable:
         return umount2(where, mountflags);
 #elif defined(__FreeBSD__) || defined(__GNU_kFreeBSD__)
 	return unmount(where, mountflags);
+#endif
 #endif
         return -1;
 }

--- a/core/utils.c
+++ b/core/utils.c
@@ -3721,6 +3721,7 @@ char *uwsgi_expand_path(char *dir, int dir_len, char *ptr) {
 
 
 void uwsgi_set_cpu_affinity() {
+#if defined(__linux__) || defined(__FreeBSD__) || defined(__GNU_kFreeBSD__)
 	char buf[4096];
 	int ret;
 	int pos = 0;
@@ -3740,7 +3741,6 @@ void uwsgi_set_cpu_affinity() {
 #elif defined(__FreeBSD__)
 		cpuset_t cpuset;
 #endif
-#if defined(__linux__) || defined(__FreeBSD__) || defined(__GNU_kFreeBSD__)
 		CPU_ZERO(&cpuset);
 		int i;
 		for (i = 0; i < uwsgi.cpu_affinity; i++) {
@@ -3755,7 +3755,6 @@ void uwsgi_set_cpu_affinity() {
 			pos += ret;
 			base_cpu++;
 		}
-#endif
 #if defined(__linux__) || defined(__GNU_kFreeBSD__)
 		if (sched_setaffinity(0, sizeof(cpu_set_t), &cpuset)) {
 			uwsgi_error("sched_setaffinity()");
@@ -3767,7 +3766,7 @@ void uwsgi_set_cpu_affinity() {
 #endif
 		uwsgi_log("%s\n", buf);
 	}
-
+#endif
 }
 
 #ifdef UWSGI_ELF


### PR DESCRIPTION
Some variables remain unused when the #ifdefs for Linux/BSD are not satisfied. This addresses #2446.