### PR TITLE
Minor rework of Python 3.13 support

### DIFF
--- a/plugins/python/python_plugin.c
+++ b/plugins/python/python_plugin.c
@@ -1659,14 +1659,14 @@ void uwsgi_python_suspend(struct wsgi_request *wsgi_req) {
 	PyGILState_Release(pgst);
 
 	if (wsgi_req) {
-#ifdef UWSGI_PY312
+#ifdef UWSGI_PY313
 		up.current_c_recursion_remaining[wsgi_req->async_id] = tstate->c_recursion_remaining;
 		up.current_py_recursion_remaining[wsgi_req->async_id] = tstate->py_recursion_remaining;
-#ifdef UWSGI_PY313
 		up.current_frame[wsgi_req->async_id] = tstate->current_frame;
-#else
+#elif defined UWSGI_PY312
+		up.current_c_recursion_remaining[wsgi_req->async_id] = tstate->c_recursion_remaining;
+		up.current_py_recursion_remaining[wsgi_req->async_id] = tstate->py_recursion_remaining;
 		up.current_frame[wsgi_req->async_id] = tstate->cframe;
-#endif
 #elif defined UWSGI_PY311
 		up.current_recursion_remaining[wsgi_req->async_id] = tstate->recursion_remaining;
 		up.current_frame[wsgi_req->async_id] = tstate->cframe;
@@ -1676,14 +1676,14 @@ void uwsgi_python_suspend(struct wsgi_request *wsgi_req) {
 #endif
 	}
 	else {
-#ifdef UWSGI_PY312
+#ifdef UWSGI_PY313
 		up.current_main_c_recursion_remaining = tstate->c_recursion_remaining;
 		up.current_main_py_recursion_remaining = tstate->py_recursion_remaining;
-#ifdef UWSGI_PY313
 		up.current_main_frame = tstate->current_frame;
-#else
+#elif defined UWSGI_PY312
+		up.current_main_c_recursion_remaining = tstate->c_recursion_remaining;
+		up.current_main_py_recursion_remaining = tstate->py_recursion_remaining;
 		up.current_main_frame = tstate->cframe;
-#endif
 #elif defined UWSGI_PY311
 		up.current_main_recursion_remaining = tstate->recursion_remaining;
 		up.current_main_frame = tstate->cframe;
@@ -1920,14 +1920,14 @@ void uwsgi_python_resume(struct wsgi_request *wsgi_req) {
 	PyGILState_Release(pgst);
 
 	if (wsgi_req) {
-#ifdef UWSGI_PY312
+#ifdef UWSGI_PY313
 		tstate->c_recursion_remaining = up.current_c_recursion_remaining[wsgi_req->async_id];
 		tstate->py_recursion_remaining = up.current_py_recursion_remaining[wsgi_req->async_id];
-#ifdef UWSGI_PY313
 		tstate->current_frame = up.current_frame[wsgi_req->async_id];
-#else
+#elif defined UWSGI_PY312
+		tstate->c_recursion_remaining = up.current_c_recursion_remaining[wsgi_req->async_id];
+		tstate->py_recursion_remaining = up.current_py_recursion_remaining[wsgi_req->async_id];
 		tstate->cframe = up.current_frame[wsgi_req->async_id];
-#endif
 #elif defined UWSGI_PY311
 		tstate->recursion_remaining = up.current_recursion_remaining[wsgi_req->async_id];
 		tstate->cframe = up.current_frame[wsgi_req->async_id];
@@ -1937,14 +1937,14 @@ void uwsgi_python_resume(struct wsgi_request *wsgi_req) {
 #endif
 	}
 	else {
-#ifdef UWSGI_PY312
+#ifdef UWSGI_PY313
 		tstate->c_recursion_remaining = up.current_main_c_recursion_remaining;
 		tstate->py_recursion_remaining = up.current_main_py_recursion_remaining;
-#ifdef UWSGI_PY313
 		tstate->current_frame = up.current_main_frame;
-#else
+#elif defined UWSGI_PY312
+		tstate->c_recursion_remaining = up.current_main_c_recursion_remaining;
+		tstate->py_recursion_remaining = up.current_main_py_recursion_remaining;
 		tstate->cframe = up.current_main_frame;
-#endif
 #elif defined UWSGI_PY311
 		tstate->recursion_remaining = up.current_main_recursion_remaining;
 		tstate->cframe = up.current_main_frame;

--- a/plugins/python/uwsgi_python.h
+++ b/plugins/python/uwsgi_python.h
@@ -186,22 +186,22 @@ struct uwsgi_python {
 
 	char *callable;
 
-#ifdef UWSGI_PY312
+#ifdef UWSGI_PY313
 	int *current_c_recursion_remaining;
 	int *current_py_recursion_remaining;
-#ifdef UWSGI_PY313
 	struct _PyInterpreterFrame **current_frame;
-#else
-	_PyCFrame **current_frame;
-#endif
 
 	int current_main_c_recursion_remaining;
 	int current_main_py_recursion_remaining;
-#ifdef UWSGI_PY313
 	struct _PyInterpreterFrame *current_main_frame;
-#else
+#elif defined UWSGI_PY312
+	int *current_c_recursion_remaining;
+	int *current_py_recursion_remaining;
+	_PyCFrame **current_frame;
+
+	int current_main_c_recursion_remaining;
+	int current_main_py_recursion_remaining;
 	_PyCFrame *current_main_frame;
-#endif
 #elif defined UWSGI_PY311
 	int *current_recursion_remaining;
 	_PyCFrame **current_frame;


### PR DESCRIPTION
As mentioned in https://github.com/unbit/uwsgi/pull/2655, this changes the way support for python 3.13 is handled. Instead of handling python 3.13 as a minor change from 3.12, and handling support for it under the 3.12 `#ifdef` blocks, this breaks out 3.13 into its own block, apart from 3.12. This makes the code a bit more verbose, but makes it easier to see what the structures look like for different python versions.