### PR TITLE
ini_entries is read-only starting with PHP 8.3

### DIFF
--- a/plugins/php/php_plugin.c
+++ b/plugins/php/php_plugin.c
@@ -27,6 +27,7 @@ struct uwsgi_php {
 	char *fallback;
 	char *fallback2;
 	char *fallback_qs;
+	char *ini_entries;
 	size_t ini_size;
 	int dump_config;
 	char *server_software;
@@ -232,21 +233,22 @@ static sapi_module_struct uwsgi_sapi_module;
 
 void uwsgi_php_append_config(char *filename) {
 	size_t file_size = 0;
-        char *file_content = uwsgi_open_and_read(filename, &file_size, 1, NULL);
-	uwsgi_sapi_module.ini_entries = realloc(uwsgi_sapi_module.ini_entries, uphp.ini_size + file_size);
-	memcpy(uwsgi_sapi_module.ini_entries + uphp.ini_size, file_content, file_size);
+	char *file_content = uwsgi_open_and_read(filename, &file_size, 1, NULL);
+	uphp.ini_entries = realloc(uphp.ini_entries, uphp.ini_size + file_size);
+	memcpy(uphp.ini_entries + uphp.ini_size, file_content, file_size);
 	uphp.ini_size += file_size-1;
 	free(file_content);
+	uwsgi_sapi_module.ini_entries = uphp.ini_entries;
 }
 
 void uwsgi_php_set(char *opt) {
 
-	uwsgi_sapi_module.ini_entries = realloc(uwsgi_sapi_module.ini_entries, uphp.ini_size + strlen(opt)+2);
-	memcpy(uwsgi_sapi_module.ini_entries + uphp.ini_size, opt, strlen(opt));
-
+	uphp.ini_entries = realloc(uphp.ini_entries, uphp.ini_size + strlen(opt)+2);
+	memcpy(uphp.ini_entries + uphp.ini_size, opt, strlen(opt));
 	uphp.ini_size += strlen(opt)+1;
-	uwsgi_sapi_module.ini_entries[uphp.ini_size-1] = '\n';
-	uwsgi_sapi_module.ini_entries[uphp.ini_size] = 0;
+	uphp.ini_entries[uphp.ini_size-1] = '\n';
+	uphp.ini_entries[uphp.ini_size] = 0;
+	uwsgi_sapi_module.ini_entries = uphp.ini_entries;
 }
 
 extern ps_module ps_mod_uwsgi;


### PR DESCRIPTION
See relevant commit
https://github.com/php/php-src/commit/d53ad4b566a74ff9b95b4f6305cef14df782516c

Without this change, building against PHP 8.3.0RC1 (which have final API)

```
plugins/php/php_plugin.c: In function ‘uwsgi_php_append_config’:
plugins/php/php_plugin.c:226:66: warning: passing argument 1 of ‘realloc’ discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
  226 |         uwsgi_sapi_module.ini_entries = realloc(uwsgi_sapi_module.ini_entries, uphp.ini_size + file_size);
      |                                                 ~~~~~~~~~~~~~~~~~^~~~~~~~~~~~
In file included from /opt/remi/php83/root/usr/include/php/main/../main/php_config.h:2313,
                 from /opt/remi/php83/root/usr/include/php/Zend/zend_config.h:1,
                 from /opt/remi/php83/root/usr/include/php/Zend/zend_portability.h:43,
                 from /opt/remi/php83/root/usr/include/php/Zend/zend_types.h:25,
                 from /opt/remi/php83/root/usr/include/php/Zend/zend.h:27,
                 from /opt/remi/php83/root/usr/include/php/main/php.h:31,
                 from plugins/php/common.h:1,
                 from plugins/php/php_plugin.c:1:
/usr/include/stdlib.h:564:29: note: expected ‘void *’ but argument is of type ‘const char *’
  564 | extern void *realloc (void *__ptr, size_t __size)
      |                       ~~~~~~^~~~~
plugins/php/php_plugin.c:227:46: warning: passing argument 1 of ‘memcpy’ discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
  227 |         memcpy(uwsgi_sapi_module.ini_entries + uphp.ini_size, file_content, file_size);
      |                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~
In file included from /usr/include/features.h:490,
                 from /usr/include/bits/libc-header-start.h:33,
                 from /usr/include/stdlib.h:26:
/usr/include/bits/string_fortified.h:26:1: note: expected ‘void * restrict’ but argument is of type ‘const char *’
   26 | __NTH (memcpy (void *__restrict __dest, const void *__restrict __src,
      | ^~~~~
plugins/php/php_plugin.c: In function ‘uwsgi_php_set’:
plugins/php/php_plugin.c:234:66: warning: passing argument 1 of ‘realloc’ discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
  234 |         uwsgi_sapi_module.ini_entries = realloc(uwsgi_sapi_module.ini_entries, uphp.ini_size + strlen(opt)+2);
      |                                                 ~~~~~~~~~~~~~~~~~^~~~~~~~~~~~
/usr/include/stdlib.h:564:29: note: expected ‘void *’ but argument is of type ‘const char *’
  564 | extern void *realloc (void *__ptr, size_t __size)
      |                       ~~~~~~^~~~~
plugins/php/php_plugin.c:235:46: warning: passing argument 1 of ‘memcpy’ discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
  235 |         memcpy(uwsgi_sapi_module.ini_entries + uphp.ini_size, opt, strlen(opt));
      |                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~
/usr/include/bits/string_fortified.h:26:1: note: expected ‘void * restrict’ but argument is of type ‘const char *’
   26 | __NTH (memcpy (void *__restrict __dest, const void *__restrict __src,
      | ^~~~~
plugins/php/php_plugin.c:238:56: error: assignment of read-only location ‘*(uwsgi_sapi_module.ini_entries + ((sizetype)uphp.ini_size + 18446744073709551615))’
  238 |         uwsgi_sapi_module.ini_entries[uphp.ini_size-1] = '\n';
      |                                                        ^
plugins/php/php_plugin.c:239:54: error: assignment of read-only location ‘*(uwsgi_sapi_module.ini_entries + (sizetype)uphp.ini_size)’
  239 |         uwsgi_sapi_module.ini_entries[uphp.ini_size] = 0;
      |                                                      ^
*** unable to build php83 plugin ***

```