### PR TITLE
`gracefully_kill()` uses pipe to stop worker loop

### DIFF
--- a/core/loop.c
+++ b/core/loop.c
@@ -127,6 +127,7 @@ void *simple_loop_run(void *arg1) {
 	int main_queue = event_queue_init();
 
 	uwsgi_add_sockets_to_queue(main_queue, core_id);
+	event_queue_add_fd_read(main_queue, uwsgi.loop_stop_pipe[0]);
 
 	if (uwsgi.signal_socket > -1) {
 		event_queue_add_fd_read(main_queue, uwsgi.signal_socket);

--- a/uwsgi.h
+++ b/uwsgi.h
@@ -2953,6 +2953,8 @@ struct uwsgi_server {
 	struct uwsgi_buffer *websockets_continuation_buffer;
 
 	uint64_t max_worker_lifetime_delta;
+	// This pipe is used to stop event_queue_wait() in threaded workers.
+	int loop_stop_pipe[2];
 };
 
 struct uwsgi_rpc {


### PR DESCRIPTION
Fix #2653