### PR TITLE
Fix for Flaky Exit Code When Using 'need-app' and 'lazy-apps' Flags Together

### DIFF
--- a/core/uwsgi.c
+++ b/core/uwsgi.c
@@ -3937,13 +3937,6 @@ void uwsgi_init_all_apps() {
 		if (uwsgi.need_app) {
 			if (!uwsgi.lazy)
 				uwsgi_log("*** no app loaded. GAME OVER ***\n");
-			if (uwsgi.lazy_apps) {
-				if (uwsgi.master_process) {
-					if (kill(uwsgi.workers[0].pid, SIGINT)) {
-						uwsgi_error("kill()");
-					}
-				}
-			}
 			exit(UWSGI_FAILED_APP_CODE);
 		}
 		else {


### PR DESCRIPTION
Remove old code that causes a race-condition over termination of uWSGI process when using need-app and lazy-apps flags together.
Full details about this bug here: https://github.com/unbit/uwsgi/issues/2640
Fixes: https://github.com/unbit/uwsgi/issues/2640