### PR TITLE
py-call-osafterfork isn't needed in python 3.13+

### DIFF
--- a/plugins/python/python_plugin.c
+++ b/plugins/python/python_plugin.c
@@ -460,13 +460,18 @@ void uwsgi_python_post_fork() {
 
 	// reset python signal flags so child processes can trap signals
 	// Necessary if uwsgi fork hooks not called to update interpreter state
-	if (!up.call_uwsgi_fork_hooks && up.call_osafterfork) {
-#ifdef HAS_NOT_PYOS_FORK_STABLE_API
-		PyOS_AfterFork();
-#else
-                PyOS_AfterFork_Child();
-#endif
-	}
+    #if PY_VERSION_HEX < 0x030D0000
+		if (!up.call_uwsgi_fork_hooks && up.call_osafterfork) {
+			// before python 3.7
+			#ifdef HAS_NOT_PYOS_FORK_STABLE_API
+					PyOS_AfterFork();
+			
+			// python 3.7 - 3.12
+			#else
+					PyOS_AfterFork_Child();
+			#endif
+		}
+	#endif
 
 	uwsgi_python_reset_random_seed();
 


### PR DESCRIPTION
fixes https://github.com/unbit/uwsgi/issues/2710


in 3.13, there's a new [mutex type](https://docs.python.org/3/c-api/init.html#c.PyMutex) that now cares if the mutex is unlocked while not currently locked


A warning should be emitted to advise to use `py-call-uwsgi-fork-hooks` if running against 3.13 (+ a doc update that suggests to use `py-call-uwsgi-fork-hooks` over `py-call-osafterfork`

since maintainers want to support py-call-osafterfork for LTS reasons, my suggestion would be to just remove `py-call-osafterfork` entirely otherwise