### PR TITLE
plugins/python: Fix a memory leak coming from PyBytes_FromString

### DIFF
--- a/plugins/python/uwsgi_pymodule.c
+++ b/plugins/python/uwsgi_pymodule.c
@@ -2141,6 +2141,24 @@ PyObject *py_uwsgi_spooler_jobs(PyObject * self, PyObject * args) {
 }
 
 
+#ifdef PYTHREE
+static PyObject *uwsgi_py_dict_get(PyObject *a, const char *key) {
+	PyObject *key_bytes = PyBytes_FromString(key);
+	PyObject *result = PyDict_GetItem(a, key_bytes);
+	Py_DECREF(key_bytes);
+	return result;
+}
+
+static void uwsgi_py_dict_del(PyObject *a, const char *key) {
+	PyObject *key_bytes = PyBytes_FromString(key);
+	PyDict_DelItem(a, key_bytes);
+	Py_DECREF(key_bytes);
+}
+#else
+#define uwsgi_py_dict_get(a, b) PyDict_GetItemString(a, b)
+#define uwsgi_py_dict_del(a, b) PyDict_DelItemString(a, b)
+#endif
+
 PyObject *py_uwsgi_send_spool(PyObject * self, PyObject * args, PyObject *kw) {
 	PyObject *spool_dict, *spool_vars;
 	PyObject *zero, *key, *val;

--- a/plugins/python/uwsgi_python.h
+++ b/plugins/python/uwsgi_python.h
@@ -96,14 +96,10 @@ PyAPI_FUNC(PyObject *) PyMarshal_ReadObjectFromString(char *, Py_ssize_t);
 #define	PyString_Concat		PyBytes_Concat
 #define	PyString_AsString	(char *) PyBytes_AsString
 #define PyFile_FromFile(A,B,C,D) PyFile_FromFd(fileno((A)), (B), (C), -1, NULL, NULL, NULL, 0)
-#define uwsgi_py_dict_get(a, b) PyDict_GetItem(a, PyBytes_FromString(b));
-#define uwsgi_py_dict_del(a, b) PyDict_DelItem(a, PyBytes_FromString(b));
 
 #else
 #define UWSGI_PYFROMSTRING(x) PyString_FromString(x)
 #define UWSGI_PYFROMSTRINGSIZE(x, y) PyString_FromStringAndSize(x, y)
-#define uwsgi_py_dict_get(a, b) PyDict_GetItemString(a, b)
-#define uwsgi_py_dict_del(a, b) PyDict_DelItemString(a, b)
 #endif
 
 #define LOADER_DYN              0


### PR DESCRIPTION
`PyBytes_FromString` returns a new reference, which must be freed.

To fix this, use a static function instead of a macro, and clean up inside it. Also, move the function from the header to the only place where it’s used, to fix GCC warnings about undefined function.