### PR TITLE
ci: update python versions in smoke tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,8 +19,8 @@ jobs:
     - name: Install dependencies
       run: |
         sudo apt update -qq
-        sudo apt install --no-install-recommends -qqyf python{2.7,3.5,3.6,3.7,3.8}-dev \
-          python3.8-distutils \
+        sudo apt install --no-install-recommends -qqyf python{2.7,3.6,3.7,3.8,3.9,3.10}-dev \
+          python3.8-distutils python3.9-distutils python3.10-distutils \
           libpcre3-dev libjansson-dev libcap2-dev \
           curl check
     - uses: actions/checkout@v2
@@ -32,10 +32,6 @@ jobs:
       run: |
         /usr/bin/python2.7 -V
         /usr/bin/python2.7 uwsgiconfig.py --plugin plugins/python base python27
-    - name: Build python3.5 plugin
-      run: |
-        /usr/bin/python3.5 -V
-        /usr/bin/python3.5 uwsgiconfig.py --plugin plugins/python base python35
     - name: Build python3.6 plugin
       run: |
         /usr/bin/python3.6 -V
@@ -48,6 +44,14 @@ jobs:
       run: |
         /usr/bin/python3.8 -V
         /usr/bin/python3.8 uwsgiconfig.py --plugin plugins/python base python38
+    - name: Build python3.9 plugin
+      run: |
+        /usr/bin/python3.9 -V
+        /usr/bin/python3.9 uwsgiconfig.py --plugin plugins/python base python39
+    - name: Build python3.10 plugin
+      run: |
+        /usr/bin/python3.10 -V
+        /usr/bin/python3.10 uwsgiconfig.py --plugin plugins/python base python310
     - name: Build rack plugin
       run: |
         ruby -v


### PR DESCRIPTION
Drop python 3.5 and add 3.9 and 3.10