### PR TITLE
Fix for gracefully_kill_them_all() which broke setups using fifo-based master graceful reload

### DIFF
--- a/core/uwsgi.c
+++ b/core/uwsgi.c
@@ -1355,37 +1355,56 @@ void kill_them_all(int signum) {
 
 // gracefully destroy
 void gracefully_kill_them_all(int signum) {
+	if (uwsgi_instance_is_dying) return;
+	uwsgi.status.gracefully_destroying = 1;
 
-        int waitpid_status;
+	// unsubscribe if needed
+	uwsgi_unsubscribe_all();
 
-        if (uwsgi_instance_is_dying) return;
-        uwsgi.status.gracefully_destroying = 1;
+	uwsgi_log_verbose("graceful shutdown triggered...\n");
 
-        // unsubscribe if needed
-        uwsgi_unsubscribe_all();
+	int i;
+	for (i = 1; i <= uwsgi.numproc; i++) {
+		if (uwsgi.workers[i].pid > 0) {
+			uwsgi.workers[i].shutdown_sockets = 1;
+			uwsgi_curse(i, SIGHUP);
+		}
+	}
 
-        uwsgi_log_verbose("graceful shutdown triggered...\n");
+	for (i = 0; i < uwsgi.mules_cnt; i++) {
+		if (uwsgi.mules[i].pid > 0) {
+			uwsgi_curse_mule(i, SIGHUP);
+		}
+	}
 
-        int i;
-        for (i = 1; i <= uwsgi.numproc; i++) {
-                if (uwsgi.workers[i].pid > 0) {
-                        uwsgi.workers[i].shutdown_sockets = 1;
-                        uwsgi_curse(i, SIGHUP);
-                }
-        }
-        for (i = 0; i < uwsgi.mules_cnt; i++) {
-                if (uwsgi.mules[i].pid > 0) {
-                        uwsgi_curse_mule(i, SIGHUP);
-                }
-        }
+	// avoid breaking other child process signal handling logic by doing nohang checks on the workers
+	// until they are all done.
+	int keep_waiting = 1;
+	while (keep_waiting == 1) {
+		int still_running = 0;
+		int errors = 0;
+		for (i = 1; i <= uwsgi.numproc; i++) {
+			if (uwsgi.workers[i].pid > 0) {
+				pid_t rval = waitpid(uwsgi.workers[i].pid, NULL, WNOHANG);
+				if (rval == uwsgi.workers[i].pid) {
+					uwsgi.workers[i].pid = 0;
+				} else if (rval == 0) {
+					still_running++;
+				} else if (rval < 0) {
+					errors++;
+				}
+			}
+		}
 
-        for (i = 1; i <= uwsgi.numproc; i++) {
-            if (uwsgi.workers[i].pid > 0) {
-                waitpid(uwsgi.workers[i].pid, &waitpid_status, 0);
-            }
-        }
+		// exit out if everything is done or we got errors as we can't do much about the errors at this point
+		if (still_running == 0 || errors > 0) {
+			keep_waiting = 0;
+			break;
+		}
+		sleep(1);
+	}
 
-        uwsgi_destroy_processes();
+	uwsgi_destroy_processes();
 }
 
 


### PR DESCRIPTION
Instead of doing a blocking waitpid call, use WNOHANG calls to avoid breaking existing child process signal handling which was part of the master fork/exit cleanup that allowed FIFO-based zero downtime reloads to happen. This will also allow the fix to continue on as this code will block until all the workers have exited.