### PR TITLE
Fix reload-on-touch/change

### DIFF
--- a/core/master_utils.c
+++ b/core/master_utils.c
@@ -54,12 +54,6 @@ void uwsgi_destroy_processes() {
 
         uwsgi_detach_daemons();
 
-	for (i = 1; i <= uwsgi.numproc; i++) {
-		if (uwsgi.workers[i].pid > 0) {
-			waitpid(uwsgi.workers[i].pid, &waitpid_status, 0);
-		}
-	}
-
         for (i = 0; i < ushared->gateways_cnt; i++) {
                 if (ushared->gateways[i].pid > 0) {
                         kill(ushared->gateways[i].pid, SIGKILL);

--- a/core/uwsgi.c
+++ b/core/uwsgi.c
@@ -1356,7 +1356,7 @@ void kill_them_all(int signum) {
 // gracefully destroy
 void gracefully_kill_them_all(int signum) {
 
-	    int waitpid_status;
+        int waitpid_status;
 
         if (uwsgi_instance_is_dying) return;
         uwsgi.status.gracefully_destroying = 1;
@@ -1379,12 +1379,12 @@ void gracefully_kill_them_all(int signum) {
                 }
         }
 
-
         for (i = 1; i <= uwsgi.numproc; i++) {
             if (uwsgi.workers[i].pid > 0) {
                 waitpid(uwsgi.workers[i].pid, &waitpid_status, 0);
             }
         }
+
         uwsgi_destroy_processes();
 }
 

--- a/core/uwsgi.c
+++ b/core/uwsgi.c
@@ -1356,6 +1356,8 @@ void kill_them_all(int signum) {
 // gracefully destroy
 void gracefully_kill_them_all(int signum) {
 
+	    int waitpid_status;
+
         if (uwsgi_instance_is_dying) return;
         uwsgi.status.gracefully_destroying = 1;
 
@@ -1377,6 +1379,12 @@ void gracefully_kill_them_all(int signum) {
                 }
         }
 
+
+        for (i = 1; i <= uwsgi.numproc; i++) {
+            if (uwsgi.workers[i].pid > 0) {
+                waitpid(uwsgi.workers[i].pid, &waitpid_status, 0);
+            }
+        }
         uwsgi_destroy_processes();
 }
 


### PR DESCRIPTION
As part of a fix for #2656, commit 8f1d0e5 introduced a measure to wait for processes to finish work while reloading. The code to do this affects other logic flows was well, breaking the ability to reload uwsgi when a config file changes.

This moves the code around a bit so #2656 stays fixed, but reload-on-touch/change works again.

Fixes #2681.