### PR TITLE
Wait for other worker thread on shutdown

### DIFF
--- a/core/uwsgi.c
+++ b/core/uwsgi.c
@@ -3718,6 +3718,10 @@ void uwsgi_ignition() {
 		}
 	}
 
+	if (uwsgi.threads > 1 && !uwsgi_instance_is_dying) {
+		wait_for_threads();
+	}
+
 	// end of the process...
 	end_me(0);
 }


### PR DESCRIPTION
When worker stop due to max-lifetime, the first thread will now wait for additional thread to complet before terminating the worker process.

This fix the issue described in #1894. With this change I never get any request error nor request that don't finish.

I think this will also fix the issue seen on production described in #2480

If you want that I make this wait behind an option, just ask and I'll update this PR.