### PR TITLE
Added log before waiting on threads

### DIFF
--- a/core/uwsgi.c
+++ b/core/uwsgi.c
@@ -1321,6 +1321,7 @@ void end_me(int signum) {
 static void simple_goodbye_cruel_world(const char *reason) {
 
 	if (uwsgi.threads > 1 && !uwsgi_instance_is_dying) {
+		uwsgi_log_verbose("Now waiting on process %d threads\n", getpid());
 		wait_for_threads();
 	}
 


### PR DESCRIPTION
## Why do we need this log?

We manage a large Python application, one we started using the `max-requests` we noticed that clients are receiving 502 during this restart.

We have 5 `uwsgi` processes, each with 70 threads.

Next, we added the `mercy-reload` to grant our application 20 minutes to finish old connections.

This still didn't resolve our problem.

In order to investigate it, we wanted to understand what happens inside our application before the reload to understand what is stuck and prevent it from shutdown gracefully.

we compiled a version of `uwsgi` with this PR, and once we saw the new log message we knew this is our window to dump the process `stacktrace`  (we used `py-spy`) from the host.

