### PR TITLE
fix: install atexit handlers after apps are initialized

### DIFF
--- a/core/uwsgi.c
+++ b/core/uwsgi.c
@@ -3202,12 +3202,11 @@ next:
 	//init apps hook (if not lazy)
 	if (!uwsgi.lazy && !uwsgi.lazy_apps) {
 		uwsgi_init_all_apps();
+		// Register uwsgi atexit plugin callbacks after all applications have
+		// been loaded. This ensures plugin atexit callbacks are called prior
+		// to application registered atexit callbacks.
+		atexit(uwsgi_plugins_atexit);
 	}
-
-	// Register uwsgi atexit plugin callbacks after all applications have
-	// been loaded. This ensures plugin atexit callbacks are called prior
-	// to application registered atexit callbacks.
-	atexit(uwsgi_plugins_atexit);
 
 	if (!uwsgi.master_as_root) {
 		uwsgi_log("dropping root privileges after application loading\n");
@@ -3553,6 +3552,11 @@ void uwsgi_worker_run() {
 
 	if (uwsgi.lazy || uwsgi.lazy_apps) {
 		uwsgi_init_all_apps();
+
+		// Register uwsgi atexit plugin callbacks after all applications have
+		// been loaded. This ensures plugin atexit callbacks are called prior
+		// to application registered atexit callbacks.
+		atexit(uwsgi_plugins_atexit);
 	}
 
 	// some apps could be mounted only on specific workers


### PR DESCRIPTION
When `--lazy` or `--lazy-apps` is set, uwsgi's `atexit()` handlers, for Python it is `uwsgi_python_atexit()`, are installed in master process before calling `fork()`, and when worker loads the application, destructors for static global variables used in Python native extension modules are installed via `atexit()`. 

Those static global variables are destructed first and uwsgi `atexit()` handlers are run.  

An application can install Python atexit handler via following two ways
1. uwsgi Python module's `atexit` attribute, which will be called by `uwsgi_python_atexit()` [here](https://github.com/taegyunkim/uwsgi/blob/58aa1806e147f84bcf29cd3536edc2d3d2576071/plugins/python/python_plugin.c#L420-L426). 
2. using Python `atexit` module, which will be called by CPython `Py_Finalize()`, and uwsgi calls `Py_Finalize()` also from `uwsgi_python_atexit()` from [here](https://github.com/taegyunkim/uwsgi/blob/58aa1806e147f84bcf29cd3536edc2d3d2576071/plugins/python/python_plugin.c#L445)

For both cases, setting `--lazy` or `--lazy-apps` changes the order `atexit()` handlers are installed.  


So, if the Python atexit function installed with either of the method calls into native extension module using global states, it results in an undefined behavior leading to segmentation faults. 

I believe this has been reported many times previously. As an author of python native extension module, one can intentionally leak the global states as in https://github.com/pytorch/pytorch/issues/42125. As a user of uwsgi package, one can avoid calling such `atexit()` handlers by setting `--skip-atexit` as in https://github.com/ansible/ansible-ai-connect-service/pull/248.

However, these do not address the underlying problem, and I believe this PR would fix that. 