### PR TITLE
properly init cache for purge_lru

### DIFF
--- a/core/cache.c
+++ b/core/cache.c
@@ -737,6 +737,12 @@ void uwsgi_cache_fix(struct uwsgi_cache *uc) {
 			if (uci->expires && (!next_scan || next_scan > uci->expires)) {
 				next_scan = uci->expires;
 			}
+			if (!uc->lru_head && !uci->lru_prev) {
+				uc->lru_head = i;
+			}
+			if (!uc->lru_tail && !uci->lru_next) {
+				uc->lru_tail = i;
+			}
 			restored++;
 		}
 		else {


### PR DESCRIPTION
Purging the least recently used cache item relies on a linked list maintained during cache get and set. While uwsgi is running, this works well. But if the uwsgi process is stopped, lru_head and lru_tail are not initialized when loading the existing cache file. As a consequence, least recently used items never get deleted a full cache fails to set any new keys until the cache file is deleted.

This patch properly initializes those variables.