### PR TITLE
STR_EMPTY_ALLOC removed in PHP 8.5

### DIFF
--- a/plugins/php/session.c
+++ b/plugins/php/session.c
@@ -14,7 +14,7 @@ PS_READ_FUNC(uwsgi) {
 	uint64_t valsize = 0;
 	char *value = uwsgi_cache_magic_get(key->val, key->len , &valsize, NULL, cache);
 	if (!value) {
-		*val = STR_EMPTY_ALLOC();
+		*val = ZSTR_EMPTY_ALLOC();
 		return SUCCESS;
 	}
 	*val = zend_string_init(value, valsize, 0);


### PR DESCRIPTION
ZSTR_EMPTY_ALLOC exists since 7.0