### PR TITLE
rack plugin: rack3 header values can be an Array to handle multiple values

### DIFF
--- a/t/rack/app.ru
+++ b/t/rack/app.ru
@@ -1,7 +1,10 @@
 class App
 
-  def call(environ)
-    [200, {"content-type" => "text/plain"}, ['Hello']]
+  def call(env)
+    headers = {"content-type" => "text/plain"}
+    Rack::Utils.set_cookie_header!(headers, "country", { :value => "UK", :path => "/"})
+    Rack::Utils.set_cookie_header!(headers, "autologin", { :value => "yes", :path => "/", :secure => true})
+    [200, headers, ["Hello"]]
   end
 
 end

--- a/t/runner
+++ b/t/runner
@@ -251,8 +251,14 @@ class UwsgiTest(unittest.TestCase):
             ]
         )
 
-        self.assert_GET_body("/", "Hello")
+        with requests.get(f"http://{UWSGI_HTTP}/") as r:
+            self.assertEqual(r.text, "Hello")
+            self.assertEqual(r.headers["Content-type"], "text/plain")
+            self.assertEqual(
+                r.headers["Set-Cookie"],
+                "country=UK; path=/, autologin=yes; path=/; secure",
+            )
 
 
 if __name__ == "__main__":
-    unittest.main()
+    unittest.main(verbosity=2)


### PR DESCRIPTION
>There is one changed feature in Rack 3 which is not backwards compatible:
>
> - Response header values can be an Array to handle multiple values (and no longer supports \n encoded headers).

This patch fixes seing in response header:

`Set-Cookie: ["autologin=[secret];secure"]`

instead of

`Set-Cookie: autologin=[secret];secure`


