### PR TITLE
PHP: Add support for uwsgi.disconnect() function

### DIFF
--- a/plugins/php/common.h
+++ b/plugins/php/common.h
@@ -7,5 +7,7 @@
 
 #include "ext/session/php_session.h"
 
+#include "ext/standard/head.h"
+
 #include <uwsgi.h>
 

--- a/plugins/php/php_plugin.c
+++ b/plugins/php/php_plugin.c
@@ -499,6 +499,21 @@ PHP_FUNCTION(uwsgi_signal) {
         RETURN_NULL();
 }
 
+PHP_FUNCTION(uwsgi_disconnect) {
+
+	struct wsgi_request *wsgi_req = (struct wsgi_request *) SG(server_context);
+
+	php_output_end_all();
+	php_header();
+
+	uwsgi_disconnect(wsgi_req);
+
+	php_output_set_status(PHP_OUTPUT_DISABLED);
+
+	RETURN_NULL();
+}
+
+
 ZEND_BEGIN_ARG_INFO_EX(arginfo_void, 0, 0, 0)
 ZEND_END_ARG_INFO()
 
@@ -517,6 +532,7 @@ zend_function_entry uwsgi_php_functions[] = {
 	PHP_FE(uwsgi_cache_del, arginfo_void)
 	PHP_FE(uwsgi_cache_clear, arginfo_void)
 	PHP_FE(uwsgi_cache_exists, arginfo_void)
+	PHP_FE(uwsgi_disconnect, arginfo_void)
 	{ NULL, NULL, NULL},
 };
 


### PR DESCRIPTION
This allows to run some code after finishing request. As described in https://symfony.com/doc/current/components/http_kernel.html#8-the-kernel-terminate-event

Implements same functionality as `fastcgi_finish_request()` but for uwsgi. Function name taken from official API https://uwsgi-docs.readthedocs.io/en/latest/API.html