### PR TITLE
fix build with PHP >= 8.2

### DIFF
--- a/plugins/php/php_plugin.c
+++ b/plugins/php/php_plugin.c
@@ -617,7 +617,11 @@ static void activate_user_config(const char *filename, const char *doc_root, siz
 static int php_uwsgi_startup(sapi_module_struct *sapi_module)
 {
 
+#if ((PHP_MAJOR_VERSION >= 8) && (PHP_MINOR_VERSION >= 2))
+	if (php_module_startup(&uwsgi_sapi_module, &uwsgi_module_entry)==FAILURE) {
+#else
 	if (php_module_startup(&uwsgi_sapi_module, &uwsgi_module_entry, 1)==FAILURE) {
+#endif
 		return FAILURE;
 	} else {
 		return SUCCESS;


### PR DESCRIPTION
from https://raw.githubusercontent.com/php/php-src/PHP-8.2/UPGRADING.INTERNALS:

    ========================                                                             5. SAPI changes                                                                      ========================                                                                                                                                                   * The signature of php_module_startup() has changed from                               int php_module_startup(sapi_module_struct *sf, zend_module_entry              +*additional_modules, uint32_t num_additional_modules)                                      to                                                                                   zend_result php_module_startup(sapi_module_struct *sf, zend_module_entry      +*additional_module)                                                                        as only one additional module was ever provided.