### PR TITLE
core/lock: silence glibc warnings against pthread robust mutex functions

### DIFF
--- a/core/lock.c
+++ b/core/lock.c
@@ -91,11 +91,6 @@ retry:
 	}
 
 #ifdef EOWNERDEAD
-#ifndef PTHREAD_MUTEX_ROBUST
-#define PTHREAD_MUTEX_ROBUST PTHREAD_MUTEX_ROBUST_NP
-#define pthread_mutexattr_setrobust pthread_mutexattr_setrobust_np
-#define pthread_mutex_consistent pthread_mutex_consistent_np
-#endif
 	if (uwsgi_pthread_robust_mutexes_enabled) {
 		int ret;
 		if ((ret = pthread_mutexattr_setprotocol(&attr, PTHREAD_PRIO_INHERIT)) != 0) {


### PR DESCRIPTION
Since glibc 2.34 we are gettings warnings that pthread_mutexattr_setrobust_np and pthread_mutex_consistent_np are deprecated.
Problem is that we are checking PTHREAD_MUTEX_ROBUST with the preprocessor but it doesn't work because it's an enum :) So in the end we are using the _np versions of the functions even if the standard ones are available. Since this stuff is implemented on linux libc since 2010-2011 and 2016 in freebsd assume it's here.