### PR TITLE
avoid interleaving pyuwsgi threadstate

### DIFF
--- a/plugins/pyuwsgi/pyuwsgi.c
+++ b/plugins/pyuwsgi/pyuwsgi.c
@@ -115,12 +115,6 @@ pyuwsgi_setup(PyObject *self, PyObject *args, PyObject *kwds)
         return NULL;
     }
 
-    //TODO: ...???
-    // actually do the thing!
-    PyThreadState *_tstate = PyThreadState_Get();
-    uwsgi_setup(orig_argc, orig_argv, environ);
-    PyThreadState_Swap(_tstate);
-
     Py_INCREF(self);
     return self;
 }
@@ -133,6 +127,7 @@ pyuwsgi_init(PyObject *self, PyObject *args, PyObject *kwds)
         return NULL;
     }
 
+    uwsgi_setup(orig_argc, orig_argv, environ);
     int rc = uwsgi_run();
 
     // never(?) here
@@ -149,6 +144,7 @@ pyuwsgi_run(PyObject *self, PyObject *args, PyObject *kwds)
         return NULL;
     }
 
+    uwsgi_setup(orig_argc, orig_argv, environ);
     int rc = uwsgi_run();
 
     // never(?) here


### PR DESCRIPTION
resolves #2659

so there's quite a lot going on here so I'll try to explain the change

- in all versions of pyuwsgi at the moment the *first* fork has a `NULL` threadstate 
    - due to `uwsgi_python_master_fixup` which calls `UWSGI_RELEASE_GIL` (expanded to `PyEval_SaveThread` -- which drops the GIL and sets threadstate to `NULL`)
    - this is called during `uwsgi_setup`
    - after `uwsgi_setup` was returning, `PyThreadState_Swap` was restoring the pyuwsgi threadstate (in both the original and worker processes)
- future forks would have the pyuwsgi threadstate active (from the restoration at `PyThreadState_Swap`)
    - in python versions < 3.12 this wasn't an issue (for a reason I'm not completely understanding -- but my notes are below this)
    - in 3.12+ the `PyEval_RestoreThread` would attempt to `take_gil` and then block forever on the GIL mutex (despite it actually holding it?  due to the fork state from the parent process)
    - bisecting cpython showed that https://github.com/python/cpython/commit/92d8bfffbf377e91d8b92666525cb8700bb1d5e8 slightly changed behaviour of `PyThreadState_Swap` (it now additionally manages GIL state: unlocking the previous threadstate and locking the new threadstate)
    - putting a log line in the `PyThreadState_Swap` showed a suspicious `swapping from oldts=123123 to newts=123123` (swapping from its own threadstate to itself?)
    - this is because after forking control would be given back to the original threadstate (which mostly worked but was in UB territory given the GIL state)
- in the new version of the code, once we call `uwsgi_setup` we never give control back to the original `pyuwsgi` threadstate avoiding the `Swap` dance entirely!