### PR TITLE
uwsgiconfig: don't error on deprecated declarations

### DIFF
--- a/uwsgiconfig.py
+++ b/uwsgiconfig.py
@@ -685,6 +685,7 @@ class uConf(object):
             '-I.',
             '-Wall',
             '-Werror',
+            '-Wno-error=deprecated-declarations',
             '-D_LARGEFILE_SOURCE',
             '-D_FILE_OFFSET_BITS=64'
         ] + os.environ.get("CFLAGS", "").split() + self.get('cflags', '').split()


### PR DESCRIPTION
Get us some more time to handle all the deprecations
(pthread, openssl 3, python 3.11) to keep things compiling.