### PR TITLE
Fix calculate `uwsgi.max_procname`

### DIFF
--- a/core/uwsgi.c
+++ b/core/uwsgi.c
@@ -1729,7 +1729,7 @@ static void fixup_argv_and_environ(int argc, char **argv, char **environ, char *
 	uwsgi.argv = uwsgi_malloc(sizeof(char *) * (argc + 1));
 
 	for (i = 0; i < argc; i++) {
-		if (i == 0 || argv[0] + uwsgi.max_procname + 1 == argv[i]) {
+		if (i == 0 || argv[0] + uwsgi.max_procname == argv[i]) {
 			uwsgi.max_procname += strlen(argv[i]) + 1;
 		}
 		uwsgi.argv[i] = strdup(argv[i]);


### PR DESCRIPTION
Fixing double addition of 1
```c
if (i == 0 || argv[0] + uwsgi.max_procname + 1 == argv[i]) { // wrong addition 1
  uwsgi.max_procname += strlen(argv[i]) + 1;  // addition 1
}
```