### PR TITLE
Stop using distutils

### DIFF
--- a/plugins/asyncio/uwsgiplugin.py
+++ b/plugins/asyncio/uwsgiplugin.py
@@ -1,10 +1,10 @@
-from distutils import sysconfig
+import sysconfig
 
 NAME = 'asyncio'
 
 CFLAGS = [
-    '-I' + sysconfig.get_python_inc(),
-    '-I' + sysconfig.get_python_inc(plat_specific=True)
+    '-I' + sysconfig.get_path('include'),
+    '-I' + sysconfig.get_path('platinclude')
 ]
 LDFLAGS = []
 LIBS = []

--- a/plugins/gevent/uwsgiplugin.py
+++ b/plugins/gevent/uwsgiplugin.py
@@ -1,10 +1,10 @@
-from distutils import sysconfig
+import sysconfig
 
 NAME = 'gevent'
 
 CFLAGS = [
-    '-I' + sysconfig.get_python_inc(),
-    '-I' + sysconfig.get_python_inc(plat_specific=True)
+    '-I' + sysconfig.get_path('include'),
+    '-I' + sysconfig.get_path('platinclude')
 ]
 LDFLAGS = []
 LIBS = []

--- a/plugins/greenlet/uwsgiplugin.py
+++ b/plugins/greenlet/uwsgiplugin.py
@@ -1,10 +1,10 @@
-from distutils import sysconfig
+import sysconfig
 
 NAME = 'greenlet'
 
 CFLAGS = [
-    '-I' + sysconfig.get_python_inc(),
-    '-I' + sysconfig.get_python_inc(plat_specific=True)
+    '-I' + sysconfig.get_path('include'),
+    '-I' + sysconfig.get_path('platinclude')
 ]
 LDFLAGS = []
 LIBS = []

--- a/plugins/python/uwsgiplugin.py
+++ b/plugins/python/uwsgiplugin.py
@@ -1,7 +1,7 @@
 import os
 import sys
 
-from distutils import sysconfig
+import sysconfig
 
 
 def get_python_version():
@@ -31,8 +31,8 @@ GCC_LIST = [
 ]
 
 CFLAGS = [
-    '-I' + sysconfig.get_python_inc(),
-    '-I' + sysconfig.get_python_inc(plat_specific=True),
+    '-I' + sysconfig.get_path('include'),
+    '-I' + sysconfig.get_path('platinclude'),
 ]
 LDFLAGS = []
 

--- a/plugins/pyuwsgi/uwsgiplugin.py
+++ b/plugins/pyuwsgi/uwsgiplugin.py
@@ -1,4 +1,4 @@
-from distutils import sysconfig
+import sysconfig
 import os, sys
 
 os.environ['UWSGI_PYTHON_NOLIB'] = '1'
@@ -6,8 +6,8 @@ os.environ['UWSGI_PYTHON_NOLIB'] = '1'
 NAME = 'pyuwsgi'
 
 CFLAGS = [
-    '-I' + sysconfig.get_python_inc(),
-    '-I' + sysconfig.get_python_inc(plat_specific=True),
+    '-I' + sysconfig.get_path('include'),
+    '-I' + sysconfig.get_path('platinclude'),
 ]
 LDFLAGS = []
 LIBS = []

--- a/plugins/stackless/uwsgiplugin.py
+++ b/plugins/stackless/uwsgiplugin.py
@@ -1,10 +1,10 @@
-from distutils import sysconfig
+import sysconfig
 
 NAME = 'stackless'
 
 CFLAGS = [
-    '-I' + sysconfig.get_python_inc(),
-    '-I' + sysconfig.get_python_inc(plat_specific=True),
+    '-I' + sysconfig.get_path('include'),
+    '-I' + sysconfig.get_path('platinclude'),
 ]
 LDFLAGS = []
 LIBS = []

--- a/plugins/tornado/uwsgiplugin.py
+++ b/plugins/tornado/uwsgiplugin.py
@@ -1,10 +1,10 @@
-from distutils import sysconfig
+import sysconfig
 
 NAME = 'tornado'
 
 CFLAGS = [
-    '-I' + sysconfig.get_python_inc(),
-    '-I' + sysconfig.get_python_inc(plat_specific=True),
+    '-I' + sysconfig.get_path('include'),
+    '-I' + sysconfig.get_path('platinclude'),
 ]
 LDFLAGS = []
 LIBS = []

--- a/setup.cpyext.py
+++ b/setup.cpyext.py
@@ -12,9 +12,8 @@ import errno
 import shlex
 import uwsgiconfig
 
-from setuptools import setup
+from setuptools import setup, Extension
 from setuptools.command.build_ext import build_ext
-from distutils.core import Extension
 
 
 class uWSGIBuildExt(build_ext):

--- a/uwsgiconfig.py
+++ b/uwsgiconfig.py
@@ -12,6 +12,7 @@ uwsgi_cpu = os.uname()[4]
 
 import sys
 import subprocess
+import sysconfig
 from threading import Thread, Lock
 from optparse import OptionParser
 
@@ -19,8 +20,6 @@ try:
     from queue import Queue
 except ImportError:
     from Queue import Queue
-
-from distutils import sysconfig
 
 try:
     import ConfigParser


### PR DESCRIPTION
distutils is due to be removed in Python 3.12, but even so we don't need to use it, since the sysconfig module can handle our use-cases just fine for all supported Python versions.