### PR TITLE
fixes for python tracebacker segfaults

### DIFF
--- a/plugins/python/python_plugin.c
+++ b/plugins/python/python_plugin.c
@@ -1727,8 +1727,10 @@ uint64_t uwsgi_python_rpc(void *func, uint8_t argc, char **argv, uint16_t argvs[
 	PyObject *pyargs = PyTuple_New(argc);
 	PyObject *ret;
 
-	if (!pyargs)
+	if (!pyargs) {
+		UWSGI_RELEASE_GIL;
 		return 0;
+	}
 
 	for (i = 0; i < argc; i++) {
 		PyTuple_SetItem(pyargs, i, PyString_FromStringAndSize(argv[i], argvs[i]));

--- a/valgrind/valgrind-generate-sups.sh
+++ b/valgrind/valgrind-generate-sups.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+pydir=${1:-/usr}
+
 
 gensup() {
     for SUP in Cond Free Leak Overlap Addr1 Addr2 Addr4 Addr8 Addr16 Value1 Value2 Value4 Value8 Value16 ; do
@@ -16,10 +18,10 @@ gensup() {
 
 while read SO ; do
     gensup libpython "$SO"
-done < <(find /usr/lib*/ -type f -name libpython*)
+done < <(find ${pydir}/lib*/ -type f -name libpython*)
 
 
 while read SO ; do
     gensup python "$SO"
-done < <(find /usr/lib*/python*/ -type f -name \*.so)
+done < <(find ${pydir}/lib*/python*/ -type f -name \*.so)
 


### PR DESCRIPTION
We've found that the uwsgi build with python 3.11 has a log of segfaults when generating the tracebacks via the tracebacker thread. This is a new implementation for that in python 3.11 that has been much more stable as it avoids using sys._current_frames(), instead using the python thread state object uwsgi already has, and then moves more of the hard work into python code to simplify and make that code safer. Hopefully it's helpful for others.