### PR TITLE
Update glusterfs io callback function signature

### DIFF
--- a/plugins/glusterfs/glusterfs.c
+++ b/plugins/glusterfs/glusterfs.c
@@ -46,7 +46,7 @@ struct uwsgi_glusterfs_async_io {
 	ssize_t rlen;
 };
 
-static void uwsgi_glusterfs_read_async_cb(glfs_fd_t *fd, ssize_t rlen, void *data) {
+static void uwsgi_glusterfs_read_async_cb(glfs_fd_t *fd, ssize_t rlen, struct glfs_stat *prestat, struct glfs_stat *poststat, void *data) {
 	struct uwsgi_glusterfs_async_io *aio = (struct uwsgi_glusterfs_async_io *) data;
 #ifdef UWSGI_DEBUG
 	uwsgi_log("[glusterfs-cb] rlen = %d\n", rlen);


### PR DESCRIPTION
Starting with glusterfs 6.0, the IO callback function takes two additional parameters for stats structs.

Ideally there'd be a way to detect which API version we're building against, but nothing convenient seems to exist.