### PR TITLE
Check if the `pcre_libs` exists

### DIFF
--- a/uwsgiconfig.py
+++ b/uwsgiconfig.py
@@ -1117,11 +1117,12 @@ class uConf(object):
                 print("*** libpcre headers unavailable. uWSGI build is interrupted. You have to install pcre development package or disable pcre")
                 sys.exit(1)
 
-            self.libs.append(pcre_libs)
-            self.cflags.append(pcre_cflags)
-            self.gcc_list.append('core/regexp')
-            self.cflags.append(pcre_define)
-            has_pcre = True
+            if pcre_libs:
+                self.libs.append(pcre_libs)
+                self.cflags.append(pcre_cflags)
+                self.gcc_list.append('core/regexp')
+                self.cflags.append(pcre_define)
+                has_pcre = True
 
         if has_pcre:
             report['pcre'] = True


### PR DESCRIPTION
This handles the case where the `required_pcre` is `auto` and the `pcre_libs` is not found.

https://github.com/unbit/uwsgi/issues/2630