### PR TITLE
make dev version PEP-0440 compliant

### DIFF
--- a/uwsgiconfig.py
+++ b/uwsgiconfig.py
@@ -164,7 +164,7 @@ def uniq_warnings(elements):
 
 if uwsgi_version.endswith('-dev') and os.path.exists('%s/.git' % os.path.dirname(os.path.abspath(__file__))):
     try:
-        uwsgi_version += '-%s' % spcall('git rev-parse --short HEAD')
+        uwsgi_version += '+%s' % spcall('git rev-parse --short HEAD')
     except Exception:
         pass
 


### PR DESCRIPTION
The current dev version string is not PEP-0440 compliant and the pip tooling will not allow creating wheels with a non-compliant version. We use wheels and would like to be able to deploy and test development versions.