### PR TITLE
ci: refactor tests to be run in parallel

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,10 +7,13 @@ on:
     branches: [ master, uwsgi-2.0 ]
 
 jobs:
-  build:
+  python:
 
     runs-on: ubuntu-18.04
-
+    strategy:
+      matrix:
+        python-version: ["2.7", "3.6", "3.7", "3.8", "3.9", "3.10", "3.11"]
+        test-suite: [unittest, python, deadlocks]
     steps:
     - name: Add deadnakes ppa
       run: |
@@ -19,8 +22,49 @@ jobs:
     - name: Install dependencies
       run: |
         sudo apt update -qq
-        sudo apt install --no-install-recommends -qqyf python{2.7,3.6,3.7,3.8,3.9,3.10,3.11}-dev \
-          python3.8-distutils python3.9-distutils python3.10-distutils python3.11-distutils \
+        sudo apt install --no-install-recommends -qqyf python${{ matrix.python-version }}-dev \
+          libpcre3-dev libjansson-dev libcap2-dev \
+          curl check
+    - name: Install distutils
+      if: contains(fromJson('["3.8","3.9","3.10","3.11"]'), matrix.python-version)
+      run: |
+        sudo apt install --no-install-recommends -qqyf python${{ matrix.python-version }}-distutils \
+    - uses: actions/checkout@v2
+    - name: Run unit tests
+      if: matrix.test-suite == 'unittest'
+      run: make tests
+    - name: Build uWSGI binary
+      if: matrix.test-suite != 'unittest'
+      run: make
+    - name: Build python${{ matrix.python-version }} plugin
+      if: matrix.test-suite != 'unittest'
+      run: |
+        PYTHON_VERSION=${{ matrix.python-version }}
+        PYTHON_VERSION=python${PYTHON_VERSION//.}
+        /usr/bin/python${{ matrix.python-version }} -V
+        /usr/bin/python${{ matrix.python-version }} uwsgiconfig.py --plugin plugins/python base $PYTHON_VERSION
+    - name: run smoke tests
+      if: matrix.test-suite != 'unittest'
+      run: |
+        PYTHON_VERSION=${{ matrix.python-version }}
+        PYTHON_VERSION=python${PYTHON_VERSION//.}
+        ./tests/gh-${{ matrix.test-suite }}.sh ${PYTHON_VERSION}
+
+  rack:
+
+    runs-on: ubuntu-18.04
+    strategy:
+      matrix:
+        rack-version: ["251"]
+    steps:
+    - name: Add deadnakes ppa
+      run: |
+        sudo apt install -qqyf software-properties-common
+        sudo add-apt-repository ppa:deadsnakes/ppa -y
+    - name: Install dependencies
+      run: |
+        sudo apt update -qq
+        sudo apt install --no-install-recommends -qqyf python3-dev \
           libpcre3-dev libjansson-dev libcap2-dev \
           curl check
     - uses: actions/checkout@v2
@@ -28,38 +72,10 @@ jobs:
       run: make tests
     - name: Build uWSGI binary
       run: make
-    - name: Build python2.7 plugin
-      run: |
-        /usr/bin/python2.7 -V
-        /usr/bin/python2.7 uwsgiconfig.py --plugin plugins/python base python27
-    - name: Build python3.6 plugin
-      run: |
-        /usr/bin/python3.6 -V
-        /usr/bin/python3.6 uwsgiconfig.py --plugin plugins/python base python36
-    - name: Build python3.7 plugin
-      run: |
-        /usr/bin/python3.7 -V
-        /usr/bin/python3.7 uwsgiconfig.py --plugin plugins/python base python37
-    - name: Build python3.8 plugin
-      run: |
-        /usr/bin/python3.8 -V
-        /usr/bin/python3.8 uwsgiconfig.py --plugin plugins/python base python38
-    - name: Build python3.9 plugin
-      run: |
-        /usr/bin/python3.9 -V
-        /usr/bin/python3.9 uwsgiconfig.py --plugin plugins/python base python39
-    - name: Build python3.10 plugin
-      run: |
-        /usr/bin/python3.10 -V
-        /usr/bin/python3.10 uwsgiconfig.py --plugin plugins/python base python310
-    - name: Build python3.11 plugin
-      run: |
-        /usr/bin/python3.11 -V
-        /usr/bin/python3.11 uwsgiconfig.py --plugin plugins/python base python311
     - name: Build rack plugin
       run: |
         ruby -v
-        UWSGICONFIG_RUBYPATH=ruby /usr/bin/python uwsgiconfig.py --plugin plugins/rack base rack251
-    - name: Run smoke tests
+        UWSGICONFIG_RUBYPATH=ruby /usr/bin/python uwsgiconfig.py --plugin plugins/rack base rack${{ matrix.rack-version }}
+    - name: run smoke tests
       run: |
-        ./tests/travis.sh .github/workflows/test.yml
+        ./tests/gh-rack.sh rack${{ matrix.rack-version}}

--- a/tests/gh-deadlocks.sh
+++ b/tests/gh-deadlocks.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -u
+
+PYTHON_VERSION="$1"
+. "./tests/gh-shared.sh"
+
+
+for INI_FILE in tests/deadlocks/*.ini ; do
+  test_python_deadlocks "${PYTHON_VERSION}" "$INI_FILE"
+done
+
+results

--- a/tests/gh-python.sh
+++ b/tests/gh-python.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -u
+
+PYTHON_VERSION="$1"
+. "./tests/gh-shared.sh"
+
+
+for WSGI_FILE in tests/staticfile.py tests/testworkers.py tests/testrpc.py ; do
+  test_python "${PYTHON_VERSION}" "${WSGI_FILE}"
+done
+
+results

--- a/tests/gh-rack.sh
+++ b/tests/gh-rack.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -u
+
+RACK_VERSION="$1"
+. "./tests/gh-shared.sh"
+
+
+for RACK in examples/config2.ru ; do
+  test_rack "${RACK_VERSION}" "${RACK}"
+done
+
+results

--- a/tests/gh-shared.sh
+++ b/tests/gh-shared.sh
@@ -1,0 +1,108 @@
+#!/bin/bash
+
+txtund=$(tput sgr 0 1)          # underline
+txtbld=$(tput bold)             # bold
+bldred=${txtbld}$(tput setaf 1) # red
+bldgre=${txtbld}$(tput setaf 2) # green
+bldyel=${txtbld}$(tput setaf 3) # yellow
+bldblu=${txtbld}$(tput setaf 4) # blue
+txtcya=$(tput setaf 6)          # cyan
+bldwht=${txtbld}$(tput setaf 7) # white
+txtrst=$(tput sgr0)             # reset
+
+
+ERROR=0
+SUCCESS=0
+
+
+die() {
+    date > reload.txt
+    sleep 3
+    pidof uwsgi && killall uwsgi
+    sleep 1
+    pidof uwsgi && killall -9 uwsgi
+    echo -e "$@"
+    if [ -e uwsgi.log ]; then
+        echo -e "${bldyel}>>> uwsgi.log:${txtrst}"
+        echo -e "${txtcya}"
+        cat uwsgi.log
+        echo -e "${txtrst}"
+    fi
+}
+
+
+http_test() {
+    URL=$1
+    UPID=`pidof uwsgi`
+    if [ "$UPID" != "" ]; then
+        echo -e "${bldgre}>>> Spawned PID $UPID, running tests${txtrst}"
+        sleep 5
+        curl -fI $URL
+        RET=$?
+        if [ $RET != 0 ]; then
+            die "${bldred}>>> Error during curl run${txtrst}"
+            ERROR=$((ERROR+1))
+        else
+            SUCCESS=$((SUCCESS+1))
+        fi
+        die "${bldyel}>>> SUCCESS: Done${txtrst}"
+    else
+        die "${bldred}>>> ERROR: uWSGI did not start${txtrst}"
+        ERROR=$((ERROR+1))
+    fi
+}
+
+
+test_python() {
+    date > reload.txt
+    rm -f uwsgi.log
+    echo -e "${bldyel}================== TESTING $1 $2 =====================${txtrst}"
+    echo -e "${bldyel}>>> Spawning uWSGI python app${txtrst}"
+    echo -en "${bldred}"
+    ./uwsgi --master --plugin 0:$1 --http :8080 --exit-on-reload --touch-reload reload.txt --wsgi-file $2 --daemonize uwsgi.log
+    sleep 1
+    echo -en "${txtrst}"
+    http_test "http://localhost:8080/"
+    echo -e "${bldyel}===================== DONE $1 $2 =====================${txtrst}\n\n"
+}
+
+
+test_python_deadlocks() {
+    date > reload.txt
+    rm -f uwsgi.log
+    echo -e "${bldyel}================== TESTING DEADLOCKS $1 $2 =====================${txtrst}"
+    echo -e "${bldyel}>>> Starting python app${txtrst}"
+    echo -en "${bldred}"
+    # initialize with tests/deadlocks/sitecustomize.py
+    PYTHONPATH=tests/deadlocks ./uwsgi --plugin 0:$1 --http :8080 --exit-on-reload --touch-reload reload.txt --wsgi-file tests/deadlocks/main.py --ini $2 --daemonize uwsgi.log
+    sleep 1
+    echo -en "${txtrst}"
+    http_test "http://localhost:8080/"
+    echo -e "${bldyel}===================== DONE $1 $2 =====================${txtrst}\n\n"
+}
+
+
+test_rack() {
+    date > reload.txt
+    rm -f uwsgi.log
+    # the code assumes that ruby environment is activated by `rvm use`
+    echo -e "${bldyel}================== TESTING $1 $2 =====================${txtrst}"
+    echo -e "${bldyel}>>> Installing sinatra gem using gem${txtrst}"
+    sudo gem install sinatra || die
+    echo -e "${bldyel}>>> Spawning uWSGI rack app${txtrst}"
+    echo -en "${bldred}"
+    ./uwsgi --master --plugin 0:$1 --http :8080 --exit-on-reload --touch-reload reload.txt --rack $2 --daemonize uwsgi.log
+    echo -en "${txtrst}"
+    http_test "http://localhost:8080/hi"
+    echo -e "${bldyel}===================== DONE $1 $2 =====================${txtrst}\n\n"
+}
+
+results() {
+  echo "${bldgre}>>> $SUCCESS SUCCESSFUL TEST(S)${txtrst}"
+  if [ $ERROR -ge 1 ]; then
+      echo "${bldred}>>> $ERROR FAILED TEST(S)${txtrst}"
+      exit 1
+  fi
+
+  exit 0
+}


### PR DESCRIPTION
starting from `tests/travis.sh` subdivide test suites into:
  * `tests/gh-python.sh`
  * `tests/gh-deadlocks.sh`
  * `tests/gh-rack.sh`
  
that share common variables and functions from `tests/gh-shared.sh`

refactor github test workflow to use a multidimensional matrix in order to run each test suite (unittest, python, deadlocks) on each supported python version and rack tests on each supported rack version.

closes https://github.com/unbit/uwsgi/issues/2479

leave `tests/travis.sh` because it can be useful as is somewhere else.