### PR TITLE
apache2: let httpd handle CL/TE for non-http handlers

### DIFF
--- a/apache2/mod_proxy_uwsgi.c
+++ b/apache2/mod_proxy_uwsgi.c
@@ -374,6 +374,12 @@ static int uwsgi_response(request_rec *r, proxy_conn_rec *backend, proxy_server_
 	  return HTTP_BAD_GATEWAY;
 	}
 
+	/* T-E wins over C-L */
+	if (apr_table_get(r->headers_out, "Transfer-Encoding")) {
+		apr_table_unset(r->headers_out, "Content-Length");
+		backend->close = 1;
+	}
+
 	if ((buf = apr_table_get(r->headers_out, "Content-Type"))) {
 		ap_set_content_type(r, apr_pstrdup(r->pool, buf));
 	}


### PR DESCRIPTION
Fix #2635

origin: https://github.com/apache/httpd/commit/a29723ce1af75eed0813c3717d3f6dee9b405ca8.patch
bug-cve: https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-24795