### PR TITLE
plugins/python: Port to Python 3.14 beta 1

### DIFF
--- a/plugins/python/uwsgi_python.h
+++ b/plugins/python/uwsgi_python.h
@@ -29,6 +29,10 @@
 #  define UWSGI_PY313
 #endif
 
+#if (PY_VERSION_HEX >= 0x030e0000)
+#  define UWSGI_PY314
+#endif
+
 #if PY_MAJOR_VERSION == 2 && PY_MINOR_VERSION < 7
 #define HAS_NOT_PyMemoryView_FromBuffer
 #endif
@@ -186,7 +190,13 @@ struct uwsgi_python {
 
 	char *callable;
 
-#ifdef UWSGI_PY313
+#ifdef UWSGI_PY314
+	int *current_py_recursion_remaining;
+	struct _PyInterpreterFrame **current_frame;
+
+	int current_main_py_recursion_remaining;
+	struct _PyInterpreterFrame *current_main_frame;
+#elif defined UWSGI_PY313
 	int *current_c_recursion_remaining;
 	int *current_py_recursion_remaining;
 	struct _PyInterpreterFrame **current_frame;


### PR DESCRIPTION
The PyThreadState.c_recursion_remaining member has been removed in Python 3.14 beta 1:
https://github.com/python/cpython/pull/133080