### PR TITLE
Fix gracefully_kill_them_all with running requests

### DIFF
--- a/core/master_utils.c
+++ b/core/master_utils.c
@@ -54,6 +54,12 @@ void uwsgi_destroy_processes() {
 
         uwsgi_detach_daemons();
 
+	for (i = 1; i <= uwsgi.numproc; i++) {
+		if (uwsgi.workers[i].pid > 0) {
+			waitpid(uwsgi.workers[i].pid, &waitpid_status, 0);
+		}
+	}
+
         for (i = 0; i < ushared->gateways_cnt; i++) {
                 if (ushared->gateways[i].pid > 0) {
                         kill(ushared->gateways[i].pid, SIGKILL);


### PR DESCRIPTION
With the following:

```
wsgi = app:app
http = :8000
master = true
processes = 2
harakiri = 15
harakiri-verbose = true
harakiri-graceful-timeout = 15
harakiri-graceful-signal = 15
max-requests = 100000
memory-report = true
enable-threads = true
threads = 4
enable-thread = true
showconfig = true
listen = 1024
post-buffering = 8192
buffer-size = 32768
lazy = true
http-keepalive = 1
add-header = Connection: Keep-Alive
http-timeout = 70
socket-timeout = 75
hook-master-start = unix_signal:15 gracefully_kill_them_all
vacuum = true
hook-master-start = unix_signal:15 gracefully_kill_them_all
```

kill -s 15 master-pid while request does not complete. fllowing is uwsgi log:

```
running "unix_signal:15 gracefully_kill_them_all" (master-start)...
WSGI app 0 (mountpoint='') ready in 0 seconds on interpreter 0x55de52cb68f0 pid: 143521 (default app)
WSGI app 0 (mountpoint='') ready in 0 seconds on interpreter 0x55de52cb68f0 pid: 143520 (default app)
graceful shutdown triggered...
Gracefully killing worker 1 (pid: 143520)...
gateway "uWSGI http 1" has been buried (pid: 143522)
Gracefully killing worker 2 (pid: 143521)...
worker 1 buried after 1 seconds
{address space usage: 277147648 bytes/264MB} {rss usage: 34459648 bytes/32MB} [pid: 143521|app: 0|req: 1/1] 127.0.0.1 () {28 vars in 291 bytes
} [Mon Jul 22 09:13:34 2024] GET / => generated 11 bytes in 6036 msecs (HTTP/1.1 200) 3 headers in 103 bytes (1 switches on core 0)
worker 2 buried after 4 seconds
goodbye to uWSGI.
```

The gateway process(pid=143522) is closed prematurely, causing the client to be unable to correctly receive the request result.

I think you should wait for the worker process to shut down before shutting down the gateway process

Fix #2656