### PR TITLE
plugins/python: fix reload-os-env=true

### DIFF
--- a/plugins/python/pyloader.c
+++ b/plugins/python/pyloader.c
@@ -129,21 +129,33 @@ int init_uwsgi_app(int loader, void *arg1, struct wsgi_request *wsgi_req, PyThre
                         		p = strchr(*e, '=');
                         		if (p == NULL) continue;
 
+#ifdef PYTHREE
+					k = PyUnicode_FromStringAndSize(*e, (int)(p-*e));
+#else
 					k = PyString_FromStringAndSize(*e, (int)(p-*e));
+#endif
 					if (k == NULL) {
                                 		PyErr_Print();
                                 		continue;
 					}
 
-                        		env_value = PyString_FromString(p+1);
+#ifdef PYTHREE
+					env_value = PyUnicode_FromString(p+1);
+#else
+					env_value = PyString_FromString(p+1);
+#endif
                         		if (env_value == NULL) {
                                 		PyErr_Print();
 						Py_DECREF(k);
                                 		continue;
                         		}
-	
+
 #ifdef UWSGI_DEBUG
+#ifdef PYTHREE
+					uwsgi_log("%s = %s\n", PyUnicode_AsUTF8(k), PyUnicode_AsUTF8(env_value));
+#else
 					uwsgi_log("%s = %s\n", PyString_AsString(k), PyString_AsString(env_value));
+#endif
 #endif
 
                         		if (PyObject_SetItem(py_environ, k, env_value)) {
@@ -209,7 +221,7 @@ int init_uwsgi_app(int loader, void *arg1, struct wsgi_request *wsgi_req, PyThre
 		if (multiapp < 1) {
 			uwsgi_log("you have to define at least one app in the applications dictionary\n");
 			goto doh;
-		}		
+		}
 
 		PyObject *app_mnt = PyList_GetItem(app_list, 0);
 		if (!PyString_Check(app_mnt)) {
@@ -228,7 +240,7 @@ int init_uwsgi_app(int loader, void *arg1, struct wsgi_request *wsgi_req, PyThre
 		if (PyString_Check((PyObject *) wi->callable)) {
 			PyObject *callables_dict = get_uwsgi_pydict((char *)arg1);
 			if (callables_dict) {
-				wi->callable = PyDict_GetItem(callables_dict, (PyObject *)wi->callable);	
+				wi->callable = PyDict_GetItem(callables_dict, (PyObject *)wi->callable);
 				if (!wi->callable) {
 					uwsgi_log("skipping broken app %s\n", wsgi_req->appid);
 					goto multiapp;
@@ -377,7 +389,7 @@ int init_uwsgi_app(int loader, void *arg1, struct wsgi_request *wsgi_req, PyThre
 multiapp:
 	if (multiapp > 1) {
 		for(i=1;i<multiapp;i++) {
-			PyObject *app_mnt = PyList_GetItem(app_list, i);		
+			PyObject *app_mnt = PyList_GetItem(app_list, i);
 			if (!PyString_Check(app_mnt)) {
 				uwsgi_log("applications dictionary key must be a string, skipping.\n");
 				continue;
@@ -770,7 +782,7 @@ PyObject *uwsgi_eval_loader(void *arg1) {
 		wsgi_eval_callable = PyDict_GetItemString(up.loader_dict, up.callable);
 	}
 	else {
-		
+
 		wsgi_eval_callable = PyDict_GetItemString(up.loader_dict, "application");
 	}
 


### PR DESCRIPTION
Fixes the following stacktrace with the options enabled:

```
Traceback (most recent call last):
  File "/srv/knip/development/KnipKnap/lib/python3.4/os.py", line 637, in __setitem__
    key = self.encodekey(key)
  File "/srv/knip/development/KnipKnap/lib/python3.4/os.py", line 706, in encode
    raise TypeError("str expected, not %s" % type(value).__name__)
TypeError: str expected, not bytes
```