### PR TITLE
Configurable MAX_GATEWAYS, MAX_TIMERS, MAX_CRONS

### DIFF
--- a/uwsgi.h
+++ b/uwsgi.h
@@ -81,9 +81,18 @@ extern "C" {
 #define UWSGI_OPT_METRICS	(1 << 15)
 
 #define MAX_GENERIC_PLUGINS 128
+
+#ifndef MAX_GATEWAYS
 #define MAX_GATEWAYS 64
+#endif
+
+#ifndef MAX_TIMERS
 #define MAX_TIMERS 64
+#endif
+
+#ifndef MAX_CRONS
 #define MAX_CRONS 64
+#endif
 
 #define UWSGI_VIA_SENDFILE	1
 #define UWSGI_VIA_ROUTE	2


### PR DESCRIPTION
Hi,

In some cases default max values (namely for `MAX_CRONS`) won't be enough.

This change allows setting more suitable macro values through CFLAGS, e.g:
```
CFLAGS="-DMAX_CRONS=128"
```
